### PR TITLE
Divide form of item

### DIFF
--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:schema="https://schema.org/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    >
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+        <dct:title xml:lang="en">Maps: form of item</dct:title>
+        <dct:alternative xml:lang="en">MARC21 008/29 values for maps expressed using RDF</dct:alternative>
+        <dct:description xml:lang="en">Specifies the form of material for the item.</dct:description>
+        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+        <dct:source rdf:resource="http://marc21rdf.info"/>
+        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+        <dct:issued>2024</dct:issued>
+        <dc:language>en</dc:language>
+        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+        <schema:version>1-0-0</schema:version>
+        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfilm.</skos:definition>
+        <skos:notation>a</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+        <skos:definition xml:lang="en">Braille.</skos:definition>
+        <skos:notation>f</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+        <skos:notation>#</skos:notation>
+        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+        <skos:definition xml:lang="en">Large print.</skos:definition>
+        <skos:notation>d</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+        <skos:definition xml:lang="en">Microopaque.</skos:definition>
+        <skos:notation>c</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfiche.</skos:definition>
+        <skos:notation>b</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+        <skos:notation>r</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+        <skos:notation>o</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+        <skos:notation>q</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+        <skos:notation>s</skos:notation>
+        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+    </rdf:Description>
+</rdf:RDF>

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -6,7 +6,7 @@
     xmlns:schema="https://schema.org/"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
         <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
         <dct:title xml:lang="en">Maps: form of item</dct:title>
@@ -26,73 +26,73 @@
         <schema:version>1-0-0</schema:version>
         <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
         <skos:definition xml:lang="en">Microfilm.</skos:definition>
         <skos:notation>a</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
         <skos:definition xml:lang="en">Braille.</skos:definition>
         <skos:notation>f</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
         <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
         <skos:notation>#</skos:notation>
         <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
         <skos:definition xml:lang="en">Large print.</skos:definition>
         <skos:notation>d</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
         <skos:definition xml:lang="en">Microopaque.</skos:definition>
         <skos:notation>c</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
         <skos:definition xml:lang="en">Microfiche.</skos:definition>
         <skos:notation>b</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
         <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
         <skos:notation>r</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">online</skos:prefLabel>
         <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
         <skos:notation>o</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
         <skos:notation>q</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
         <skos:notation>s</skos:notation>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 >
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -23,12 +24,17 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    <uwp:appliesToMaterial>books</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>computer files</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>music</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -21,7 +21,7 @@
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
-    <dct:issued>2023</dct:issued>
+    <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <schema:version>1-0-2</schema:version>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -31,7 +31,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <uwp:appliesToMaterial>books</uwp:appliesToMaterial>
-    <uwp:appliesToMaterial>computer files</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>music</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -6,7 +6,7 @@
     xmlns:schema="https://schema.org/"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
         <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
         <dct:title xml:lang="en">Visual: form of item</dct:title>
@@ -26,73 +26,73 @@
         <schema:version>1-0-0</schema:version>
         <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
         <skos:definition xml:lang="en">Microfilm.</skos:definition>
         <skos:notation>a</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
         <skos:definition xml:lang="en">Braille.</skos:definition>
         <skos:notation>f</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
         <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
         <skos:notation>#</skos:notation>
         <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
         <skos:definition xml:lang="en">Large print.</skos:definition>
         <skos:notation>d</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
         <skos:definition xml:lang="en">Microopaque.</skos:definition>
         <skos:notation>c</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
         <skos:definition xml:lang="en">Microfiche.</skos:definition>
         <skos:notation>b</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
         <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
         <skos:notation>r</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">online</skos:prefLabel>
         <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
         <skos:notation>o</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
         <skos:notation>q</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
         <skos:notation>s</skos:notation>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:schema="https://schema.org/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    >
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+        <dct:title xml:lang="en">Visual: form of item</dct:title>
+        <dct:alternative xml:lang="en">MARC21 008/29 values for visual materials expressed using RDF</dct:alternative>
+        <dct:description xml:lang="en">Specifies the form of material.</dct:description>
+        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+        <dct:source rdf:resource="http://marc21rdf.info"/>
+        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+        <dct:issued>2024</dct:issued>
+        <dc:language>en</dc:language>
+        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+        <schema:version>1-0-0</schema:version>
+        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfilm.</skos:definition>
+        <skos:notation>a</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+        <skos:definition xml:lang="en">Braille.</skos:definition>
+        <skos:notation>f</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+        <skos:notation>#</skos:notation>
+        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+        <skos:definition xml:lang="en">Large print.</skos:definition>
+        <skos:notation>d</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+        <skos:definition xml:lang="en">Microopaque.</skos:definition>
+        <skos:notation>c</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfiche.</skos:definition>
+        <skos:notation>b</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+        <skos:notation>r</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+        <skos:notation>o</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+        <skos:notation>q</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+        <skos:notation>s</skos:notation>
+        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+    </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
This pull request will create two new vocabularies: maps_form_of_item and visual_form_of_item.  Neither has been serialized yet, but DOIs have been created in draft form for eventual publication.  

The vocabulary some_form_of_item has been modified so that it includes appliesToMaterial elements that do not include maps, visual materials (because they now have their own vocabulary), or computer files (because that always had its own vocabulary).

These changes are made so that the vocabularies better match the MARC standard.