### PR TITLE
Divide form of item

### DIFF
--- a/008/maps_form_of_item/maps_form_of_item.html
+++ b/008/maps_form_of_item/maps_form_of_item.html
@@ -1,0 +1,1558 @@
+<!DOCTYPE html>
+<html lang="en" prefix="dc: http://purl.org/dc/elements/1.1/ dct: http://purl.org/dc/terms/ rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# schema: https://schema.org/ skos: http://www.w3.org/2004/02/skos/core# xml: http://www.w3.org/XML/1998/namespace ">
+    <head>
+        <title>Maps: form of item</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <link href="https://uwlib-cams.github.io/webviews/css/uwlswd.css" rel="stylesheet" type="text/css">
+        <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png">
+        <script type="application/ld+json"> 
+        { 
+        "@context" : "http://schema.org" , 
+        "@type" : "Dataset" , 
+        "@id" : "https://doi.org/10.6069/uwlswd.8dk4-4h49", 
+        "name" : "Maps: form of item" , 
+         
+        "alternateName" : "MARC21 008/29 values for maps expressed using RDF" ,
+        "description" : "Specifies the form of material for the item." , 
+            
+        "isBasedOn" : [ 
+            "https://www.loc.gov/marc/bibliographic/bd008.html" , 
+            
+            "http://marc21rdf.info"
+            ] , 
+        "creator" : 
+            {
+            "@id" : "http://viaf.org/viaf/139541794", 
+            "name" : "University of Washington Libraries" ,  
+            "sameAs" : "http://viaf.org/viaf/139541794" 
+            } ,        
+                    
+        "publisher" : {
+            "@id" : "http://viaf.org/viaf/139541794", 
+            "name" : "University of Washington Libraries" ,  
+            "sameAs" : "http://viaf.org/viaf/139541794"
+            } , 
+    
+        "contributor" : [
+            {
+            "@id" : "http://viaf.org/viaf/151962300", 
+            "name" : "Library of Congress" , 
+            "sameAs" : "http://viaf.org/viaf/151962300"
+            } , 
+        
+            {
+            "name" : "Metadata Management Associates"
+            }
+            ] , 
+            
+        "datePublished" : "2024", 
+       
+        "inLanguage" : "en" ,  
+        "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
+        
+        "version" : "1-0-0" , 
+             
+        "distribution" : [
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl" ,
+              "encodingFormat" : "text/turtle" 
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt" ,
+              "encodingFormat" : "application/n-triples"  
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld" ,
+              "encodingFormat" : "application/ld+json" 
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf" ,
+              "encodingFormat" : "application/rdf+xml"
+            } 
+            ] , 
+        "encodingFormat" : "text/html" 
+        } 
+    </script>
+        <link rel="alternate" type="application/n-triples" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt">
+        <link rel="alternate" type="application/rdf+xml" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf">
+        <link rel="alternate" type="text/turtle" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl">
+        <link rel="alternate" type="application/ld+json" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld">
+    </head>
+    <body about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+        <script type="text/javascript" src="https://uwlib-cams.github.io/webviews/js/uwlswd.js"></script>
+        <a class="return" href="https://uwlib-cams.github.io/uwlswd/">Return to all UWLSWD datasets and vocabularies</a>
+        <h1>Maps: form of item</h1>
+        <h2 id="altTitle">(MARC21 008/29 values for maps expressed using RDF)</h2>
+        <p>Specifies the form of material for the item.</p>
+        <h2 id="triples">RDF Triples for Maps: form of item</h2>
+        <div class="tab">
+            <button class="tablinks" onclick="openTab(event, 'table')">Table View</button>
+            <button class="tablinks" onclick="openTab(event, 'rdfxml')">RDF/XML</button>
+            <button class="tablinks" onclick="openTab(event, 'ttl')">Turtle</button>
+            <button class="tablinks" onclick="openTab(event, 'nt')">N-Triples</button>
+            <button class="tablinks" onclick="openTab(event, 'json')">JSON</button>
+        </div>
+        <div id="table" class="tabcontent" style="display:block">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Subject</th>
+                        <th scope="col">Predicate</th>
+                        <th scope="col">Object</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/elements/1.1/contributor">dc:contributor</a>
+                        </td>
+                        <td property="dc:contributor" xml:lang="en">Metadata Management Associates</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/elements/1.1/language">dc:language</a>
+                        </td>
+                        <td property="dc:language">en</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/alternative">dct:alternative</a>
+                        </td>
+                        <td property="dct:alternative" xml:lang="en">MARC21 008/29 values for maps expressed using RDF</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/contributor">dct:contributor</a>
+                        </td>
+                        <td property="dct:contributor" resource="http://viaf.org/viaf/151962300">
+                            <a href="http://viaf.org/viaf/151962300">http://viaf.org/viaf/151962300</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/creator">dct:creator</a>
+                        </td>
+                        <td property="dct:creator" resource="http://viaf.org/viaf/139541794">
+                            <a href="http://viaf.org/viaf/139541794">http://viaf.org/viaf/139541794</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/description">dct:description</a>
+                        </td>
+                        <td property="dct:description" xml:lang="en">Specifies the form of material for the item.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/format">dct:format</a>
+                        </td>
+                        <td property="dct:format" resource="http://www.w3.org/ns/formats/RDFa">
+                            <a href="http://www.w3.org/ns/formats/RDFa">http://www.w3.org/ns/formats/RDFa</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/issued">dct:issued</a>
+                        </td>
+                        <td property="dct:issued">2024</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/license">dct:license</a>
+                        </td>
+                        <td property="dct:license" resource="http://creativecommons.org/publicdomain/zero/1.0">
+                            <a href="http://creativecommons.org/publicdomain/zero/1.0">http://creativecommons.org/publicdomain/zero/1.0</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
+                        </td>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/publisher">dct:publisher</a>
+                        </td>
+                        <td property="dct:publisher" resource="http://viaf.org/viaf/139541794">
+                            <a href="http://viaf.org/viaf/139541794">http://viaf.org/viaf/139541794</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/source">dct:source</a>
+                        </td>
+                        <td property="dct:source" resource="https://www.loc.gov/marc/bibliographic/bd008.html">
+                            <a href="https://www.loc.gov/marc/bibliographic/bd008.html">https://www.loc.gov/marc/bibliographic/bd008.html</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/source">dct:source</a>
+                        </td>
+                        <td property="dct:source" resource="http://marc21rdf.info">
+                            <a href="http://marc21rdf.info">http://marc21rdf.info</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/title">dct:title</a>
+                        </td>
+                        <td property="dct:title" xml:lang="en">Maps: form of item</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/type">dct:type</a>
+                        </td>
+                        <td property="dct:type" resource="http://purl.org/dc/dcmitype/Dataset">
+                            <a href="http://purl.org/dc/dcmitype/Dataset">http://purl.org/dc/dcmitype/Dataset</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+                            <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">http://www.w3.org/2004/02/skos/core#ConceptScheme</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
+                        </td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                        <td>
+                            <a href="https://schema.org/version">schema:version</a>
+                        </td>
+                        <td property="schema:version">1-0-0</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+                        <td id="a">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">https://doi.org/10.6069/uwlswd.8dk4-4h49#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">https://doi.org/10.6069/uwlswd.8dk4-4h49#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microfilm.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">https://doi.org/10.6069/uwlswd.8dk4-4h49#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">https://doi.org/10.6069/uwlswd.8dk4-4h49#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">a</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">https://doi.org/10.6069/uwlswd.8dk4-4h49#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microfilm</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+                        <td id="b">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">https://doi.org/10.6069/uwlswd.8dk4-4h49#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">https://doi.org/10.6069/uwlswd.8dk4-4h49#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microfiche.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">https://doi.org/10.6069/uwlswd.8dk4-4h49#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">https://doi.org/10.6069/uwlswd.8dk4-4h49#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">b</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">https://doi.org/10.6069/uwlswd.8dk4-4h49#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microfiche</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+                        <td id="c">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">https://doi.org/10.6069/uwlswd.8dk4-4h49#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">https://doi.org/10.6069/uwlswd.8dk4-4h49#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microopaque.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">https://doi.org/10.6069/uwlswd.8dk4-4h49#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">https://doi.org/10.6069/uwlswd.8dk4-4h49#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">c</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">https://doi.org/10.6069/uwlswd.8dk4-4h49#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microopaque</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+                        <td id="d">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">https://doi.org/10.6069/uwlswd.8dk4-4h49#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">https://doi.org/10.6069/uwlswd.8dk4-4h49#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Large print.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">https://doi.org/10.6069/uwlswd.8dk4-4h49#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">https://doi.org/10.6069/uwlswd.8dk4-4h49#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">d</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">https://doi.org/10.6069/uwlswd.8dk4-4h49#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">large print</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+                        <td id="f">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">https://doi.org/10.6069/uwlswd.8dk4-4h49#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">https://doi.org/10.6069/uwlswd.8dk4-4h49#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Braille.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">https://doi.org/10.6069/uwlswd.8dk4-4h49#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">https://doi.org/10.6069/uwlswd.8dk4-4h49#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">f</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">https://doi.org/10.6069/uwlswd.8dk4-4h49#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">braille</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+                        <td id="o">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">https://doi.org/10.6069/uwlswd.8dk4-4h49#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">https://doi.org/10.6069/uwlswd.8dk4-4h49#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Accessed by means of hardware and software connections to a communications network.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">https://doi.org/10.6069/uwlswd.8dk4-4h49#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">https://doi.org/10.6069/uwlswd.8dk4-4h49#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">o</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">https://doi.org/10.6069/uwlswd.8dk4-4h49#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">online</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td id="pound">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille,
+                  online, direct electronic, regular print reproduction, or electronic.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">#</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">none of the following</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">https://doi.org/10.6069/uwlswd.8dk4-4h49#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#scopeNote">skos:scopeNote</a>
+                        </td>
+                        <td property="skos:scopeNote" xml:lang="en">Not specified by one of the other codes.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+                        <td id="q">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">https://doi.org/10.6069/uwlswd.8dk4-4h49#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">https://doi.org/10.6069/uwlswd.8dk4-4h49#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway
+                  device, flashdrive, portable hard drive, etc.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">https://doi.org/10.6069/uwlswd.8dk4-4h49#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">https://doi.org/10.6069/uwlswd.8dk4-4h49#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">q</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">https://doi.org/10.6069/uwlswd.8dk4-4h49#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">direct electronic</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+                        <td id="r">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">https://doi.org/10.6069/uwlswd.8dk4-4h49#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">https://doi.org/10.6069/uwlswd.8dk4-4h49#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition">Eye-readable print, such as a photocopy.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">https://doi.org/10.6069/uwlswd.8dk4-4h49#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">https://doi.org/10.6069/uwlswd.8dk4-4h49#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">r</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">https://doi.org/10.6069/uwlswd.8dk4-4h49#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">regular print reproduction</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td id="s">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly
+                  or remotely, in some cases requiring the use of peripheral devices attached to the
+                  computer (e.g., a CD-ROM player).</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49">https://doi.org/10.6069/uwlswd.8dk4-4h49</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">s</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">electronic</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">https://doi.org/10.6069/uwlswd.8dk4-4h49#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#scopeNote">skos:scopeNote</a>
+                        </td>
+                        <td property="skos:scopeNote" xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact
+                  discs, videodiscs).</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="rdfxml" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf" download="" target="_blank" rel="noopener noreferrer">Download RDF/XML</a>
+            <pre>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Maps: form of item&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/29 values for maps expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Specifies the form of material for the item.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+&lt;/rdf:RDF&gt;
+</pre>
+        </div>
+        <div id="ttl" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl" download="" target="_blank" rel="noopener noreferrer">Download Turtle</a>
+            <pre>@prefix dc: &lt;http://purl.org/dc/elements/1.1/&gt; .
+@prefix dct: &lt;http://purl.org/dc/terms/&gt; .
+@prefix schema: &lt;https://schema.org/&gt; .
+@prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; a skos:Concept ;
+    skos:definition "Microfilm."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "a" ;
+    skos:prefLabel "microfilm"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; a skos:Concept ;
+    skos:definition "Microfiche."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "b" ;
+    skos:prefLabel "microfiche"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; a skos:Concept ;
+    skos:definition "Microopaque."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "c" ;
+    skos:prefLabel "microopaque"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; a skos:Concept ;
+    skos:definition "Large print."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "d" ;
+    skos:prefLabel "large print"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; a skos:Concept ;
+    skos:definition "Braille."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "f" ;
+    skos:prefLabel "braille"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; a skos:Concept ;
+    skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "o" ;
+    skos:prefLabel "online"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; a skos:Concept ;
+    skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "#" ;
+    skos:prefLabel "none of the following"@en ;
+    skos:scopeNote "Not specified by one of the other codes."@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; a skos:Concept ;
+    skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "q" ;
+    skos:prefLabel "direct electronic"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; a skos:Concept ;
+    skos:definition "Eye-readable print, such as a photocopy." ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "r" ;
+    skos:prefLabel "regular print reproduction"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; a skos:Concept ;
+    skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; ;
+    skos:notation "s" ;
+    skos:prefLabel "electronic"@en ;
+    skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; a skos:ConceptScheme ;
+    dc:contributor "Metadata Management Associates"@en ;
+    dc:language "en" ;
+    dct:alternative "MARC21 008/29 values for maps expressed using RDF"@en ;
+    dct:contributor &lt;http://viaf.org/viaf/151962300&gt; ;
+    dct:creator &lt;http://viaf.org/viaf/139541794&gt; ;
+    dct:description "Specifies the form of material for the item."@en ;
+    dct:format &lt;http://www.w3.org/ns/formats/Turtle&gt; ;
+    dct:hasFormat &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf&gt; ;
+    dct:issued "2024" ;
+    dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
+    dct:source &lt;http://marc21rdf.info&gt;,
+        &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
+    dct:title "Maps: form of item"@en ;
+    dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-0-0" .
+
+</pre>
+        </div>
+        <div id="nt" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
+            <pre>&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for maps expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/version&gt; "1-0-0" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material for the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+</pre>
+        </div>
+        <div id="json" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
+            <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://purl.org/dc/elements/1.1/contributor": [
+      {
+        "@language": "en",
+        "@value": "Metadata Management Associates"
+      }
+    ],
+    "http://purl.org/dc/elements/1.1/language": [
+      {
+        "@value": "en"
+      }
+    ],
+    "http://purl.org/dc/terms/alternative": [
+      {
+        "@language": "en",
+        "@value": "MARC21 008/29 values for maps expressed using RDF"
+      }
+    ],
+    "http://purl.org/dc/terms/contributor": [
+      {
+        "@id": "http://viaf.org/viaf/151962300"
+      }
+    ],
+    "http://purl.org/dc/terms/creator": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "Specifies the form of material for the item."
+      }
+    ],
+    "http://purl.org/dc/terms/format": [
+      {
+        "@id": "http://www.w3.org/ns/formats/JSON-LD"
+      }
+    ],
+    "http://purl.org/dc/terms/hasFormat": [
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"
+      }
+    ],
+    "http://purl.org/dc/terms/issued": [
+      {
+        "@value": "2024"
+      }
+    ],
+    "http://purl.org/dc/terms/license": [
+      {
+        "@id": "http://creativecommons.org/publicdomain/zero/1.0"
+      }
+    ],
+    "http://purl.org/dc/terms/provenance": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+      }
+    ],
+    "http://purl.org/dc/terms/publisher": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "https://www.loc.gov/marc/bibliographic/bd008.html"
+      },
+      {
+        "@id": "http://marc21rdf.info"
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Maps: form of item"
+      }
+    ],
+    "http://purl.org/dc/terms/type": [
+      {
+        "@id": "http://purl.org/dc/dcmitype/Dataset"
+      }
+    ],
+    "https://schema.org/disambiguatingDescription": [
+      {
+        "@language": "en",
+        "@value": "SKOS Concept Scheme for MARC 00X Values"
+      }
+    ],
+    "https://schema.org/version": [
+      {
+        "@value": "1-0-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  }
+]</pre>
+        </div>
+        <hr>
+        <div class="contact">
+            <h3>Contact:</h3>
+            <p>
+                <a href="https://www.lib.washington.edu/msd">University of Washington Libraries,
+               Cataloging and Metadata Services</a>
+                <br> Box 352900, Seattle, WA 98195-2900<br> Telephone: 206-543-1919<br>
+                <a href="mailto:uwlsemanticweb@uw.edu">uwlsemanticweb@uw.edu</a>
+            </p>
+        </div>
+        <div class="footer_workaround"></div>
+        <footer>
+            <section xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+                <div class="footer_container">
+                    <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/">
+                        <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0">
+                    </a>
+                    <div>To the extent possible under law, <a rel="dct:publisher" href="https://www.lib.washington.edu/cams">
+                            <span property="dct:title">Cataloging and Metadata Services, University of Washington Libraries</span>
+                        </a> has waived all copyright and related or neighboring rights to <span property="dct:title">
+                            <strong>Maps: form of item</strong>
+                        </span>. This work is published in the <span property="vcard:Country" datatype="dct:ISO3166" content="US" about="https://www.lib.washington.edu/cams">United States</span>. </div>
+                </div>
+            </section>
+        </footer>
+    </body>
+</html>

--- a/008/maps_form_of_item/maps_form_of_item.jsonld
+++ b/008/maps_form_of_item/maps_form_of_item.jsonld
@@ -1,0 +1,401 @@
+[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://purl.org/dc/elements/1.1/contributor": [
+      {
+        "@language": "en",
+        "@value": "Metadata Management Associates"
+      }
+    ],
+    "http://purl.org/dc/elements/1.1/language": [
+      {
+        "@value": "en"
+      }
+    ],
+    "http://purl.org/dc/terms/alternative": [
+      {
+        "@language": "en",
+        "@value": "MARC21 008/29 values for maps expressed using RDF"
+      }
+    ],
+    "http://purl.org/dc/terms/contributor": [
+      {
+        "@id": "http://viaf.org/viaf/151962300"
+      }
+    ],
+    "http://purl.org/dc/terms/creator": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "Specifies the form of material for the item."
+      }
+    ],
+    "http://purl.org/dc/terms/format": [
+      {
+        "@id": "http://www.w3.org/ns/formats/JSON-LD"
+      }
+    ],
+    "http://purl.org/dc/terms/hasFormat": [
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"
+      }
+    ],
+    "http://purl.org/dc/terms/issued": [
+      {
+        "@value": "2024"
+      }
+    ],
+    "http://purl.org/dc/terms/license": [
+      {
+        "@id": "http://creativecommons.org/publicdomain/zero/1.0"
+      }
+    ],
+    "http://purl.org/dc/terms/provenance": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+      }
+    ],
+    "http://purl.org/dc/terms/publisher": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "https://www.loc.gov/marc/bibliographic/bd008.html"
+      },
+      {
+        "@id": "http://marc21rdf.info"
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Maps: form of item"
+      }
+    ],
+    "http://purl.org/dc/terms/type": [
+      {
+        "@id": "http://purl.org/dc/dcmitype/Dataset"
+      }
+    ],
+    "https://schema.org/disambiguatingDescription": [
+      {
+        "@language": "en",
+        "@value": "SKOS Concept Scheme for MARC 00X Values"
+      }
+    ],
+    "https://schema.org/version": [
+      {
+        "@value": "1-0-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  }
+]

--- a/008/maps_form_of_item/maps_form_of_item.nt
+++ b/008/maps_form_of_item/maps_form_of_item.nt
@@ -1,0 +1,74 @@
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/issued> "2024" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for maps expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/title> "Maps: form of item"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/version> "1-0-0" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/description> "Specifies the form of material for the item."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:schema="https://schema.org/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    >
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+        <dct:title xml:lang="en">Maps: form of item</dct:title>
+        <dct:alternative xml:lang="en">MARC21 008/29 values for maps expressed using RDF</dct:alternative>
+        <dct:description xml:lang="en">Specifies the form of material for the item.</dct:description>
+        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+        <dct:source rdf:resource="http://marc21rdf.info"/>
+        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+        <dct:issued>2024</dct:issued>
+        <dc:language>en</dc:language>
+        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+        <schema:version>1-0-0</schema:version>
+        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfilm.</skos:definition>
+        <skos:notation>a</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+        <skos:definition xml:lang="en">Braille.</skos:definition>
+        <skos:notation>f</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+        <skos:notation>#</skos:notation>
+        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+        <skos:definition xml:lang="en">Large print.</skos:definition>
+        <skos:notation>d</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+        <skos:definition xml:lang="en">Microopaque.</skos:definition>
+        <skos:notation>c</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfiche.</skos:definition>
+        <skos:notation>b</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+        <skos:notation>r</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+        <skos:notation>o</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+        <skos:notation>q</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+        <skos:notation>s</skos:notation>
+        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+    </rdf:Description>
+</rdf:RDF>

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -6,7 +6,7 @@
     xmlns:schema="https://schema.org/"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
         <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
         <dct:title xml:lang="en">Maps: form of item</dct:title>
@@ -26,73 +26,73 @@
         <schema:version>1-0-0</schema:version>
         <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
         <skos:definition xml:lang="en">Microfilm.</skos:definition>
         <skos:notation>a</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
         <skos:definition xml:lang="en">Braille.</skos:definition>
         <skos:notation>f</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
         <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
         <skos:notation>#</skos:notation>
         <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
         <skos:definition xml:lang="en">Large print.</skos:definition>
         <skos:notation>d</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
         <skos:definition xml:lang="en">Microopaque.</skos:definition>
         <skos:notation>c</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
         <skos:definition xml:lang="en">Microfiche.</skos:definition>
         <skos:notation>b</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
         <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
         <skos:notation>r</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">online</skos:prefLabel>
         <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
         <skos:notation>o</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
         <skos:notation>q</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
         <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
         <skos:notation>s</skos:notation>

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -1,101 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dct="http://purl.org/dc/terms/"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:schema="https://schema.org/"
-    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-    >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
-        <dct:title xml:lang="en">Maps: form of item</dct:title>
-        <dct:alternative xml:lang="en">MARC21 008/29 values for maps expressed using RDF</dct:alternative>
-        <dct:description xml:lang="en">Specifies the form of material for the item.</dct:description>
-        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
-        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
-        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
-        <dct:source rdf:resource="http://marc21rdf.info"/>
-        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
-        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
-        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
-        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
-        <dct:issued>2024</dct:issued>
-        <dc:language>en</dc:language>
-        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-        <schema:version>1-0-0</schema:version>
-        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-        <skos:definition xml:lang="en">Microfilm.</skos:definition>
-        <skos:notation>a</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-        <skos:definition xml:lang="en">Braille.</skos:definition>
-        <skos:notation>f</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-        <skos:notation>#</skos:notation>
-        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-        <skos:definition xml:lang="en">Large print.</skos:definition>
-        <skos:notation>d</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-        <skos:definition xml:lang="en">Microopaque.</skos:definition>
-        <skos:notation>c</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-        <skos:definition xml:lang="en">Microfiche.</skos:definition>
-        <skos:notation>b</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
-        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
-        <skos:notation>r</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
-        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-        <skos:notation>o</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-        <skos:notation>q</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
-        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-        <skos:notation>s</skos:notation>
-        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
-    </rdf:Description>
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+    <dct:title xml:lang="en">Maps: form of item</dct:title>
+    <dct:alternative xml:lang="en">MARC21 008/29 values for maps expressed using RDF</dct:alternative>
+    <dct:description xml:lang="en">Specifies the form of material for the item.</dct:description>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+    <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+    <dct:source rdf:resource="http://marc21rdf.info"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+    <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+    <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+    <dct:issued>2024</dct:issued>
+    <dc:language>en</dc:language>
+    <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+    <schema:version>1-0-0</schema:version>
+    <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+    <skos:definition xml:lang="en">Large print.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+    <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+    <skos:definition xml:lang="en">Microopaque.</skos:definition>
+    <skos:notation>c</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+    <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:definition xml:lang="en">Braille.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfiche.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
 </rdf:RDF>

--- a/008/maps_form_of_item/maps_form_of_item.ttl
+++ b/008/maps_form_of_item/maps_form_of_item.ttl
@@ -1,0 +1,90 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix schema: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> a skos:Concept ;
+    skos:definition "Microfilm."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "a" ;
+    skos:prefLabel "microfilm"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> a skos:Concept ;
+    skos:definition "Microfiche."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "b" ;
+    skos:prefLabel "microfiche"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> a skos:Concept ;
+    skos:definition "Microopaque."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "c" ;
+    skos:prefLabel "microopaque"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> a skos:Concept ;
+    skos:definition "Large print."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "d" ;
+    skos:prefLabel "large print"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> a skos:Concept ;
+    skos:definition "Braille."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "f" ;
+    skos:prefLabel "braille"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> a skos:Concept ;
+    skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "o" ;
+    skos:prefLabel "online"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> a skos:Concept ;
+    skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "#" ;
+    skos:prefLabel "none of the following"@en ;
+    skos:scopeNote "Not specified by one of the other codes."@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> a skos:Concept ;
+    skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "q" ;
+    skos:prefLabel "direct electronic"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> a skos:Concept ;
+    skos:definition "Eye-readable print, such as a photocopy." ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "r" ;
+    skos:prefLabel "regular print reproduction"@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> a skos:Concept ;
+    skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.8dk4-4h49> ;
+    skos:notation "s" ;
+    skos:prefLabel "electronic"@en ;
+    skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> a skos:ConceptScheme ;
+    dc:contributor "Metadata Management Associates"@en ;
+    dc:language "en" ;
+    dct:alternative "MARC21 008/29 values for maps expressed using RDF"@en ;
+    dct:contributor <http://viaf.org/viaf/151962300> ;
+    dct:creator <http://viaf.org/viaf/139541794> ;
+    dct:description "Specifies the form of material for the item."@en ;
+    dct:format <http://www.w3.org/ns/formats/Turtle> ;
+    dct:hasFormat <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf> ;
+    dct:issued "2024" ;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:publisher <http://viaf.org/viaf/139541794> ;
+    dct:source <http://marc21rdf.info>,
+        <https://www.loc.gov/marc/bibliographic/bd008.html> ;
+    dct:title "Maps: form of item"@en ;
+    dct:type <http://purl.org/dc/dcmitype/Dataset> ;
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-0-0" .
+

--- a/008/some_form_of_item/some_form_of_item.html
+++ b/008/some_form_of_item/some_form_of_item.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" prefix="dc: http://purl.org/dc/elements/1.1/ dct: http://purl.org/dc/terms/ rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# schema: https://schema.org/ skos: http://www.w3.org/2004/02/skos/core# xml: http://www.w3.org/XML/1998/namespace ">
+<html lang="en" prefix="dc: http://purl.org/dc/elements/1.1/ dct: http://purl.org/dc/terms/ rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# schema: https://schema.org/ skos: http://www.w3.org/2004/02/skos/core# uwp: https://doi.org/10.6069/uwlib.55.d.3# xml: http://www.w3.org/XML/1998/namespace ">
     <head>
         <title>Some: form of item</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -45,12 +45,12 @@
             }
             ] , 
             
-        "datePublished" : "2023", 
+        "datePublished" : "2024", 
        
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-0-2" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -222,7 +222,7 @@
                         <td>
                             <a href="http://purl.org/dc/terms/issued">dct:issued</a>
                         </td>
-                        <td property="dct:issued">2023</td>
+                        <td property="dct:issued">2024</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
                         <td>
@@ -326,7 +326,43 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-0-2</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.dh5m-5y16">https://doi.org/10.6069/uwlswd.dh5m-5y16</a>
+                        </td>
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial">uwp:appliesToMaterial</a>
+                        </td>
+                        <td property="uwp:appliesToMaterial">books</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.dh5m-5y16">https://doi.org/10.6069/uwlswd.dh5m-5y16</a>
+                        </td>
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial">uwp:appliesToMaterial</a>
+                        </td>
+                        <td property="uwp:appliesToMaterial">music</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.dh5m-5y16">https://doi.org/10.6069/uwlswd.dh5m-5y16</a>
+                        </td>
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial">uwp:appliesToMaterial</a>
+                        </td>
+                        <td property="uwp:appliesToMaterial">continuing resources</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.dh5m-5y16">https://doi.org/10.6069/uwlswd.dh5m-5y16</a>
+                        </td>
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial">uwp:appliesToMaterial</a>
+                        </td>
+                        <td property="uwp:appliesToMaterial">mixed materials</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
                         <td id="a">
@@ -1173,7 +1209,14 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
@@ -1188,28 +1231,31 @@
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-0-2&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+    &lt;uwp:appliesToMaterial&gt;books&lt;/uwp:appliesToMaterial&gt;
+    &lt;uwp:appliesToMaterial&gt;music&lt;/uwp:appliesToMaterial&gt;
+    &lt;uwp:appliesToMaterial&gt;continuing resources&lt;/uwp:appliesToMaterial&gt;
+    &lt;uwp:appliesToMaterial&gt;mixed materials&lt;/uwp:appliesToMaterial&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;punched paper tape [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1218,13 +1264,31 @@
     &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
     &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
+    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete] [USMARC only]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;x&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1233,11 +1297,12 @@
     &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
     &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;typewritten transcript [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
+    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1253,44 +1318,20 @@
     &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
     &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete] [USMARC only]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;x&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;punched paper tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
+    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1300,23 +1341,23 @@
     &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;multimedia [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;typewritten transcript [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;handwritten transcript [obsolete]&lt;/skos:prefLabel&gt;
     &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;multimedia [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1327,6 +1368,7 @@
 @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
 @prefix schema: &lt;https://schema.org/&gt; .
 @prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+@prefix uwp: &lt;https://doi.org/10.6069/uwlib.55.d.3#&gt; .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; a skos:Concept ;
     skos:definition "Microfilm."@en ;
@@ -1442,7 +1484,7 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld&gt;,
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt&gt;,
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; ;
-    dct:issued "2023" ;
+    dct:issued "2024" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
     dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
@@ -1450,126 +1492,169 @@
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Some: form of item"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
+    uwp:appliesToMaterial "books",
+        "continuing resources",
+        "mixed materials",
+        "music" ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:version "1-0-2" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: form of item"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "continuing resources" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete] [USMARC only]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for some materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/version&gt; "1-0-2" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "mixed materials" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "typewritten transcript [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "punched paper tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handwritten transcript [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "music" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handwritten transcript [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for some materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "typewritten transcript [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "punched paper tape [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete] [USMARC only]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -1581,13 +1666,94 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "x"
+        "@value": "t"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other form of reproduction [obsolete] [USMARC only]"
+        "@value": "typewritten transcript [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magnetic tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
       }
     ]
   },
@@ -1611,6 +1777,35 @@
       {
         "@language": "en",
         "@value": "other form of reproduction [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
       }
     ]
   },
@@ -1650,14 +1845,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+        "@value": "Microopaque."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1668,31 +1863,25 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "s"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "electronic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+        "@value": "microopaque"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Braille."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1703,13 +1892,111 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "o"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "punched paper tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#ix",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "multimedia [obsolete]"
       }
     ]
   },
@@ -1772,7 +2059,7 @@
     ],
     "http://purl.org/dc/terms/issued": [
       {
-        "@value": "2023"
+        "@value": "2024"
       }
     ],
     "http://purl.org/dc/terms/license": [
@@ -1809,6 +2096,20 @@
         "@id": "http://purl.org/dc/dcmitype/Dataset"
       }
     ],
+    "https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial": [
+      {
+        "@value": "books"
+      },
+      {
+        "@value": "music"
+      },
+      {
+        "@value": "continuing resources"
+      },
+      {
+        "@value": "mixed materials"
+      }
+    ],
     "https://schema.org/disambiguatingDescription": [
       {
         "@value": "SKOS Concept Scheme for MARC 00X Values"
@@ -1816,319 +2117,7 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handwritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "punched paper tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Eye-readable print, such as a photocopy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "regular print reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microopaque."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "typewritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Large print."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#ix",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "multimedia [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "magnetic tape [obsolete]"
+        "@value": "1-0-2"
       }
     ]
   },
@@ -2158,6 +2147,81 @@
       {
         "@language": "en",
         "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete] [USMARC only]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handwritten transcript [obsolete]"
       }
     ]
   }

--- a/008/some_form_of_item/some_form_of_item.jsonld
+++ b/008/some_form_of_item/some_form_of_item.jsonld
@@ -1,6 +1,41 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -12,13 +47,94 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "x"
+        "@value": "t"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other form of reproduction [obsolete] [USMARC only]"
+        "@value": "typewritten transcript [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magnetic tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
       }
     ]
   },
@@ -42,6 +158,35 @@
       {
         "@language": "en",
         "@value": "other form of reproduction [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
       }
     ]
   },
@@ -81,14 +226,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+        "@value": "Microopaque."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -99,31 +244,25 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "s"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "electronic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+        "@value": "microopaque"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Braille."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -134,13 +273,111 @@
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
         "@language": "en",
-        "@value": "o"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "punched paper tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#ix",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "multimedia [obsolete]"
       }
     ]
   },
@@ -203,7 +440,7 @@
     ],
     "http://purl.org/dc/terms/issued": [
       {
-        "@value": "2023"
+        "@value": "2024"
       }
     ],
     "http://purl.org/dc/terms/license": [
@@ -240,6 +477,20 @@
         "@id": "http://purl.org/dc/dcmitype/Dataset"
       }
     ],
+    "https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial": [
+      {
+        "@value": "books"
+      },
+      {
+        "@value": "music"
+      },
+      {
+        "@value": "continuing resources"
+      },
+      {
+        "@value": "mixed materials"
+      }
+    ],
     "https://schema.org/disambiguatingDescription": [
       {
         "@value": "SKOS Concept Scheme for MARC 00X Values"
@@ -247,319 +498,7 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handwritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "punched paper tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Eye-readable print, such as a photocopy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "regular print reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microopaque."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "typewritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Large print."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#ix",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "multimedia [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "magnetic tape [obsolete]"
+        "@value": "1-0-2"
       }
     ]
   },
@@ -589,6 +528,81 @@
       {
         "@language": "en",
         "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete] [USMARC only]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@language": "en",
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handwritten transcript [obsolete]"
       }
     ]
   }

--- a/008/some_form_of_item/some_form_of_item.nt
+++ b/008/some_form_of_item/some_form_of_item.nt
@@ -1,106 +1,110 @@
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/title> "Some: form of item"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy [obsolete]"@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "continuing resources" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete] [USMARC only]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for some materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#notation> "x"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/version> "1-0-2" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "mixed materials" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#prefLabel> "typewritten transcript [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "punched paper tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "handwritten transcript [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/title> "Some: form of item"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "music" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "handwritten transcript [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for some materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#prefLabel> "typewritten transcript [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "punched paper tape [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#notation> "x"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete] [USMARC only]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/issued> "2024" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -7,6 +7,12 @@
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
    xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 >
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">p</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -35,18 +41,17 @@
     <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -55,13 +60,31 @@
     <skos:definition xml:lang="en">Braille.</skos:definition>
     <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
-    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+    <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
+    <skos:notation xml:lang="en">r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation xml:lang="en">q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
+    <skos:notation xml:lang="en">x</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -70,11 +93,12 @@
     <skos:definition xml:lang="en">Large print.</skos:definition>
     <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+    <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -90,44 +114,20 @@
     <skos:definition xml:lang="en">Microfiche.</skos:definition>
     <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
-    <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">online</skos:prefLabel>
-    <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -137,22 +137,22 @@
     <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">handwritten transcript [obsolete]</skos:prefLabel>
     <skos:notation xml:lang="en">j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 >
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -23,12 +24,17 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    <uwp:appliesToMaterial>books</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>computer files</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>music</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
+    <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -21,7 +21,7 @@
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
-    <dct:issued>2023</dct:issued>
+    <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <schema:version>1-0-2</schema:version>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -31,7 +31,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <uwp:appliesToMaterial>books</uwp:appliesToMaterial>
-    <uwp:appliesToMaterial>computer files</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>music</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>

--- a/008/some_form_of_item/some_form_of_item.ttl
+++ b/008/some_form_of_item/some_form_of_item.ttl
@@ -2,6 +2,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix schema: <https://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix uwp: <https://doi.org/10.6069/uwlib.55.d.3#> .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#a> a skos:Concept ;
     skos:definition "Microfilm."@en ;
@@ -117,7 +118,7 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld>,
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt>,
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> ;
-    dct:issued "2023" ;
+    dct:issued "2024" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
     dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
@@ -125,6 +126,10 @@
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Some: form of item"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
+    uwp:appliesToMaterial "books",
+        "continuing resources",
+        "mixed materials",
+        "music" ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:version "1-0-2" .
 

--- a/008/visual_form_of_item/visual_form_of_item.html
+++ b/008/visual_form_of_item/visual_form_of_item.html
@@ -1,0 +1,1558 @@
+<!DOCTYPE html>
+<html lang="en" prefix="dc: http://purl.org/dc/elements/1.1/ dct: http://purl.org/dc/terms/ rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# schema: https://schema.org/ skos: http://www.w3.org/2004/02/skos/core# xml: http://www.w3.org/XML/1998/namespace ">
+    <head>
+        <title>Visual: form of item</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <link href="https://uwlib-cams.github.io/webviews/css/uwlswd.css" rel="stylesheet" type="text/css">
+        <link rel="icon" type="image/png" href="https://uwlib-cams.github.io/webviews/images/book.png">
+        <script type="application/ld+json"> 
+        { 
+        "@context" : "http://schema.org" , 
+        "@type" : "Dataset" , 
+        "@id" : "https://doi.org/10.6069/uwlswd.fr5p-1828", 
+        "name" : "Visual: form of item" , 
+         
+        "alternateName" : "MARC21 008/29 values for visual materials expressed using RDF" ,
+        "description" : "Specifies the form of material." , 
+            
+        "isBasedOn" : [ 
+            "https://www.loc.gov/marc/bibliographic/bd008.html" , 
+            
+            "http://marc21rdf.info"
+            ] , 
+        "creator" : 
+            {
+            "@id" : "http://viaf.org/viaf/139541794", 
+            "name" : "University of Washington Libraries" ,  
+            "sameAs" : "http://viaf.org/viaf/139541794" 
+            } ,        
+                    
+        "publisher" : {
+            "@id" : "http://viaf.org/viaf/139541794", 
+            "name" : "University of Washington Libraries" ,  
+            "sameAs" : "http://viaf.org/viaf/139541794"
+            } , 
+    
+        "contributor" : [
+            {
+            "@id" : "http://viaf.org/viaf/151962300", 
+            "name" : "Library of Congress" , 
+            "sameAs" : "http://viaf.org/viaf/151962300"
+            } , 
+        
+            {
+            "name" : "Metadata Management Associates"
+            }
+            ] , 
+            
+        "datePublished" : "2024", 
+       
+        "inLanguage" : "en" ,  
+        "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
+        
+        "version" : "1-0-0" , 
+             
+        "distribution" : [
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl" ,
+              "encodingFormat" : "text/turtle" 
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt" ,
+              "encodingFormat" : "application/n-triples"  
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld" ,
+              "encodingFormat" : "application/ld+json" 
+            } , 
+            { "@type" : "DataDownload" , 
+              "url" : "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf" ,
+              "encodingFormat" : "application/rdf+xml"
+            } 
+            ] , 
+        "encodingFormat" : "text/html" 
+        } 
+    </script>
+        <link rel="alternate" type="application/n-triples" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt">
+        <link rel="alternate" type="application/rdf+xml" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf">
+        <link rel="alternate" type="text/turtle" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl">
+        <link rel="alternate" type="application/ld+json" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld">
+    </head>
+    <body about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+        <script type="text/javascript" src="https://uwlib-cams.github.io/webviews/js/uwlswd.js"></script>
+        <a class="return" href="https://uwlib-cams.github.io/uwlswd/">Return to all UWLSWD datasets and vocabularies</a>
+        <h1>Visual: form of item</h1>
+        <h2 id="altTitle">(MARC21 008/29 values for visual materials expressed using RDF)</h2>
+        <p>Specifies the form of material.</p>
+        <h2 id="triples">RDF Triples for Visual: form of item</h2>
+        <div class="tab">
+            <button class="tablinks" onclick="openTab(event, 'table')">Table View</button>
+            <button class="tablinks" onclick="openTab(event, 'rdfxml')">RDF/XML</button>
+            <button class="tablinks" onclick="openTab(event, 'ttl')">Turtle</button>
+            <button class="tablinks" onclick="openTab(event, 'nt')">N-Triples</button>
+            <button class="tablinks" onclick="openTab(event, 'json')">JSON</button>
+        </div>
+        <div id="table" class="tabcontent" style="display:block">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Subject</th>
+                        <th scope="col">Predicate</th>
+                        <th scope="col">Object</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/elements/1.1/contributor">dc:contributor</a>
+                        </td>
+                        <td property="dc:contributor" xml:lang="en">Metadata Management Associates</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/elements/1.1/language">dc:language</a>
+                        </td>
+                        <td property="dc:language">en</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/alternative">dct:alternative</a>
+                        </td>
+                        <td property="dct:alternative" xml:lang="en">MARC21 008/29 values for visual materials expressed using RDF</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/contributor">dct:contributor</a>
+                        </td>
+                        <td property="dct:contributor" resource="http://viaf.org/viaf/151962300">
+                            <a href="http://viaf.org/viaf/151962300">http://viaf.org/viaf/151962300</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/creator">dct:creator</a>
+                        </td>
+                        <td property="dct:creator" resource="http://viaf.org/viaf/139541794">
+                            <a href="http://viaf.org/viaf/139541794">http://viaf.org/viaf/139541794</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/description">dct:description</a>
+                        </td>
+                        <td property="dct:description" xml:lang="en">Specifies the form of material.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/format">dct:format</a>
+                        </td>
+                        <td property="dct:format" resource="http://www.w3.org/ns/formats/RDFa">
+                            <a href="http://www.w3.org/ns/formats/RDFa">http://www.w3.org/ns/formats/RDFa</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
+                        </td>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/issued">dct:issued</a>
+                        </td>
+                        <td property="dct:issued">2024</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/license">dct:license</a>
+                        </td>
+                        <td property="dct:license" resource="http://creativecommons.org/publicdomain/zero/1.0">
+                            <a href="http://creativecommons.org/publicdomain/zero/1.0">http://creativecommons.org/publicdomain/zero/1.0</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
+                        </td>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/publisher">dct:publisher</a>
+                        </td>
+                        <td property="dct:publisher" resource="http://viaf.org/viaf/139541794">
+                            <a href="http://viaf.org/viaf/139541794">http://viaf.org/viaf/139541794</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/source">dct:source</a>
+                        </td>
+                        <td property="dct:source" resource="https://www.loc.gov/marc/bibliographic/bd008.html">
+                            <a href="https://www.loc.gov/marc/bibliographic/bd008.html">https://www.loc.gov/marc/bibliographic/bd008.html</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/source">dct:source</a>
+                        </td>
+                        <td property="dct:source" resource="http://marc21rdf.info">
+                            <a href="http://marc21rdf.info">http://marc21rdf.info</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/title">dct:title</a>
+                        </td>
+                        <td property="dct:title" xml:lang="en">Visual: form of item</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://purl.org/dc/terms/type">dct:type</a>
+                        </td>
+                        <td property="dct:type" resource="http://purl.org/dc/dcmitype/Dataset">
+                            <a href="http://purl.org/dc/dcmitype/Dataset">http://purl.org/dc/dcmitype/Dataset</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+                            <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">http://www.w3.org/2004/02/skos/core#ConceptScheme</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
+                        </td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                        <td>
+                            <a href="https://schema.org/version">schema:version</a>
+                        </td>
+                        <td property="schema:version">1-0-0</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+                        <td id="a">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#a">https://doi.org/10.6069/uwlswd.fr5p-1828#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#a">https://doi.org/10.6069/uwlswd.fr5p-1828#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microfilm.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#a">https://doi.org/10.6069/uwlswd.fr5p-1828#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#a">https://doi.org/10.6069/uwlswd.fr5p-1828#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">a</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#a">https://doi.org/10.6069/uwlswd.fr5p-1828#a</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microfilm</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+                        <td id="b">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#b">https://doi.org/10.6069/uwlswd.fr5p-1828#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#b">https://doi.org/10.6069/uwlswd.fr5p-1828#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microfiche.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#b">https://doi.org/10.6069/uwlswd.fr5p-1828#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#b">https://doi.org/10.6069/uwlswd.fr5p-1828#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">b</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#b">https://doi.org/10.6069/uwlswd.fr5p-1828#b</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microfiche</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+                        <td id="c">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#c">https://doi.org/10.6069/uwlswd.fr5p-1828#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#c">https://doi.org/10.6069/uwlswd.fr5p-1828#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Microopaque.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#c">https://doi.org/10.6069/uwlswd.fr5p-1828#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#c">https://doi.org/10.6069/uwlswd.fr5p-1828#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">c</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#c">https://doi.org/10.6069/uwlswd.fr5p-1828#c</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">microopaque</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+                        <td id="d">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#d">https://doi.org/10.6069/uwlswd.fr5p-1828#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#d">https://doi.org/10.6069/uwlswd.fr5p-1828#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Large print.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#d">https://doi.org/10.6069/uwlswd.fr5p-1828#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#d">https://doi.org/10.6069/uwlswd.fr5p-1828#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">d</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#d">https://doi.org/10.6069/uwlswd.fr5p-1828#d</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">large print</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+                        <td id="f">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#f">https://doi.org/10.6069/uwlswd.fr5p-1828#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#f">https://doi.org/10.6069/uwlswd.fr5p-1828#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Braille.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#f">https://doi.org/10.6069/uwlswd.fr5p-1828#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#f">https://doi.org/10.6069/uwlswd.fr5p-1828#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">f</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#f">https://doi.org/10.6069/uwlswd.fr5p-1828#f</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">braille</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+                        <td id="o">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#o">https://doi.org/10.6069/uwlswd.fr5p-1828#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#o">https://doi.org/10.6069/uwlswd.fr5p-1828#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Accessed by means of hardware and software connections to a communications network.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#o">https://doi.org/10.6069/uwlswd.fr5p-1828#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#o">https://doi.org/10.6069/uwlswd.fr5p-1828#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">o</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#o">https://doi.org/10.6069/uwlswd.fr5p-1828#o</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">online</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td id="pound">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille,
+                  online, direct electronic, regular print reproduction, or electronic.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">#</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">none of the following</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">https://doi.org/10.6069/uwlswd.fr5p-1828#pound</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#scopeNote">skos:scopeNote</a>
+                        </td>
+                        <td property="skos:scopeNote" xml:lang="en">Not specified by one of the other codes.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+                        <td id="q">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#q">https://doi.org/10.6069/uwlswd.fr5p-1828#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#q">https://doi.org/10.6069/uwlswd.fr5p-1828#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway
+                  device, flashdrive, portable hard drive, etc.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#q">https://doi.org/10.6069/uwlswd.fr5p-1828#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#q">https://doi.org/10.6069/uwlswd.fr5p-1828#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">q</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#q">https://doi.org/10.6069/uwlswd.fr5p-1828#q</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">direct electronic</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+                        <td id="r">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#r">https://doi.org/10.6069/uwlswd.fr5p-1828#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#r">https://doi.org/10.6069/uwlswd.fr5p-1828#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition">Eye-readable print, such as a photocopy.</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#r">https://doi.org/10.6069/uwlswd.fr5p-1828#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#r">https://doi.org/10.6069/uwlswd.fr5p-1828#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">r</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#r">https://doi.org/10.6069/uwlswd.fr5p-1828#r</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">regular print reproduction</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td id="s">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a>
+                        </td>
+                        <td property="rdf:type" resource="http://www.w3.org/2004/02/skos/core#Concept">
+                            <a href="http://www.w3.org/2004/02/skos/core#Concept">http://www.w3.org/2004/02/skos/core#Concept</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#definition">skos:definition</a>
+                        </td>
+                        <td property="skos:definition" xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly
+                  or remotely, in some cases requiring the use of peripheral devices attached to the
+                  computer (e.g., a CD-ROM player).</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#inScheme">skos:inScheme</a>
+                        </td>
+                        <td property="skos:inScheme" resource="https://doi.org/10.6069/uwlswd.fr5p-1828">
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828">https://doi.org/10.6069/uwlswd.fr5p-1828</a>
+                        </td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
+                        </td>
+                        <td property="skos:notation">s</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#prefLabel">skos:prefLabel</a>
+                        </td>
+                        <td property="skos:prefLabel" xml:lang="en">electronic</td>
+                    </tr>
+                    <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+                        <td>
+                            <a href="https://doi.org/10.6069/uwlswd.fr5p-1828#s">https://doi.org/10.6069/uwlswd.fr5p-1828#s</a>
+                        </td>
+                        <td>
+                            <a href="http://www.w3.org/2004/02/skos/core#scopeNote">skos:scopeNote</a>
+                        </td>
+                        <td property="skos:scopeNote" xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact
+                  discs, videodiscs).</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="rdfxml" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf" download="" target="_blank" rel="noopener noreferrer">Download RDF/XML</a>
+            <pre>&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Visual: form of item&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/29 values for visual materials expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Specifies the form of material.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+&lt;/rdf:RDF&gt;
+</pre>
+        </div>
+        <div id="ttl" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl" download="" target="_blank" rel="noopener noreferrer">Download Turtle</a>
+            <pre>@prefix dc: &lt;http://purl.org/dc/elements/1.1/&gt; .
+@prefix dct: &lt;http://purl.org/dc/terms/&gt; .
+@prefix schema: &lt;https://schema.org/&gt; .
+@prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt; .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; a skos:Concept ;
+    skos:definition "Microfilm."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "a" ;
+    skos:prefLabel "microfilm"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; a skos:Concept ;
+    skos:definition "Microfiche."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "b" ;
+    skos:prefLabel "microfiche"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; a skos:Concept ;
+    skos:definition "Microopaque."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "c" ;
+    skos:prefLabel "microopaque"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; a skos:Concept ;
+    skos:definition "Large print."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "d" ;
+    skos:prefLabel "large print"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; a skos:Concept ;
+    skos:definition "Braille."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "f" ;
+    skos:prefLabel "braille"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; a skos:Concept ;
+    skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "o" ;
+    skos:prefLabel "online"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; a skos:Concept ;
+    skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "#" ;
+    skos:prefLabel "none of the following"@en ;
+    skos:scopeNote "Not specified by one of the other codes."@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; a skos:Concept ;
+    skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "q" ;
+    skos:prefLabel "direct electronic"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; a skos:Concept ;
+    skos:definition "Eye-readable print, such as a photocopy." ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "r" ;
+    skos:prefLabel "regular print reproduction"@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; a skos:Concept ;
+    skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
+    skos:inScheme &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; ;
+    skos:notation "s" ;
+    skos:prefLabel "electronic"@en ;
+    skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; a skos:ConceptScheme ;
+    dc:contributor "Metadata Management Associates"@en ;
+    dc:language "en" ;
+    dct:alternative "MARC21 008/29 values for visual materials expressed using RDF"@en ;
+    dct:contributor &lt;http://viaf.org/viaf/151962300&gt; ;
+    dct:creator &lt;http://viaf.org/viaf/139541794&gt; ;
+    dct:description "Specifies the form of material."@en ;
+    dct:format &lt;http://www.w3.org/ns/formats/Turtle&gt; ;
+    dct:hasFormat &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt&gt;,
+        &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf&gt; ;
+    dct:issued "2024" ;
+    dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
+    dct:source &lt;http://marc21rdf.info&gt;,
+        &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
+    dct:title "Visual: form of item"@en ;
+    dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-0-0" .
+
+</pre>
+        </div>
+        <div id="nt" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
+            <pre>&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for visual materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/version&gt; "1-0-0" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+</pre>
+        </div>
+        <div id="json" class="tabcontent">
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
+            <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://purl.org/dc/elements/1.1/contributor": [
+      {
+        "@language": "en",
+        "@value": "Metadata Management Associates"
+      }
+    ],
+    "http://purl.org/dc/elements/1.1/language": [
+      {
+        "@value": "en"
+      }
+    ],
+    "http://purl.org/dc/terms/alternative": [
+      {
+        "@language": "en",
+        "@value": "MARC21 008/29 values for visual materials expressed using RDF"
+      }
+    ],
+    "http://purl.org/dc/terms/contributor": [
+      {
+        "@id": "http://viaf.org/viaf/151962300"
+      }
+    ],
+    "http://purl.org/dc/terms/creator": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "Specifies the form of material."
+      }
+    ],
+    "http://purl.org/dc/terms/format": [
+      {
+        "@id": "http://www.w3.org/ns/formats/JSON-LD"
+      }
+    ],
+    "http://purl.org/dc/terms/hasFormat": [
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"
+      }
+    ],
+    "http://purl.org/dc/terms/issued": [
+      {
+        "@value": "2024"
+      }
+    ],
+    "http://purl.org/dc/terms/license": [
+      {
+        "@id": "http://creativecommons.org/publicdomain/zero/1.0"
+      }
+    ],
+    "http://purl.org/dc/terms/provenance": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+      }
+    ],
+    "http://purl.org/dc/terms/publisher": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "https://www.loc.gov/marc/bibliographic/bd008.html"
+      },
+      {
+        "@id": "http://marc21rdf.info"
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Visual: form of item"
+      }
+    ],
+    "http://purl.org/dc/terms/type": [
+      {
+        "@id": "http://purl.org/dc/dcmitype/Dataset"
+      }
+    ],
+    "https://schema.org/disambiguatingDescription": [
+      {
+        "@language": "en",
+        "@value": "SKOS Concept Scheme for MARC 00X Values"
+      }
+    ],
+    "https://schema.org/version": [
+      {
+        "@value": "1-0-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  }
+]</pre>
+        </div>
+        <hr>
+        <div class="contact">
+            <h3>Contact:</h3>
+            <p>
+                <a href="https://www.lib.washington.edu/msd">University of Washington Libraries,
+               Cataloging and Metadata Services</a>
+                <br> Box 352900, Seattle, WA 98195-2900<br> Telephone: 206-543-1919<br>
+                <a href="mailto:uwlsemanticweb@uw.edu">uwlsemanticweb@uw.edu</a>
+            </p>
+        </div>
+        <div class="footer_workaround"></div>
+        <footer>
+            <section xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+                <div class="footer_container">
+                    <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/">
+                        <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0">
+                    </a>
+                    <div>To the extent possible under law, <a rel="dct:publisher" href="https://www.lib.washington.edu/cams">
+                            <span property="dct:title">Cataloging and Metadata Services, University of Washington Libraries</span>
+                        </a> has waived all copyright and related or neighboring rights to <span property="dct:title">
+                            <strong>Visual: form of item</strong>
+                        </span>. This work is published in the <span property="vcard:Country" datatype="dct:ISO3166" content="US" about="https://www.lib.washington.edu/cams">United States</span>. </div>
+                </div>
+            </section>
+        </footer>
+    </body>
+</html>

--- a/008/visual_form_of_item/visual_form_of_item.jsonld
+++ b/008/visual_form_of_item/visual_form_of_item.jsonld
@@ -1,0 +1,401 @@
+[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://purl.org/dc/elements/1.1/contributor": [
+      {
+        "@language": "en",
+        "@value": "Metadata Management Associates"
+      }
+    ],
+    "http://purl.org/dc/elements/1.1/language": [
+      {
+        "@value": "en"
+      }
+    ],
+    "http://purl.org/dc/terms/alternative": [
+      {
+        "@language": "en",
+        "@value": "MARC21 008/29 values for visual materials expressed using RDF"
+      }
+    ],
+    "http://purl.org/dc/terms/contributor": [
+      {
+        "@id": "http://viaf.org/viaf/151962300"
+      }
+    ],
+    "http://purl.org/dc/terms/creator": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/description": [
+      {
+        "@language": "en",
+        "@value": "Specifies the form of material."
+      }
+    ],
+    "http://purl.org/dc/terms/format": [
+      {
+        "@id": "http://www.w3.org/ns/formats/JSON-LD"
+      }
+    ],
+    "http://purl.org/dc/terms/hasFormat": [
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"
+      },
+      {
+        "@id": "https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"
+      }
+    ],
+    "http://purl.org/dc/terms/issued": [
+      {
+        "@value": "2024"
+      }
+    ],
+    "http://purl.org/dc/terms/license": [
+      {
+        "@id": "http://creativecommons.org/publicdomain/zero/1.0"
+      }
+    ],
+    "http://purl.org/dc/terms/provenance": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+      }
+    ],
+    "http://purl.org/dc/terms/publisher": [
+      {
+        "@id": "http://viaf.org/viaf/139541794"
+      }
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "https://www.loc.gov/marc/bibliographic/bd008.html"
+      },
+      {
+        "@id": "http://marc21rdf.info"
+      }
+    ],
+    "http://purl.org/dc/terms/title": [
+      {
+        "@language": "en",
+        "@value": "Visual: form of item"
+      }
+    ],
+    "http://purl.org/dc/terms/type": [
+      {
+        "@id": "http://purl.org/dc/dcmitype/Dataset"
+      }
+    ],
+    "https://schema.org/disambiguatingDescription": [
+      {
+        "@language": "en",
+        "@value": "SKOS Concept Scheme for MARC 00X Values"
+      }
+    ],
+    "https://schema.org/version": [
+      {
+        "@value": "1-0-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  }
+]

--- a/008/visual_form_of_item/visual_form_of_item.nt
+++ b/008/visual_form_of_item/visual_form_of_item.nt
@@ -1,0 +1,74 @@
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/title> "Visual: form of item"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for visual materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/version> "1-0-0" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/issued> "2024" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -6,7 +6,7 @@
     xmlns:schema="https://schema.org/"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
         <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
         <dct:title xml:lang="en">Visual: form of item</dct:title>
@@ -26,73 +26,73 @@
         <schema:version>1-0-0</schema:version>
         <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
         <skos:definition xml:lang="en">Microfilm.</skos:definition>
         <skos:notation>a</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
         <skos:definition xml:lang="en">Braille.</skos:definition>
         <skos:notation>f</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
         <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
         <skos:notation>#</skos:notation>
         <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
         <skos:definition xml:lang="en">Large print.</skos:definition>
         <skos:notation>d</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
         <skos:definition xml:lang="en">Microopaque.</skos:definition>
         <skos:notation>c</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
         <skos:definition xml:lang="en">Microfiche.</skos:definition>
         <skos:notation>b</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
         <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
         <skos:notation>r</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">online</skos:prefLabel>
         <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
         <skos:notation>o</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
         <skos:notation>q</skos:notation>
     </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
         <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
         <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
         <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
         <skos:notation>s</skos:notation>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:schema="https://schema.org/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    >
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+        <dct:title xml:lang="en">Visual: form of item</dct:title>
+        <dct:alternative xml:lang="en">MARC21 008/29 values for visual materials expressed using RDF</dct:alternative>
+        <dct:description xml:lang="en">Specifies the form of material.</dct:description>
+        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+        <dct:source rdf:resource="http://marc21rdf.info"/>
+        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+        <dct:issued>2024</dct:issued>
+        <dc:language>en</dc:language>
+        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+        <schema:version>1-0-0</schema:version>
+        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfilm.</skos:definition>
+        <skos:notation>a</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+        <skos:definition xml:lang="en">Braille.</skos:definition>
+        <skos:notation>f</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+        <skos:notation>#</skos:notation>
+        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+        <skos:definition xml:lang="en">Large print.</skos:definition>
+        <skos:notation>d</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+        <skos:definition xml:lang="en">Microopaque.</skos:definition>
+        <skos:notation>c</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+        <skos:definition xml:lang="en">Microfiche.</skos:definition>
+        <skos:notation>b</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+        <skos:notation>r</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+        <skos:notation>o</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+        <skos:notation>q</skos:notation>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+        <skos:notation>s</skos:notation>
+        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+    </rdf:Description>
+</rdf:RDF>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -1,101 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dct="http://purl.org/dc/terms/"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:schema="https://schema.org/"
-    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-    >
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-        <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
-        <dct:title xml:lang="en">Visual: form of item</dct:title>
-        <dct:alternative xml:lang="en">MARC21 008/29 values for visual materials expressed using RDF</dct:alternative>
-        <dct:description xml:lang="en">Specifies the form of material.</dct:description>
-        <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
-        <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
-        <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
-        <dct:source rdf:resource="http://marc21rdf.info"/>
-        <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
-        <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
-        <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
-        <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
-        <dct:issued>2024</dct:issued>
-        <dc:language>en</dc:language>
-        <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-        <schema:version>1-0-0</schema:version>
-        <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-        <skos:definition xml:lang="en">Microfilm.</skos:definition>
-        <skos:notation>a</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-        <skos:definition xml:lang="en">Braille.</skos:definition>
-        <skos:notation>f</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-        <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-        <skos:notation>#</skos:notation>
-        <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-        <skos:definition xml:lang="en">Large print.</skos:definition>
-        <skos:notation>d</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-        <skos:definition xml:lang="en">Microopaque.</skos:definition>
-        <skos:notation>c</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-        <skos:definition xml:lang="en">Microfiche.</skos:definition>
-        <skos:notation>b</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
-        <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
-        <skos:notation>r</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">online</skos:prefLabel>
-        <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-        <skos:notation>o</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-        <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-        <skos:notation>q</skos:notation>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
-        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-        <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-        <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
-        <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-        <skos:notation>s</skos:notation>
-        <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
-    </rdf:Description>
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+    <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
+    <dct:title xml:lang="en">Visual: form of item</dct:title>
+    <dct:alternative xml:lang="en">MARC21 008/29 values for visual materials expressed using RDF</dct:alternative>
+    <dct:description xml:lang="en">Specifies the form of material.</dct:description>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
+    <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
+    <dct:source rdf:resource="http://marc21rdf.info"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
+    <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
+    <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>
+    <dct:issued>2024</dct:issued>
+    <dc:language>en</dc:language>
+    <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
+    <schema:version>1-0-0</schema:version>
+    <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld"/>
+    <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+    <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:definition xml:lang="en">Braille.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+    <skos:definition xml:lang="en">Large print.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">online</skos:prefLabel>
+    <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfiche.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+    <skos:definition xml:lang="en">Microopaque.</skos:definition>
+    <skos:notation>c</skos:notation>
+  </rdf:Description>
 </rdf:RDF>

--- a/008/visual_form_of_item/visual_form_of_item.ttl
+++ b/008/visual_form_of_item/visual_form_of_item.ttl
@@ -1,0 +1,90 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix schema: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> a skos:Concept ;
+    skos:definition "Microfilm."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "a" ;
+    skos:prefLabel "microfilm"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> a skos:Concept ;
+    skos:definition "Microfiche."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "b" ;
+    skos:prefLabel "microfiche"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> a skos:Concept ;
+    skos:definition "Microopaque."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "c" ;
+    skos:prefLabel "microopaque"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> a skos:Concept ;
+    skos:definition "Large print."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "d" ;
+    skos:prefLabel "large print"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> a skos:Concept ;
+    skos:definition "Braille."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "f" ;
+    skos:prefLabel "braille"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> a skos:Concept ;
+    skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "o" ;
+    skos:prefLabel "online"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> a skos:Concept ;
+    skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "#" ;
+    skos:prefLabel "none of the following"@en ;
+    skos:scopeNote "Not specified by one of the other codes."@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> a skos:Concept ;
+    skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "q" ;
+    skos:prefLabel "direct electronic"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> a skos:Concept ;
+    skos:definition "Eye-readable print, such as a photocopy." ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "r" ;
+    skos:prefLabel "regular print reproduction"@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> a skos:Concept ;
+    skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
+    skos:inScheme <https://doi.org/10.6069/uwlswd.fr5p-1828> ;
+    skos:notation "s" ;
+    skos:prefLabel "electronic"@en ;
+    skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+
+<https://doi.org/10.6069/uwlswd.fr5p-1828> a skos:ConceptScheme ;
+    dc:contributor "Metadata Management Associates"@en ;
+    dc:language "en" ;
+    dct:alternative "MARC21 008/29 values for visual materials expressed using RDF"@en ;
+    dct:contributor <http://viaf.org/viaf/151962300> ;
+    dct:creator <http://viaf.org/viaf/139541794> ;
+    dct:description "Specifies the form of material."@en ;
+    dct:format <http://www.w3.org/ns/formats/Turtle> ;
+    dct:hasFormat <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt>,
+        <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf> ;
+    dct:issued "2024" ;
+    dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:publisher <http://viaf.org/viaf/139541794> ;
+    dct:source <http://marc21rdf.info>,
+        <https://www.loc.gov/marc/bibliographic/bd008.html> ;
+    dct:title "Visual: form of item"@en ;
+    dct:type <http://purl.org/dc/dcmitype/Dataset> ;
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-0-0" .
+


### PR DESCRIPTION
some_form_of_item, visual_form_of_item, and map_form_of_item now have datacite metadata and have been serialized, they are ready to be published and for DataCite to be updated. 