### PR TITLE
Cleanup for marc_006_008 vocabs

### DIFF
--- a/006/form_of_material.html
+++ b/006/form_of_material.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-2-0" , 
+        "version" : "1-3-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -315,7 +315,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.25z4-e963">
                         <td>
@@ -324,7 +324,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-2-0</td>
+                        <td property="schema:version">1-3-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.25z4-e963#a">
                         <td id="a">
@@ -1074,26 +1074,19 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;three-dimensional artifact or naturally occurring object&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Three-dimensional artifact or naturally occurring object.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;kit&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Kit.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#d"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;manuscript notated music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Manuscript notated music.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;computer file or electronic resource&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Computer file or an electronic resource in form.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;projected medium&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Projected medium.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1115,44 +1108,9 @@
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html"/&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
     &lt;dct:description xml:lang="en"&gt;Identifies a form of material.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;schema:version&gt;1-2-0&lt;/schema:version&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:version&gt;1-3-0&lt;/schema:version&gt;
     &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;nonmusical sound recording&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Nonmusical sound recording.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;serial or integrating resource&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Control aspects of a non-printed continuing resource.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;cartographic material&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Nonmanuscript cartographic material.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;projected medium&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Projected medium.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;kit&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Kit.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#t"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1168,19 +1126,47 @@
     &lt;skos:definition xml:lang="en"&gt;Notated music.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#k"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;two-dimensional nonprojectable graphic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Two-dimensional nonprojectable graphic.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;musical sound recording&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Musical sound recording.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;language material&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Nonserial language material.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;serial or integrating resource&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Control aspects of a non-printed continuing resource.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;nonmusical sound recording&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Nonmusical sound recording.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;computer file or electronic resource&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Computer file or an electronic resource in form.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;mixed material&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Mixed material.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;cartographic material&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Nonmanuscript cartographic material.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1189,19 +1175,33 @@
     &lt;skos:definition xml:lang="en"&gt;Manuscript cartographic material .&lt;/skos:definition&gt;
     &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#j"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;musical sound recording&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Musical sound recording.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;language material&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Nonserial language material.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#p"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#k"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;mixed material&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Mixed material.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;two-dimensional nonprojectable graphic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Two-dimensional nonprojectable graphic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;manuscript notated music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Manuscript notated music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;three-dimensional artifact or naturally occurring object&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Three-dimensional artifact or naturally occurring object.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1323,115 +1323,311 @@
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Form of material"@en ;
     schema:additionalType "Dataset"@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-2-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-3-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript notated music."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "computer file or electronic resource"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/title&gt; "Form of material"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "nonmusical sound recording"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "serial or integrating resource"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projected medium."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "kit"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript language material."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonmanuscript cartographic material."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three-dimensional artifact or naturally occurring object"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript cartographic material ."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cartographic material"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/version&gt; "1-2-0" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript notated music"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mixed material"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript language material"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "projected medium"@en .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/additionalType&gt; "Dataset"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonmusical sound recording."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 006/00 values for all materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Musical sound recording."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "notated music"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "projected medium"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "musical sound recording"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Computer file or an electronic resource in form."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Notated music."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional artifact or naturally occurring object."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonserial language material."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two-dimensional nonprojectable graphic."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "two-dimensional nonprojectable graphic"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/description&gt; "Identifies a form of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mixed material."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Control aspects of a non-printed continuing resource."@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Kit."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "notated music"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/title&gt; "Form of material"@en .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "serial or integrating resource"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript language material"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/description&gt; "Identifies a form of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 006/00 values for all materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mixed material."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonmusical sound recording."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "musical sound recording"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Control aspects of a non-printed continuing resource."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "two-dimensional nonprojectable graphic"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two-dimensional nonprojectable graphic."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Computer file or an electronic resource in form."@en .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "language material"@en .
-&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript cartographic material"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "kit"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonmanuscript cartographic material."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mixed material"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three-dimensional artifact or naturally occurring object"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/additionalType&gt; "Dataset"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional artifact or naturally occurring object."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript notated music."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cartographic material"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "nonmusical sound recording"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Notated music."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;https://schema.org/version&gt; "1-3-0" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
 &lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nonserial language material."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript cartographic material ."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Musical sound recording."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projected medium."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Manuscript language material."@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "computer file or electronic resource"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript cartographic material"@en .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.25z4-e963#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript notated music"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Kit."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "kit"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional artifact or naturally occurring object."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "three-dimensional artifact or naturally occurring object"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two-dimensional nonprojectable graphic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "two-dimensional nonprojectable graphic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Notated music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "notated music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Manuscript language material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript language material"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mixed material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "mixed material"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Manuscript notated music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript notated music"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#i",
     "@type": [
@@ -1489,14 +1685,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#c",
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Notated music."
+        "@value": "Musical sound recording."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1506,13 +1702,41 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "c"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "notated music"
+        "@value": "musical sound recording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nonserial language material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "language material"
       }
     ]
   },
@@ -1615,264 +1839,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-2-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nonserial language material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "language material"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Computer file or an electronic resource in form."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "computer file or electronic resource"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nonmanuscript cartographic material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cartographic material"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Musical sound recording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "musical sound recording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two-dimensional nonprojectable graphic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "two-dimensional nonprojectable graphic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Three-dimensional artifact or naturally occurring object."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three-dimensional artifact or naturally occurring object"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Kit."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "kit"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Manuscript notated music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "manuscript notated music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mixed material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "mixed material"
+        "@value": "1-3-0"
       }
     ]
   },
@@ -1905,14 +1878,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#t",
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Manuscript language material."
+        "@value": "Computer file or an electronic resource in form."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1922,13 +1895,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "t"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "manuscript language material"
+        "@value": "computer file or electronic resource"
       }
     ]
   },
@@ -1957,6 +1930,34 @@
       {
         "@language": "en",
         "@value": "projected medium"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nonmanuscript cartographic material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cartographic material"
       }
     ]
   }

--- a/006/form_of_material.jsonld
+++ b/006/form_of_material.jsonld
@@ -1,5 +1,201 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Kit."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "kit"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional artifact or naturally occurring object."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "three-dimensional artifact or naturally occurring object"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two-dimensional nonprojectable graphic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "two-dimensional nonprojectable graphic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Notated music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "notated music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Manuscript language material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript language material"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mixed material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "mixed material"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Manuscript notated music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript notated music"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#i",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -56,14 +252,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#c",
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Notated music."
+        "@value": "Musical sound recording."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -73,13 +269,41 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "c"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "notated music"
+        "@value": "musical sound recording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nonserial language material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "language material"
       }
     ]
   },
@@ -182,264 +406,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-2-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nonserial language material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "language material"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Computer file or an electronic resource in form."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "computer file or electronic resource"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nonmanuscript cartographic material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cartographic material"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Musical sound recording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "musical sound recording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two-dimensional nonprojectable graphic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "two-dimensional nonprojectable graphic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Three-dimensional artifact or naturally occurring object."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three-dimensional artifact or naturally occurring object"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Kit."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "kit"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Manuscript notated music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "manuscript notated music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mixed material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "mixed material"
+        "@value": "1-3-0"
       }
     ]
   },
@@ -472,14 +445,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#t",
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Manuscript language material."
+        "@value": "Computer file or an electronic resource in form."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -489,13 +462,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "t"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "manuscript language material"
+        "@value": "computer file or electronic resource"
       }
     ]
   },
@@ -524,6 +497,34 @@
       {
         "@language": "en",
         "@value": "projected medium"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.25z4-e963#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nonmanuscript cartographic material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.25z4-e963"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cartographic material"
       }
     ]
   }

--- a/006/form_of_material.nt
+++ b/006/form_of_material.nt
@@ -1,97 +1,97 @@
-<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript notated music."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "computer file or electronic resource"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/title> "Form of material"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.ttl> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "nonmusical sound recording"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "serial or integrating resource"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#definition> "Projected medium."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "kit"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript language material."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#definition> "Nonmanuscript cartographic material."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "three-dimensional artifact or naturally occurring object"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript cartographic material ."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "cartographic material"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/version> "1-2-0" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript notated music"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "mixed material"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript language material"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.rdf> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "projected medium"@en .
 <https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/elements/1.1/language> "en" .
 <https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/additionalType> "Dataset"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#definition> "Nonmusical sound recording."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/alternative> "MARC21 006/00 values for all materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#definition> "Musical sound recording."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.jsonld> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "notated music"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "projected medium"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "musical sound recording"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#definition> "Computer file or an electronic resource in form."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#definition> "Notated music."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional artifact or naturally occurring object."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#definition> "Nonserial language material."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#definition> "Two-dimensional nonprojectable graphic."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "two-dimensional nonprojectable graphic"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/description> "Identifies a form of material."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#definition> "Mixed material."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
-<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#definition> "Control aspects of a non-printed continuing resource."@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
-<https://doi.org/10.6069/uwlswd.25z4-e963> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
 <https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#definition> "Kit."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.rdf> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "notated music"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/title> "Form of material"@en .
 <https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "serial or integrating resource"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript language material"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/description> "Identifies a form of material."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/alternative> "MARC21 006/00 values for all materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#definition> "Mixed material."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#definition> "Nonmusical sound recording."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "musical sound recording"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.jsonld> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#definition> "Control aspects of a non-printed continuing resource."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "two-dimensional nonprojectable graphic"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#definition> "Two-dimensional nonprojectable graphic."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#definition> "Computer file or an electronic resource in form."@en .
 <https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "language material"@en .
-<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript cartographic material"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "kit"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#definition> "Nonmanuscript cartographic material."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "mixed material"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.ttl> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "three-dimensional artifact or naturally occurring object"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/additionalType> "Dataset"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional artifact or naturally occurring object."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript notated music."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "cartographic material"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "nonmusical sound recording"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#c> <http://www.w3.org/2004/02/skos/core#definition> "Notated music."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <https://schema.org/version> "1-3-0" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
 <https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#a> <http://www.w3.org/2004/02/skos/core#definition> "Nonserial language material."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript cartographic material ."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.25z4-e963> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#j> <http://www.w3.org/2004/02/skos/core#definition> "Musical sound recording."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#g> <http://www.w3.org/2004/02/skos/core#definition> "Projected medium."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#t> <http://www.w3.org/2004/02/skos/core#definition> "Manuscript language material."@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.25z4-e963#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "computer file or electronic resource"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript cartographic material"@en .
+<https://doi.org/10.6069/uwlswd.25z4-e963#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.25z4-e963#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript notated music"@en .

--- a/006/form_of_material.rdf
+++ b/006/form_of_material.rdf
@@ -1,25 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">three-dimensional artifact or naturally occurring object</skos:prefLabel>
-    <skos:definition xml:lang="en">Three-dimensional artifact or naturally occurring object.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:prefLabel xml:lang="en">kit</skos:prefLabel>
+    <skos:definition xml:lang="en">Kit.</skos:definition>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">manuscript notated music</skos:prefLabel>
-    <skos:definition xml:lang="en">Manuscript notated music.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">computer file or electronic resource</skos:prefLabel>
-    <skos:definition xml:lang="en">Computer file or an electronic resource in form.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:prefLabel xml:lang="en">projected medium</skos:prefLabel>
+    <skos:definition xml:lang="en">Projected medium.</skos:definition>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -45,41 +44,6 @@
     <schema:version>1-3-0</schema:version>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">nonmusical sound recording</skos:prefLabel>
-    <skos:definition xml:lang="en">Nonmusical sound recording.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">serial or integrating resource</skos:prefLabel>
-    <skos:definition xml:lang="en">Control aspects of a non-printed continuing resource.</skos:definition>
-    <skos:notation>s</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">cartographic material</skos:prefLabel>
-    <skos:definition xml:lang="en">Nonmanuscript cartographic material.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">projected medium</skos:prefLabel>
-    <skos:definition xml:lang="en">Projected medium.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#o">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">kit</skos:prefLabel>
-    <skos:definition xml:lang="en">Kit.</skos:definition>
-    <skos:notation>o</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
@@ -94,19 +58,47 @@
     <skos:definition xml:lang="en">Notated music.</skos:definition>
     <skos:notation>c</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#k">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">two-dimensional nonprojectable graphic</skos:prefLabel>
-    <skos:definition xml:lang="en">Two-dimensional nonprojectable graphic.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:prefLabel xml:lang="en">musical sound recording</skos:prefLabel>
+    <skos:definition xml:lang="en">Musical sound recording.</skos:definition>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">language material</skos:prefLabel>
-    <skos:definition xml:lang="en">Nonserial language material.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">serial or integrating resource</skos:prefLabel>
+    <skos:definition xml:lang="en">Control aspects of a non-printed continuing resource.</skos:definition>
+    <skos:notation>s</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">nonmusical sound recording</skos:prefLabel>
+    <skos:definition xml:lang="en">Nonmusical sound recording.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#m">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">computer file or electronic resource</skos:prefLabel>
+    <skos:definition xml:lang="en">Computer file or an electronic resource in form.</skos:definition>
+    <skos:notation>m</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">mixed material</skos:prefLabel>
+    <skos:definition xml:lang="en">Mixed material.</skos:definition>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">cartographic material</skos:prefLabel>
+    <skos:definition xml:lang="en">Nonmanuscript cartographic material.</skos:definition>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -115,18 +107,32 @@
     <skos:definition xml:lang="en">Manuscript cartographic material .</skos:definition>
     <skos:notation>f</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#j">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">musical sound recording</skos:prefLabel>
-    <skos:definition xml:lang="en">Musical sound recording.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:prefLabel xml:lang="en">language material</skos:prefLabel>
+    <skos:definition xml:lang="en">Nonserial language material.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#p">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
-    <skos:prefLabel xml:lang="en">mixed material</skos:prefLabel>
-    <skos:definition xml:lang="en">Mixed material.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:prefLabel xml:lang="en">two-dimensional nonprojectable graphic</skos:prefLabel>
+    <skos:definition xml:lang="en">Two-dimensional nonprojectable graphic.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">manuscript notated music</skos:prefLabel>
+    <skos:definition xml:lang="en">Manuscript notated music.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
+    <skos:prefLabel xml:lang="en">three-dimensional artifact or naturally occurring object</skos:prefLabel>
+    <skos:definition xml:lang="en">Three-dimensional artifact or naturally occurring object.</skos:definition>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/006/form_of_material.rdf
+++ b/006/form_of_material.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
@@ -47,7 +41,7 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <dct:description xml:lang="en">Identifies a form of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <schema:version>1-2-0</schema:version>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
   </rdf:Description>

--- a/006/form_of_material.rdf
+++ b/006/form_of_material.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
@@ -41,8 +47,8 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <dct:description xml:lang="en">Identifies a form of material.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
-    <schema:version>1-2-1</schema:version>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:version>1-2-0</schema:version>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i">

--- a/006/form_of_material.rdf
+++ b/006/form_of_material.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.25z4-e963"/>
@@ -47,8 +41,8 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/006/form_of_material.html"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <dct:description xml:lang="en">Identifies a form of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
-    <schema:version>1-2-0</schema:version>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:version>1-2-1</schema:version>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i">

--- a/006/form_of_material.rdf
+++ b/006/form_of_material.rdf
@@ -42,7 +42,7 @@
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <dct:description xml:lang="en">Identifies a form of material.</dct:description>
     <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
-    <schema:version>1-2-0</schema:version>
+    <schema:version>1-3-0</schema:version>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.25z4-e963#i">

--- a/006/form_of_material.ttl
+++ b/006/form_of_material.ttl
@@ -113,6 +113,6 @@
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Form of material"@en ;
     schema:additionalType "Dataset"@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-2-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-3-0" .
 

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
                         <td id="b">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c">
                         <td>
@@ -457,7 +457,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
                         <td>
@@ -512,7 +512,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
                         <td>
@@ -552,7 +552,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
                         <td>
@@ -603,7 +603,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e">
                         <td>
@@ -653,7 +653,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
                         <td>
@@ -703,7 +703,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
                         <td>
@@ -753,7 +753,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m">
                         <td>
@@ -793,7 +793,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
                         <td>
@@ -850,7 +850,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
                         <td>
@@ -900,7 +900,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
                         <td>
@@ -949,7 +949,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#r">
                         <td>
@@ -1003,7 +1003,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s">
                         <td>
@@ -1053,7 +1053,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
                         <td>
@@ -1104,7 +1104,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u">
                         <td>
@@ -1128,13 +1128,41 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;publication date and copyright date&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Date of publication/release/production/execution and a copyright or phonogram copyright date.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;questionable date&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;range of years of bulk of collection&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;date of distribution/release/issue and production/recording session when different&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
     &lt;dct:title xml:lang="en"&gt;All: type of date or publication status&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/06 values for all materials expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates type of date given. Or, for continuing resources, indicates publication status.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
@@ -1145,121 +1173,93 @@
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#r"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;reprint/reissue date and original date&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;The date of reproduction or reissue;the date of the original, if known.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;dates unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;detailed date&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;publication date and copyright date&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Date of publication/release/production/execution and a copyright or phonogram copyright date.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;range of years of bulk of collection&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;date of distribution/release/issue and production/recording session when different&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;questionable date&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;continuing resource ceased publication&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;actual date and copyright date [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;single known date/probable date&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;detailed date [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;inclusive dates of collection&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;no dates given; b.c. date involved&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;One or more dates associated with the item are Before Common Era (B.C.) dates.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;single known date/probable date&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;continuing resource status unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;detailed date [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;continuing resource currently published&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Used for an item for which an issue has been received within the last three years.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;reprint/reissue date and original date&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;The date of reproduction or reissue;the date of the original, if known.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;continuing resource ceased publication&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;multiple dates&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;dates unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;inclusive dates of collection&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;actual date and copyright date [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1274,94 +1274,94 @@
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; a skos:Concept ;
     skos:definition "One or more dates associated with the item are Before Common Era (B.C.) dates."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "no dates given; b.c. date involved"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; a skos:Concept ;
     skos:definition "Used for an item for which an issue has been received within the last three years."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "continuing resource currently published"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "actual date and copyright date [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; a skos:Concept ;
     skos:definition "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "continuing resource ceased publication"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "detailed date [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; a skos:Concept ;
     skos:definition "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "detailed date"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; a skos:Concept ;
     skos:definition "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "inclusive dates of collection"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; a skos:Concept ;
     skos:definition "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "range of years of bulk of collection"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; a skos:Concept ;
     skos:definition "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multiple dates"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "dates unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; a skos:Concept ;
     skos:definition "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "date of distribution/release/issue and production/recording session when different"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; a skos:Concept ;
     skos:definition "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "questionable date"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; a skos:Concept ;
     skos:definition "The date of reproduction or reissue;the date of the original, if known."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "reprint/reissue date and original date"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; a skos:Concept ;
     skos:definition "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "single known date/probable date"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; a skos:Concept ;
     skos:definition "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "publication date and copyright date"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; a skos:Concept ;
     skos:definition "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "continuing resource status unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; a skos:ConceptScheme ;
@@ -1384,126 +1384,126 @@
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "All: type of date or publication status"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/06 values for all materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "date of distribution/release/issue and production/recording session when different"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/title&gt; "All: type of date or publication status"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "detailed date [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "range of years of bulk of collection"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The date of reproduction or reissue;the date of the original, if known."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource status unknown"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "questionable date"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "actual date and copyright date [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple dates"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource currently published"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "publication date and copyright date"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used for an item for which an issue has been received within the last three years."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "One or more dates associated with the item are Before Common Era (B.C.) dates."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "single known date/probable date"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "range of years of bulk of collection"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dates unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource ceased publication"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "inclusive dates of collection"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no dates given; b.c. date involved"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reprint/reissue date and original date"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates type of date given. Or, for continuing resources, indicates publication status."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "detailed date"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
 &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource currently published"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The date of reproduction or reissue;the date of the original, if known."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reprint/reissue date and original date"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple dates"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "publication date and copyright date"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "inclusive dates of collection"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "date of distribution/release/issue and production/recording session when different"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "One or more dates associated with the item are Before Common Era (B.C.) dates."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource status unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used for an item for which an issue has been received within the last three years."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/title&gt; "All: type of date or publication status"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuing resource ceased publication"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "actual date and copyright date [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "detailed date [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates type of date given. Or, for continuing resources, indicates publication status."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "single known date/probable date"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "detailed date"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/06 values for all materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en .
+&lt;https://doi.org/10.6069/uwlswd.4a8z-tq62#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#c",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Used for an item for which an issue has been received within the last three years."
+        "@value": "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1513,43 +1513,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "continuing resource currently published"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The date of reproduction or reissue;the date of the original, if known."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reprint/reissue date and original date"
+        "@value": "single known date/probable date"
       }
     ]
   },
@@ -1571,7 +1541,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],
@@ -1583,14 +1552,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#d",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."
+        "@value": "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1600,14 +1569,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "continuing resource ceased publication"
+        "@value": "questionable date"
       }
     ]
   },
@@ -1629,7 +1597,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -1637,162 +1604,6 @@
       {
         "@language": "en",
         "@value": "detailed date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "inclusive dates of collection"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dates unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "One or more dates associated with the item are Before Common Era (B.C.) dates."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no dates given; b.c. date involved"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#cx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "actual date and copyright date [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "single known date/probable date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#dx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "detailed date [obsolete]"
       }
     ]
   },
@@ -1814,7 +1625,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -1822,6 +1632,246 @@
       {
         "@language": "en",
         "@value": "multiple dates"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The date of reproduction or reissue;the date of the original, if known."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reprint/reissue date and original date"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#cx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "actual date and copyright date [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource ceased publication"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource status unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "inclusive dates of collection"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "range of years of bulk of collection"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "One or more dates associated with the item are Before Common Era (B.C.) dates."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no dates given; b.c. date involved"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Used for an item for which an issue has been received within the last three years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource currently published"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dates unknown"
       }
     ]
   },
@@ -1923,25 +1973,20 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#k",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#dx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1950,72 +1995,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "k"
+        "@value": "d"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "range of years of bulk of collection"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "questionable date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "continuing resource status unknown"
+        "@value": "detailed date [obsolete]"
       }
     ]
   },
@@ -2037,7 +2023,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#c",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Used for an item for which an issue has been received within the last three years."
+        "@value": "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,43 +17,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "continuing resource currently published"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The date of reproduction or reissue;the date of the original, if known."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reprint/reissue date and original date"
+        "@value": "single known date/probable date"
       }
     ]
   },
@@ -75,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],
@@ -87,14 +56,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#d",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."
+        "@value": "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -104,14 +73,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "continuing resource ceased publication"
+        "@value": "questionable date"
       }
     ]
   },
@@ -133,7 +101,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -141,162 +108,6 @@
       {
         "@language": "en",
         "@value": "detailed date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "inclusive dates of collection"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dates unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "One or more dates associated with the item are Before Common Era (B.C.) dates."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no dates given; b.c. date involved"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#cx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "actual date and copyright date [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "single known date/probable date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#dx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "detailed date [obsolete]"
       }
     ]
   },
@@ -318,7 +129,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -326,6 +136,246 @@
       {
         "@language": "en",
         "@value": "multiple dates"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The date of reproduction or reissue;the date of the original, if known."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reprint/reissue date and original date"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#cx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "actual date and copyright date [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource ceased publication"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource status unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "inclusive dates of collection"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "range of years of bulk of collection"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "One or more dates associated with the item are Before Common Era (B.C.) dates."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no dates given; b.c. date involved"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Used for an item for which an issue has been received within the last three years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "continuing resource currently published"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dates unknown"
       }
     ]
   },
@@ -427,25 +477,20 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#k",
+    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#dx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -454,72 +499,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "k"
+        "@value": "d"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "range of years of bulk of collection"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "questionable date"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4a8z-tq62"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "continuing resource status unknown"
+        "@value": "detailed date [obsolete]"
       }
     ]
   },
@@ -541,7 +527,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt
@@ -1,99 +1,99 @@
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#definition> "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#definition> "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#definition> "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/alternative> "MARC21 008/06 values for all materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#definition> "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "date of distribution/release/issue and production/recording session when different"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/title> "All: type of date or publication status"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#prefLabel> "detailed date [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "range of years of bulk of collection"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#definition> "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#definition> "The date of reproduction or reissue;the date of the original, if known."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#definition> "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource status unknown"@en .
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "questionable date"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#prefLabel> "actual date and copyright date [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple dates"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource currently published"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#definition> "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "publication date and copyright date"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#definition> "Used for an item for which an issue has been received within the last three years."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#definition> "One or more dates associated with the item are Before Common Era (B.C.) dates."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "single known date/probable date"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#definition> "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "range of years of bulk of collection"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html> .
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "dates unknown"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource ceased publication"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "inclusive dates of collection"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#definition> "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "no dates given; b.c. date involved"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "reprint/reissue date and original date"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/description> "Indicates type of date given. Or, for continuing resources, indicates publication status."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#definition> "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "detailed date"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#definition> "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource currently published"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#definition> "The date of reproduction or reissue;the date of the original, if known."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "reprint/reissue date and original date"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple dates"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "publication date and copyright date"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#definition> "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "inclusive dates of collection"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "date of distribution/release/issue and production/recording session when different"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#definition> "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#definition> "One or more dates associated with the item are Before Common Era (B.C.) dates."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#definition> "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource status unknown"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#definition> "Used for an item for which an issue has been received within the last three years."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/title> "All: type of date or publication status"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuing resource ceased publication"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#prefLabel> "actual date and copyright date [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> <http://www.w3.org/2004/02/skos/core#prefLabel> "detailed date [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#definition> "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/description> "Indicates type of date given. Or, for continuing resources, indicates publication status."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#definition> "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "single known date/probable date"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "detailed date"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#q> <http://www.w3.org/2004/02/skos/core#definition> "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#e> <http://www.w3.org/2004/02/skos/core#definition> "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4a8z-tq62> .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62> <http://purl.org/dc/terms/alternative> "MARC21 008/06 values for all materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#k> <http://www.w3.org/2004/02/skos/core#definition> "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en .
+<https://doi.org/10.6069/uwlswd.4a8z-tq62#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">All: type of date or publication status</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/06 values for all materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates type of date given. Or, for continuing resources, indicates publication status.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld"/>
@@ -35,108 +29,108 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">reprint/reissue date and original date</skos:prefLabel>
     <skos:definition xml:lang="en">The date of reproduction or reissue;the date of the original, if known.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date</skos:prefLabel>
     <skos:definition xml:lang="en">Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">publication date and copyright date</skos:prefLabel>
     <skos:definition xml:lang="en">Date of publication/release/production/execution and a copyright or phonogram copyright date.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">range of years of bulk of collection</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">date of distribution/release/issue and production/recording session when different</skos:prefLabel>
     <skos:definition xml:lang="en">Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">questionable date</skos:prefLabel>
     <skos:definition xml:lang="en">Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource ceased publication</skos:prefLabel>
     <skos:definition xml:lang="en">New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">actual date and copyright date [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">single known date/probable date</skos:prefLabel>
     <skos:definition xml:lang="en">One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">inclusive dates of collection</skos:prefLabel>
     <skos:definition xml:lang="en">Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">no dates given; b.c. date involved</skos:prefLabel>
     <skos:definition xml:lang="en">One or more dates associated with the item are Before Common Era (B.C.) dates.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource status unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource currently published</skos:prefLabel>
     <skos:definition xml:lang="en">Used for an item for which an issue has been received within the last three years.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">multiple dates</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">dates unknown</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
@@ -1,5 +1,39 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">publication date and copyright date</skos:prefLabel>
+    <skos:definition xml:lang="en">Date of publication/release/production/execution and a copyright or phonogram copyright date.</skos:definition>
+    <skos:notation>t</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">questionable date</skos:prefLabel>
+    <skos:definition xml:lang="en">Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">range of years of bulk of collection</skos:prefLabel>
+    <skos:definition xml:lang="en">The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">date of distribution/release/issue and production/recording session when different</skos:prefLabel>
+    <skos:definition xml:lang="en">Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).</skos:definition>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,12 +58,11 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#r">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">reprint/reissue date and original date</skos:prefLabel>
-    <skos:definition xml:lang="en">The date of reproduction or reissue;the date of the original, if known.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:prefLabel xml:lang="en">dates unknown</skos:prefLabel>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -38,46 +71,12 @@
     <skos:definition xml:lang="en">Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast.</skos:definition>
     <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">publication date and copyright date</skos:prefLabel>
-    <skos:definition xml:lang="en">Date of publication/release/production/execution and a copyright or phonogram copyright date.</skos:definition>
-    <skos:notation>t</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">range of years of bulk of collection</skos:prefLabel>
-    <skos:definition xml:lang="en">The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.</skos:definition>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">date of distribution/release/issue and production/recording session when different</skos:prefLabel>
-    <skos:definition xml:lang="en">Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">questionable date</skos:prefLabel>
-    <skos:definition xml:lang="en">Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).</skos:definition>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">continuing resource ceased publication</skos:prefLabel>
-    <skos:definition xml:lang="en">New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">actual date and copyright date [obsolete]</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">no dates given; b.c. date involved</skos:prefLabel>
+    <skos:definition xml:lang="en">One or more dates associated with the item are Before Common Era (B.C.) dates.</skos:definition>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -86,32 +85,18 @@
     <skos:definition xml:lang="en">One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.</skos:definition>
     <skos:notation>s</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">detailed date [obsolete]</skos:prefLabel>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">inclusive dates of collection</skos:prefLabel>
-    <skos:definition xml:lang="en">Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">no dates given; b.c. date involved</skos:prefLabel>
-    <skos:definition xml:lang="en">One or more dates associated with the item are Before Common Era (B.C.) dates.</skos:definition>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource status unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known.</skos:definition>
     <skos:notation>u</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">detailed date [obsolete]</skos:prefLabel>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -120,6 +105,20 @@
     <skos:definition xml:lang="en">Used for an item for which an issue has been received within the last three years.</skos:definition>
     <skos:notation>c</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">reprint/reissue date and original date</skos:prefLabel>
+    <skos:definition xml:lang="en">The date of reproduction or reissue;the date of the original, if known.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">continuing resource ceased publication</skos:prefLabel>
+    <skos:definition xml:lang="en">New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
@@ -127,10 +126,17 @@
     <skos:definition xml:lang="en">The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year.</skos:definition>
     <skos:notation>m</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
-    <skos:prefLabel xml:lang="en">dates unknown</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:prefLabel xml:lang="en">inclusive dates of collection</skos:prefLabel>
+    <skos:definition xml:lang="en">Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
+    <skos:prefLabel xml:lang="en">actual date and copyright date [obsolete]</skos:prefLabel>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">All: type of date or publication status</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/06 values for all materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates type of date given. Or, for continuing resources, indicates publication status.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld"/>
@@ -29,108 +35,108 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">reprint/reissue date and original date</skos:prefLabel>
     <skos:definition xml:lang="en">The date of reproduction or reissue;the date of the original, if known.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date</skos:prefLabel>
     <skos:definition xml:lang="en">Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">publication date and copyright date</skos:prefLabel>
     <skos:definition xml:lang="en">Date of publication/release/production/execution and a copyright or phonogram copyright date.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">range of years of bulk of collection</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">date of distribution/release/issue and production/recording session when different</skos:prefLabel>
     <skos:definition xml:lang="en">Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">questionable date</skos:prefLabel>
     <skos:definition xml:lang="en">Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource ceased publication</skos:prefLabel>
     <skos:definition xml:lang="en">New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">actual date and copyright date [obsolete]</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">single known date/probable date</skos:prefLabel>
     <skos:definition xml:lang="en">One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date [obsolete]</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">inclusive dates of collection</skos:prefLabel>
     <skos:definition xml:lang="en">Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">no dates given; b.c. date involved</skos:prefLabel>
     <skos:definition xml:lang="en">One or more dates associated with the item are Before Common Era (B.C.) dates.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource status unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource currently published</skos:prefLabel>
     <skos:definition xml:lang="en">Used for an item for which an issue has been received within the last three years.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">multiple dates</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">dates unknown</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.jsonld"/>

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">All: type of date or publication status</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/06 values for all materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates type of date given. Or, for continuing resources, indicates publication status.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,108 +29,108 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">reprint/reissue date and original date</skos:prefLabel>
     <skos:definition xml:lang="en">The date of reproduction or reissue;the date of the original, if known.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date</skos:prefLabel>
     <skos:definition xml:lang="en">Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">publication date and copyright date</skos:prefLabel>
     <skos:definition xml:lang="en">Date of publication/release/production/execution and a copyright or phonogram copyright date.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">range of years of bulk of collection</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">date of distribution/release/issue and production/recording session when different</skos:prefLabel>
     <skos:definition xml:lang="en">Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965).</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">questionable date</skos:prefLabel>
     <skos:definition xml:lang="en">Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846).</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource ceased publication</skos:prefLabel>
     <skos:definition xml:lang="en">New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">actual date and copyright date [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">single known date/probable date</skos:prefLabel>
     <skos:definition xml:lang="en">One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">detailed date [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">inclusive dates of collection</skos:prefLabel>
     <skos:definition xml:lang="en">Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">no dates given; b.c. date involved</skos:prefLabel>
     <skos:definition xml:lang="en">One or more dates associated with the item are Before Common Era (B.C.) dates.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource status unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">continuing resource currently published</skos:prefLabel>
     <skos:definition xml:lang="en">Used for an item for which an issue has been received within the last three years.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">multiple dates</skos:prefLabel>
     <skos:definition xml:lang="en">The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4a8z-tq62#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4a8z-tq62"/>
     <skos:prefLabel xml:lang="en">dates unknown</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl
+++ b/008/all_type_of_date_or_publication_status/all_type_of_date_or_publication_status.ttl
@@ -6,94 +6,94 @@
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#b> a skos:Concept ;
     skos:definition "One or more dates associated with the item are Before Common Era (B.C.) dates."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "no dates given; b.c. date involved"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#c> a skos:Concept ;
     skos:definition "Used for an item for which an issue has been received within the last three years."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "continuing resource currently published"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#cx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "actual date and copyright date [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#d> a skos:Concept ;
     skos:definition "New issues of a continuing resource have ceased to be published or that a change in author or title has caused a successive entry record to be created. When a new title supersedes a previously existing one, the earlier title is considered dead and coded d in field 008/06. An item is considered to have ceased publication only when there is clear evidence that it has. Generally, a period of more than three years during which no new issue of a continuing resource has been published is considered evidence that it has ceased publication."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "continuing resource ceased publication"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#dx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "detailed date [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#e> a skos:Concept ;
     skos:definition "Detailed date which contains the month (and possibly the day) in addition to the year is present. For visual materials, this code may be used with televised material to give the date of the original broadcast."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "detailed date"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#i> a skos:Concept ;
     skos:definition "Inclusive dates applicable to a collection. If the inclusive dates are represented by a single year, that date is given in both places."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "inclusive dates of collection"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#k> a skos:Concept ;
     skos:definition "The range of years applicable to most of the material in a collection. If the bulk dates are represented by only a single year, that date is given in both places."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "range of years of bulk of collection"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#m> a skos:Concept ;
     skos:definition "The range of years of publication of a multipart item, excluding the case when both dates for a multipart item are represented by a single year."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multiple dates"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#n> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "dates unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#p> a skos:Concept ;
     skos:definition "Both a date of distribution/release/issue (008/07-10) and a date of production/recording (008/11-14) are present because there is a difference between the two dates. For computer files, code p is used when there is a difference between the date the file first became operational for analysis and processing in machine-readable form (i.e., production date) and the date the file became available to the public, usually through an established agency (i.e., distribution date). For moving images, if a work with identical content but in a different medium has a later release date than the original work, code p is used (e.g., a videorecording released in 1978 that was originally produced as a motion picture in 1965)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "date of distribution/release/issue and production/recording session when different"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#q> a skos:Concept ;
     skos:definition "Exact date for a single date item is not known but a range of years for the date can be specified (e.g., between 1824 and 1846)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "questionable date"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#r> a skos:Concept ;
     skos:definition "The date of reproduction or reissue;the date of the original, if known."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "reprint/reissue date and original date"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#s> a skos:Concept ;
     skos:definition "One known single date of distribution, publication, release, production, execution, writing, or a probable date that can be represented by four digits. The single date associated with the item may be actual, approximate, or conjectural (e.g., if the single date is uncertain). Also used for a single unpublished item such as an original or historical graphic when there is a single date associated with the execution of the item."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "single known date/probable date"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#t> a skos:Concept ;
     skos:definition "Date of publication/release/production/execution and a copyright or phonogram copyright date."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "publication date and copyright date"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62#u> a skos:Concept ;
     skos:definition "Used for continuing resources when there is no clear indication that publication of the item has ceased. A beginning date of publication; and the characters uuuu since no ending date is known."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4a8z-tq62> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "continuing resource status unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.4a8z-tq62> a skos:ConceptScheme ;
@@ -116,6 +116,6 @@
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "All: type of date or publication status"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/books_biography/books_biography.html
+++ b/008/books_biography/books_biography.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
                         <td id="a">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
                         <td>
@@ -466,7 +466,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#c">
                         <td>
@@ -515,7 +515,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#d">
                         <td>
@@ -564,7 +564,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound">
                         <td>
@@ -588,64 +588,64 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;individual biography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Biography of one individual.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
     &lt;dct:title xml:lang="en"&gt;Books: biography&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/34 values for books expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;contains biographical information&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Contains biographical information.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;no biographical material&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;No biographical or autobiographical material.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;individual biography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Biography of one individual.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;contains biographical information&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Contains biographical information.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;autobiography&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Autobiography.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;collective biography&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Biographical material about more than one individual.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -660,31 +660,31 @@
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; a skos:Concept ;
     skos:definition "Autobiography."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autobiography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; a skos:Concept ;
     skos:definition "Biography of one individual."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "individual biography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; a skos:Concept ;
     skos:definition "Biographical material about more than one individual."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "collective biography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; a skos:Concept ;
     skos:definition "Contains biographical information."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "contains biographical information"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; a skos:Concept ;
     skos:definition "No biographical or autobiographical material."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no biographical material"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; a skos:ConceptScheme ;
@@ -701,71 +701,99 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Books: biography"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "contains biographical information"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No biographical or autobiographical material."@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "individual biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for books expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biography of one individual."@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are."@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Autobiography."@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "collective biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biography of one individual."@en .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biographical material about more than one individual."@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autobiography"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biographical material about more than one individual."@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "collective biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf&gt; .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no biographical material"@en .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "individual biography"@en .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Contains biographical information."@en .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for books expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "contains biographical information"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autobiography"@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Autobiography."@en .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are."@en .
 &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
-&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.x4ce-sd21#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Biography of one individual."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "individual biography"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#a",
     "@type": [
@@ -784,7 +812,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -792,93 +819,6 @@
       {
         "@language": "en",
         "@value": "autobiography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Contains biographical information."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "contains biographical information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Biographical material about more than one individual."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "collective biography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No biographical or autobiographical material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no biographical material"
       }
     ]
   },
@@ -951,7 +891,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -980,24 +920,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#b",
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Biography of one individual."
+        "@value": "Biographical material about more than one individual."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1007,14 +948,69 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "individual biography"
+        "@value": "collective biography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Contains biographical information."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "contains biographical information"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No biographical or autobiographical material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no biographical material"
       }
     ]
   }

--- a/008/books_biography/books_biography.jsonld
+++ b/008/books_biography/books_biography.jsonld
@@ -1,5 +1,33 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Biography of one individual."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "individual biography"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -17,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -25,93 +52,6 @@
       {
         "@language": "en",
         "@value": "autobiography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Contains biographical information."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "contains biographical information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Biographical material about more than one individual."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "collective biography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No biographical or autobiographical material."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no biographical material"
       }
     ]
   },
@@ -184,7 +124,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -213,24 +153,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#b",
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Biography of one individual."
+        "@value": "Biographical material about more than one individual."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -240,14 +181,69 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "individual biography"
+        "@value": "collective biography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Contains biographical information."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "contains biographical information"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No biographical or autobiographical material."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.x4ce-sd21"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no biographical material"
       }
     ]
   }

--- a/008/books_biography/books_biography.nt
+++ b/008/books_biography/books_biography.nt
@@ -1,47 +1,47 @@
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/title> "Books: biography"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "contains biographical information"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#definition> "No biographical or autobiographical material."@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "individual biography"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for books expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#definition> "Biography of one individual."@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/description> "Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are."@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#definition> "No biographical or autobiographical material."@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.html> .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#definition> "Autobiography."@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "collective biography"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#definition> "Biography of one individual."@en .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#definition> "Biographical material about more than one individual."@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autobiography"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#definition> "Biographical material about more than one individual."@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "collective biography"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf> .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no biographical material"@en .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "individual biography"@en .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#definition> "Contains biographical information."@en .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for books expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "contains biographical information"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/title> "Books: biography"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autobiography"@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#definition> "Autobiography."@en .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/description> "Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are."@en .
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
-<https://doi.org/10.6069/uwlswd.x4ce-sd21#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.x4ce-sd21> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">individual biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography of one individual.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -13,7 +19,7 @@
     <dct:title xml:lang="en">Books: biography</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -24,7 +30,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld"/>
@@ -36,27 +42,27 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">contains biographical information</skos:prefLabel>
     <skos:definition xml:lang="en">Contains biographical information.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">no biographical material</skos:prefLabel>
     <skos:definition xml:lang="en">No biographical or autobiographical material.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">collective biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material about more than one individual.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">individual biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography of one individual.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Books: biography</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -30,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld"/>
@@ -42,27 +36,27 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">contains biographical information</skos:prefLabel>
     <skos:definition xml:lang="en">Contains biographical information.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">no biographical material</skos:prefLabel>
     <skos:definition xml:lang="en">No biographical or autobiographical material.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">collective biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material about more than one individual.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">individual biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography of one individual.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Books: biography</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether or not an item contains biographical material, and if so, what the biographical characteristics are.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -42,27 +36,27 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">contains biographical information</skos:prefLabel>
     <skos:definition xml:lang="en">Contains biographical information.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">no biographical material</skos:prefLabel>
     <skos:definition xml:lang="en">No biographical or autobiographical material.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">collective biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material about more than one individual.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -24,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.jsonld"/>

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -1,12 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
-    <skos:prefLabel xml:lang="en">individual biography</skos:prefLabel>
-    <skos:definition xml:lang="en">Biography of one individual.</skos:definition>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -31,19 +30,26 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
-    <skos:prefLabel xml:lang="en">contains biographical information</skos:prefLabel>
-    <skos:definition xml:lang="en">Contains biographical information.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
     <skos:prefLabel xml:lang="en">no biographical material</skos:prefLabel>
     <skos:definition xml:lang="en">No biographical or autobiographical material.</skos:definition>
     <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
+    <skos:prefLabel xml:lang="en">individual biography</skos:prefLabel>
+    <skos:definition xml:lang="en">Biography of one individual.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.x4ce-sd21"/>
+    <skos:prefLabel xml:lang="en">contains biographical information</skos:prefLabel>
+    <skos:definition xml:lang="en">Contains biographical information.</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.x4ce-sd21#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/books_biography/books_biography.rdf
+++ b/008/books_biography/books_biography.rdf
@@ -17,7 +17,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/books_biography/books_biography.ttl
+++ b/008/books_biography/books_biography.ttl
@@ -6,31 +6,31 @@
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#a> a skos:Concept ;
     skos:definition "Autobiography."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.x4ce-sd21> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autobiography"@en .
 
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#b> a skos:Concept ;
     skos:definition "Biography of one individual."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.x4ce-sd21> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "individual biography"@en .
 
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#c> a skos:Concept ;
     skos:definition "Biographical material about more than one individual."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.x4ce-sd21> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "collective biography"@en .
 
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#d> a skos:Concept ;
     skos:definition "Contains biographical information."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.x4ce-sd21> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "contains biographical information"@en .
 
 <https://doi.org/10.6069/uwlswd.x4ce-sd21#pound> a skos:Concept ;
     skos:definition "No biographical or autobiographical material."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.x4ce-sd21> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no biographical material"@en .
 
 <https://doi.org/10.6069/uwlswd.x4ce-sd21> a skos:ConceptScheme ;
@@ -47,12 +47,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_biography/books_biography.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Books: biography"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/books_illustrations/books_illustrations.html
+++ b/008/books_illustrations/books_illustrations.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
                         <td id="a">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
                         <td>
@@ -424,7 +424,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
                         <td>
@@ -473,7 +473,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c">
                         <td>
@@ -522,7 +522,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#d">
                         <td>
@@ -571,7 +571,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
                         <td>
@@ -620,7 +620,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
                         <td>
@@ -669,7 +669,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
                         <td>
@@ -718,7 +718,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h">
                         <td>
@@ -767,7 +767,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
                         <td>
@@ -816,7 +816,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
                         <td>
@@ -865,7 +865,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
                         <td>
@@ -914,7 +914,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
                         <td>
@@ -963,7 +963,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m">
                         <td>
@@ -1012,7 +1012,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#o">
                         <td>
@@ -1070,7 +1070,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
                         <td>
@@ -1119,7 +1119,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
                         <td>
@@ -1148,43 +1148,8 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;illustrations&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Illustrations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Types of illustrations not covered by any of the more specific concepts.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;no illustrations&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Work does not contain illustrations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;forms&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Forms.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;illuminations&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Illuminations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;samples&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Samples.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1192,30 +1157,44 @@
     &lt;dct:title xml:lang="en"&gt;Books: illustrations&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/18-21 values for books expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the presence of types of illustrations in the item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;no illustrations&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Work does not contain illustrations.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;charts&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Charts.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1223,63 +1202,84 @@
     &lt;skos:prefLabel xml:lang="en"&gt;photographs&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Photographs.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;If of minor importance, code as illustrations instead of photographs.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;plates&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Plates.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;portraits&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Portraits.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;phonodisc, phonowire, etc.&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Phonodisc, phonowire, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;genealogical tables&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Genealogical tables.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;coats of arms&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Coats of arms.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;plans&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Plans.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;maps&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Maps.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;samples&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Samples.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;forms&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Forms.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;illuminations&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Illuminations.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;portraits&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Portraits.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;phonodisc, phonowire, etc.&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Phonodisc, phonowire, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;plates&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Plates.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;facsimiles&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Facsimiles.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;plans&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Plans.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1294,99 +1294,99 @@
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; a skos:Concept ;
     skos:definition "Illustrations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "illustrations"@en ;
     skos:scopeNote "Types of illustrations not covered by any of the more specific concepts."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; a skos:Concept ;
     skos:definition "Maps."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "maps"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; a skos:Concept ;
     skos:definition "Portraits."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "portraits"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; a skos:Concept ;
     skos:definition "Charts."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "charts"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; a skos:Concept ;
     skos:definition "Plans."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "plans"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; a skos:Concept ;
     skos:definition "Plates."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "plates"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; a skos:Concept ;
     skos:definition "Music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; a skos:Concept ;
     skos:definition "Facsimiles."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "facsimiles"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; a skos:Concept ;
     skos:definition "Coats of arms."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "coats of arms"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; a skos:Concept ;
     skos:definition "Genealogical tables."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "genealogical tables"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; a skos:Concept ;
     skos:definition "Forms."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "forms"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; a skos:Concept ;
     skos:definition "Samples."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "samples"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; a skos:Concept ;
     skos:definition "Phonodisc, phonowire, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "phonodisc, phonowire, etc."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; a skos:Concept ;
     skos:definition "Photographs."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "photographs"@en ;
     skos:scopeNote "If of minor importance, code as illustrations instead of photographs."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; a skos:Concept ;
     skos:definition "Illuminations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "illuminations"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; a skos:Concept ;
     skos:definition "Work does not contain illustrations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no illustrations"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; a skos:ConceptScheme ;
@@ -1403,137 +1403,137 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Books: illustrations"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Illustrations."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no illustrations"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Charts."@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "illustrations"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "If of minor importance, code as illustrations instead of photographs."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Genealogical tables."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Photographs."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work does not contain illustrations."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Plates."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-21 values for books expressed using RDF"@en .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Forms."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Portraits."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "music"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Illustrations."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the presence of types of illustrations in the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "forms"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Phonodisc, phonowire, etc."@en .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "illuminations"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Portraits."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Illuminations."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Photographs."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "facsimiles"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Types of illustrations not covered by any of the more specific concepts."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Forms."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work does not contain illustrations."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Facsimiles."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Plates."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "charts"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Coats of arms."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "plates"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Plans."@en .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "phonodisc, phonowire, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "illustrations"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Genealogical tables."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "illuminations"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Plans."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "music"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "plans"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "maps"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "If of minor importance, code as illustrations instead of photographs."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Maps."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "portraits"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: illustrations"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "charts"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Facsimiles."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Music."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "facsimiles"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photographs"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "coats of arms"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Coats of arms."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Phonodisc, phonowire, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the presence of types of illustrations in the item."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Samples."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "plates"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Illuminations."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-21 values for books expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: illustrations"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "maps"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "genealogical tables"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Types of illustrations not covered by any of the more specific concepts."@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Maps."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Music."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
 &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "samples"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Charts."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no illustrations"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Samples."@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "plans"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "coats of arms"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photographs"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "portraits"@en .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; .
+&lt;https://doi.org/10.6069/uwlswd.gq3z-mv97&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#i",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Coats of arms."
+        "@value": "Genealogical tables."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1543,14 +1543,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "coats of arms"
+        "@value": "genealogical tables"
       }
     ]
   },
@@ -1572,7 +1571,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -1584,14 +1582,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#f",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#p",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Plates."
+        "@value": "Illuminations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1601,26 +1599,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "p"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "plates"
+        "@value": "illuminations"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#a",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#g",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Illustrations."
+        "@value": "Music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1630,20 +1627,187 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "g"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "illustrations"
+        "@value": "music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Phonodisc, phonowire, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "phonodisc, phonowire, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Charts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "charts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Photographs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photographs"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Types of illustrations not covered by any of the more specific concepts."
+        "@value": "If of minor importance, code as illustrations instead of photographs."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Facsimiles."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "facsimiles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Work does not contain illustrations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no illustrations"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Plans."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "plans"
       }
     ]
   },
@@ -1665,7 +1829,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -1673,6 +1836,118 @@
       {
         "@language": "en",
         "@value": "maps"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Portraits."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "portraits"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Coats of arms."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "coats of arms"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Plates."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "plates"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Samples."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "samples"
       }
     ]
   },
@@ -1745,7 +2020,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1774,24 +2049,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#c",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Portraits."
+        "@value": "Illustrations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1801,310 +2077,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "portraits"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Illuminations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "illuminations"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Photographs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photographs"
+        "@value": "illustrations"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "If of minor importance, code as illustrations instead of photographs."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Facsimiles."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "facsimiles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Phonodisc, phonowire, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "phonodisc, phonowire, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Plans."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "plans"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Samples."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "samples"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Genealogical tables."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "genealogical tables"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Charts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "charts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work does not contain illustrations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no illustrations"
+        "@value": "Types of illustrations not covered by any of the more specific concepts."
       }
     ]
   }

--- a/008/books_illustrations/books_illustrations.jsonld
+++ b/008/books_illustrations/books_illustrations.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#i",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Coats of arms."
+        "@value": "Genealogical tables."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,14 +17,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "coats of arms"
+        "@value": "genealogical tables"
       }
     ]
   },
@@ -46,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -58,14 +56,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#f",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#p",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Plates."
+        "@value": "Illuminations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -75,26 +73,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "p"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "plates"
+        "@value": "illuminations"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#a",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#g",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Illustrations."
+        "@value": "Music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -104,20 +101,187 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "g"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "illustrations"
+        "@value": "music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Phonodisc, phonowire, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "phonodisc, phonowire, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Charts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "charts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Photographs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photographs"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Types of illustrations not covered by any of the more specific concepts."
+        "@value": "If of minor importance, code as illustrations instead of photographs."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Facsimiles."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "facsimiles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Work does not contain illustrations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no illustrations"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Plans."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "plans"
       }
     ]
   },
@@ -139,7 +303,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -147,6 +310,118 @@
       {
         "@language": "en",
         "@value": "maps"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Portraits."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "portraits"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Coats of arms."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "coats of arms"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Plates."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "plates"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Samples."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "samples"
       }
     ]
   },
@@ -219,7 +494,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -248,24 +523,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#c",
+    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Portraits."
+        "@value": "Illustrations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -275,310 +551,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "portraits"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Illuminations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "illuminations"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Photographs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photographs"
+        "@value": "illustrations"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "If of minor importance, code as illustrations instead of photographs."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Facsimiles."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "facsimiles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Phonodisc, phonowire, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "phonodisc, phonowire, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Plans."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "plans"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Samples."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "samples"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Genealogical tables."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "genealogical tables"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Charts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "charts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work does not contain illustrations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.gq3z-mv97"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no illustrations"
+        "@value": "Types of illustrations not covered by any of the more specific concepts."
       }
     ]
   }

--- a/008/books_illustrations/books_illustrations.nt
+++ b/008/books_illustrations/books_illustrations.nt
@@ -1,104 +1,104 @@
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#definition> "Illustrations."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no illustrations"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#definition> "Charts."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "illustrations"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#scopeNote> "If of minor importance, code as illustrations instead of photographs."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#definition> "Genealogical tables."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.html> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#definition> "Photographs."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#definition> "Work does not contain illustrations."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#definition> "Plates."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/alternative> "MARC21 008/18-21 values for books expressed using RDF"@en .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.rdf> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#definition> "Forms."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#definition> "Portraits."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "music"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#definition> "Illustrations."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/description> "Indicates the presence of types of illustrations in the item."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "forms"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#definition> "Phonodisc, phonowire, etc."@en .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "illuminations"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#definition> "Portraits."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#definition> "Illuminations."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#definition> "Photographs."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "facsimiles"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Types of illustrations not covered by any of the more specific concepts."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#definition> "Forms."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#definition> "Work does not contain illustrations."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#definition> "Facsimiles."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#definition> "Plates."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "charts"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#definition> "Coats of arms."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "plates"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#definition> "Plans."@en .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "phonodisc, phonowire, etc."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "illustrations"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#definition> "Genealogical tables."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "illuminations"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#definition> "Plans."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "music"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "plans"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "maps"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#scopeNote> "If of minor importance, code as illustrations instead of photographs."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#definition> "Maps."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "portraits"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/title> "Books: illustrations"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "charts"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#definition> "Facsimiles."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#definition> "Music."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "facsimiles"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "photographs"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "coats of arms"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#definition> "Coats of arms."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#definition> "Phonodisc, phonowire, etc."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/description> "Indicates the presence of types of illustrations in the item."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#definition> "Samples."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "plates"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#definition> "Illuminations."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/alternative> "MARC21 008/18-21 values for books expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/title> "Books: illustrations"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "maps"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "genealogical tables"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Types of illustrations not covered by any of the more specific concepts."@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#b> <http://www.w3.org/2004/02/skos/core#definition> "Maps."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#g> <http://www.w3.org/2004/02/skos/core#definition> "Music."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "samples"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#d> <http://www.w3.org/2004/02/skos/core#definition> "Charts."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no illustrations"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#l> <http://www.w3.org/2004/02/skos/core#definition> "Samples."@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "plans"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "coats of arms"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "photographs"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "portraits"@en .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.gq3z-mv97> .
+<https://doi.org/10.6069/uwlswd.gq3z-mv97> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld> .

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -60,7 +60,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld"/>

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Illustrations.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
     <skos:scopeNote xml:lang="en">Types of illustrations not covered by any of the more specific concepts.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
@@ -13,35 +19,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">no illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Work does not contain illustrations.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">Music.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">forms</skos:prefLabel>
     <skos:definition xml:lang="en">Forms.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illuminations</skos:prefLabel>
     <skos:definition xml:lang="en">Illuminations.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
     <skos:definition xml:lang="en">Samples.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -49,7 +55,7 @@
     <dct:title xml:lang="en">Books: illustrations</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the presence of types of illustrations in the item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -60,7 +66,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld"/>
@@ -72,7 +78,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">charts</skos:prefLabel>
     <skos:definition xml:lang="en">Charts.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -80,62 +86,62 @@
     <skos:prefLabel xml:lang="en">photographs</skos:prefLabel>
     <skos:definition xml:lang="en">Photographs.</skos:definition>
     <skos:scopeNote xml:lang="en">If of minor importance, code as illustrations instead of photographs.</skos:scopeNote>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plates</skos:prefLabel>
     <skos:definition xml:lang="en">Plates.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">portraits</skos:prefLabel>
     <skos:definition xml:lang="en">Portraits.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">phonodisc, phonowire, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Phonodisc, phonowire, etc.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">genealogical tables</skos:prefLabel>
     <skos:definition xml:lang="en">Genealogical tables.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">coats of arms</skos:prefLabel>
     <skos:definition xml:lang="en">Coats of arms.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plans</skos:prefLabel>
     <skos:definition xml:lang="en">Plans.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">maps</skos:prefLabel>
     <skos:definition xml:lang="en">Maps.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">facsimiles</skos:prefLabel>
     <skos:definition xml:lang="en">Facsimiles.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Illustrations.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
     <skos:scopeNote xml:lang="en">Types of illustrations not covered by any of the more specific concepts.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
@@ -19,35 +13,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">no illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Work does not contain illustrations.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">Music.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">forms</skos:prefLabel>
     <skos:definition xml:lang="en">Forms.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illuminations</skos:prefLabel>
     <skos:definition xml:lang="en">Illuminations.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
     <skos:definition xml:lang="en">Samples.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -55,7 +49,7 @@
     <dct:title xml:lang="en">Books: illustrations</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the presence of types of illustrations in the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -66,7 +60,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.jsonld"/>
@@ -78,7 +72,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">charts</skos:prefLabel>
     <skos:definition xml:lang="en">Charts.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -86,62 +80,62 @@
     <skos:prefLabel xml:lang="en">photographs</skos:prefLabel>
     <skos:definition xml:lang="en">Photographs.</skos:definition>
     <skos:scopeNote xml:lang="en">If of minor importance, code as illustrations instead of photographs.</skos:scopeNote>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plates</skos:prefLabel>
     <skos:definition xml:lang="en">Plates.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">portraits</skos:prefLabel>
     <skos:definition xml:lang="en">Portraits.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">phonodisc, phonowire, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Phonodisc, phonowire, etc.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">genealogical tables</skos:prefLabel>
     <skos:definition xml:lang="en">Genealogical tables.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">coats of arms</skos:prefLabel>
     <skos:definition xml:lang="en">Coats of arms.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plans</skos:prefLabel>
     <skos:definition xml:lang="en">Plans.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">maps</skos:prefLabel>
     <skos:definition xml:lang="en">Maps.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">facsimiles</skos:prefLabel>
     <skos:definition xml:lang="en">Facsimiles.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -53,7 +53,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
@@ -7,41 +13,6 @@
     <skos:definition xml:lang="en">Illustrations.</skos:definition>
     <skos:notation>a</skos:notation>
     <skos:scopeNote xml:lang="en">Types of illustrations not covered by any of the more specific concepts.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">no illustrations</skos:prefLabel>
-    <skos:definition xml:lang="en">Work does not contain illustrations.</skos:definition>
-    <skos:notation>#</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">music</skos:prefLabel>
-    <skos:definition xml:lang="en">Music.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">forms</skos:prefLabel>
-    <skos:definition xml:lang="en">Forms.</skos:definition>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">illuminations</skos:prefLabel>
-    <skos:definition xml:lang="en">Illuminations.</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
-    <skos:definition xml:lang="en">Samples.</skos:definition>
-    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -67,6 +38,20 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">no illustrations</skos:prefLabel>
+    <skos:definition xml:lang="en">Work does not contain illustrations.</skos:definition>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">music</skos:prefLabel>
+    <skos:definition xml:lang="en">Music.</skos:definition>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
@@ -82,12 +67,47 @@
     <skos:scopeNote xml:lang="en">If of minor importance, code as illustrations instead of photographs.</skos:scopeNote>
     <skos:notation>o</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">plates</skos:prefLabel>
-    <skos:definition xml:lang="en">Plates.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">genealogical tables</skos:prefLabel>
+    <skos:definition xml:lang="en">Genealogical tables.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">coats of arms</skos:prefLabel>
+    <skos:definition xml:lang="en">Coats of arms.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">maps</skos:prefLabel>
+    <skos:definition xml:lang="en">Maps.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
+    <skos:definition xml:lang="en">Samples.</skos:definition>
+    <skos:notation>l</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">forms</skos:prefLabel>
+    <skos:definition xml:lang="en">Forms.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">illuminations</skos:prefLabel>
+    <skos:definition xml:lang="en">Illuminations.</skos:definition>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -103,33 +123,12 @@
     <skos:definition xml:lang="en">Phonodisc, phonowire, etc.</skos:definition>
     <skos:notation>m</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">genealogical tables</skos:prefLabel>
-    <skos:definition xml:lang="en">Genealogical tables.</skos:definition>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">coats of arms</skos:prefLabel>
-    <skos:definition xml:lang="en">Coats of arms.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">plans</skos:prefLabel>
-    <skos:definition xml:lang="en">Plans.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
-    <skos:prefLabel xml:lang="en">maps</skos:prefLabel>
-    <skos:definition xml:lang="en">Maps.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:prefLabel xml:lang="en">plates</skos:prefLabel>
+    <skos:definition xml:lang="en">Plates.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -137,5 +136,12 @@
     <skos:prefLabel xml:lang="en">facsimiles</skos:prefLabel>
     <skos:definition xml:lang="en">Facsimiles.</skos:definition>
     <skos:notation>h</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
+    <skos:prefLabel xml:lang="en">plans</skos:prefLabel>
+    <skos:definition xml:lang="en">Plans.</skos:definition>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_illustrations/books_illustrations.rdf
+++ b/008/books_illustrations/books_illustrations.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Illustrations.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
     <skos:scopeNote xml:lang="en">Types of illustrations not covered by any of the more specific concepts.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#pound">
@@ -19,35 +13,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">no illustrations</skos:prefLabel>
     <skos:definition xml:lang="en">Work does not contain illustrations.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">Music.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">forms</skos:prefLabel>
     <skos:definition xml:lang="en">Forms.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">illuminations</skos:prefLabel>
     <skos:definition xml:lang="en">Illuminations.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">samples</skos:prefLabel>
     <skos:definition xml:lang="en">Samples.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -55,7 +49,7 @@
     <dct:title xml:lang="en">Books: illustrations</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the presence of types of illustrations in the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -78,7 +72,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">charts</skos:prefLabel>
     <skos:definition xml:lang="en">Charts.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -86,62 +80,62 @@
     <skos:prefLabel xml:lang="en">photographs</skos:prefLabel>
     <skos:definition xml:lang="en">Photographs.</skos:definition>
     <skos:scopeNote xml:lang="en">If of minor importance, code as illustrations instead of photographs.</skos:scopeNote>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plates</skos:prefLabel>
     <skos:definition xml:lang="en">Plates.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">portraits</skos:prefLabel>
     <skos:definition xml:lang="en">Portraits.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">phonodisc, phonowire, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Phonodisc, phonowire, etc.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">genealogical tables</skos:prefLabel>
     <skos:definition xml:lang="en">Genealogical tables.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">coats of arms</skos:prefLabel>
     <skos:definition xml:lang="en">Coats of arms.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">plans</skos:prefLabel>
     <skos:definition xml:lang="en">Plans.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">maps</skos:prefLabel>
     <skos:definition xml:lang="en">Maps.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.gq3z-mv97#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.gq3z-mv97"/>
     <skos:prefLabel xml:lang="en">facsimiles</skos:prefLabel>
     <skos:definition xml:lang="en">Facsimiles.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_illustrations/books_illustrations.ttl
+++ b/008/books_illustrations/books_illustrations.ttl
@@ -6,99 +6,99 @@
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#a> a skos:Concept ;
     skos:definition "Illustrations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "illustrations"@en ;
     skos:scopeNote "Types of illustrations not covered by any of the more specific concepts."@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#b> a skos:Concept ;
     skos:definition "Maps."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "maps"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#c> a skos:Concept ;
     skos:definition "Portraits."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "portraits"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#d> a skos:Concept ;
     skos:definition "Charts."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "charts"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#e> a skos:Concept ;
     skos:definition "Plans."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "plans"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#f> a skos:Concept ;
     skos:definition "Plates."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "plates"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#g> a skos:Concept ;
     skos:definition "Music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "music"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#h> a skos:Concept ;
     skos:definition "Facsimiles."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "facsimiles"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#i> a skos:Concept ;
     skos:definition "Coats of arms."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "coats of arms"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#j> a skos:Concept ;
     skos:definition "Genealogical tables."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "genealogical tables"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#k> a skos:Concept ;
     skos:definition "Forms."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "forms"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#l> a skos:Concept ;
     skos:definition "Samples."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "samples"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#m> a skos:Concept ;
     skos:definition "Phonodisc, phonowire, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "phonodisc, phonowire, etc."@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#o> a skos:Concept ;
     skos:definition "Photographs."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "photographs"@en ;
     skos:scopeNote "If of minor importance, code as illustrations instead of photographs."@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#p> a skos:Concept ;
     skos:definition "Illuminations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "illuminations"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97#pound> a skos:Concept ;
     skos:definition "Work does not contain illustrations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.gq3z-mv97> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no illustrations"@en .
 
 <https://doi.org/10.6069/uwlswd.gq3z-mv97> a skos:ConceptScheme ;
@@ -115,12 +115,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_illustrations/books_illustrations.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Books: illustrations"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/books_literary_form/books_literary_form.html
+++ b/008/books_literary_form/books_literary_form.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
                         <td id="0">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">0</td>
+                        <td property="skos:notation">0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
                         <td>
@@ -415,7 +415,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">1</td>
+                        <td property="skos:notation">1</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#1">
                         <td>
@@ -455,7 +455,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#c">
                         <td>
@@ -504,7 +504,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
                         <td>
@@ -553,7 +553,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#e">
                         <td>
@@ -602,7 +602,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
                         <td>
@@ -651,7 +651,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#h">
                         <td>
@@ -700,7 +700,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
                         <td>
@@ -749,7 +749,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
                         <td>
@@ -798,7 +798,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
                         <td>
@@ -847,7 +847,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
                         <td>
@@ -896,7 +896,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
                         <td>
@@ -945,7 +945,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.f447-ax91#u">
                         <td>
@@ -969,54 +969,40 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;novels&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Novels.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;short stories&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Short story or collection of short stories.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;speeches&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Speech or collection of speeches.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;letters&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Single letter or collection of correspondence.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#1"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;fiction (not further specified)&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Work of fiction but no further identification of the literary form is desired.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;1&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;mixed forms&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Represents a variety of literary forms (e.g., poetry and short stories).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;poetry&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Poem or collection of poems.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;1&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;essays&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Essays.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not fiction (not further specified)&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Not a work of fiction and no further identification of the literary form is desired.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;0&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;dramas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Dramas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1024,64 +1010,78 @@
     &lt;dct:title xml:lang="en"&gt;Books: literary form&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for books expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the literary form of an item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;comic strips&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;letters&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Single letter or collection of correspondence.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Literary form of the item is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;dramas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Dramas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;short stories&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Short story or collection of short stories.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;speeches&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Speech or collection of speeches.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;comic strips&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#h"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;humor, satires, etc.&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Humorous work, satire, or of similar literary form.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not fiction (not further specified)&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Not a work of fiction and no further identification of the literary form is desired.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;0&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;poetry&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Poem or collection of poems.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;novels&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Novels.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;mixed forms&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Represents a variety of literary forms (e.g., poetry and short stories).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1096,78 +1096,78 @@
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; a skos:Concept ;
     skos:definition "Not a work of fiction and no further identification of the literary form is desired."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "0"@en ;
+    skos:notation "0" ;
     skos:prefLabel "not fiction (not further specified)"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; a skos:Concept ;
     skos:definition "Work of fiction but no further identification of the literary form is desired."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "1"@en ;
+    skos:notation "1" ;
     skos:prefLabel "fiction (not further specified)"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "comic strips"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; a skos:Concept ;
     skos:definition "Dramas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "dramas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; a skos:Concept ;
     skos:definition "Essays."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "essays"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; a skos:Concept ;
     skos:definition "Novels."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "novels"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; a skos:Concept ;
     skos:definition "Humorous work, satire, or of similar literary form."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "humor, satires, etc."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; a skos:Concept ;
     skos:definition "Single letter or collection of correspondence."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "letters"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; a skos:Concept ;
     skos:definition "Short story or collection of short stories."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "short stories"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; a skos:Concept ;
     skos:definition "Represents a variety of literary forms (e.g., poetry and short stories)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "mixed forms"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; a skos:Concept ;
     skos:definition "Poem or collection of poems."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "poetry"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; a skos:Concept ;
     skos:definition "Speech or collection of speeches."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "speeches"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; a skos:Concept ;
     skos:definition "Literary form of the item is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; a skos:ConceptScheme ;
@@ -1184,119 +1184,119 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Books: literary form"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Short story or collection of short stories."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "letters"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "1" .
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for books expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "letters"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: literary form"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dramas"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Essays."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Represents a variety of literary forms (e.g., poetry and short stories)."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "novels"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Novels."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "essays"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comic strips"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "1"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "speeches"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Single letter or collection of correspondence."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "humor, satires, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Speech or collection of speeches."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Literary form of the item is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the literary form of an item."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work of fiction but no further identification of the literary form is desired."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not fiction (not further specified)"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dramas."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mixed forms"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "short stories"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "0"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fiction (not further specified)"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Humorous work, satire, or of similar literary form."@en .
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not a work of fiction and no further identification of the literary form is desired."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Essays."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dramas."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work of fiction but no further identification of the literary form is desired."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for books expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: literary form"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "speeches"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not fiction (not further specified)"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Poem or collection of poems."@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "poetry"@en .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Humorous work, satire, or of similar literary form."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Literary form of the item is unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comic strips"@en .
 &lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "short stories"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dramas"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "humor, satires, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Novels."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Represents a variety of literary forms (e.g., poetry and short stories)."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#0&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "0" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mixed forms"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fiction (not further specified)"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#1&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "poetry"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Speech or collection of speeches."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the literary form of an item."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Short story or collection of short stories."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Poem or collection of poems."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Single letter or collection of correspondence."@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "novels"@en .
+&lt;https://doi.org/10.6069/uwlswd.f447-ax91&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#j",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Short story or collection of short stories."
+        "@value": "Novels."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1306,26 +1306,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "short stories"
+        "@value": "novels"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#m",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#1",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Represents a variety of literary forms (e.g., poetry and short stories)."
+        "@value": "Work of fiction but no further identification of the literary form is desired."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1335,14 +1334,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "m"
+        "@value": "1"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "mixed forms"
+        "@value": "fiction (not further specified)"
       }
     ]
   },
@@ -1415,7 +1413,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1444,122 +1442,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dramas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dramas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comic strips"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Literary form of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#1",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work of fiction but no further identification of the literary form is desired."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fiction (not further specified)"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1581,7 +1470,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -1610,7 +1498,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "s"
       }
     ],
@@ -1622,14 +1509,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#0",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Not a work of fiction and no further identification of the literary form is desired."
+        "@value": "Literary form of the item is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1639,26 +1526,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "0"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not fiction (not further specified)"
+        "@value": "unknown"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#f",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Novels."
+        "@value": "Short story or collection of short stories."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1668,26 +1554,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "novels"
+        "@value": "short stories"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#i",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comic strips"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Single letter or collection of correspondence."
+        "@value": "Represents a variety of literary forms (e.g., poetry and short stories)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1697,14 +1604,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "letters"
+        "@value": "mixed forms"
       }
     ]
   },
@@ -1726,7 +1632,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -1734,6 +1639,34 @@
       {
         "@language": "en",
         "@value": "humor, satires, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#0",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not a work of fiction and no further identification of the literary form is desired."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "0"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not fiction (not further specified)"
       }
     ]
   },
@@ -1755,7 +1688,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],
@@ -1763,6 +1695,62 @@
       {
         "@language": "en",
         "@value": "poetry"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dramas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dramas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Single letter or collection of correspondence."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "letters"
       }
     ]
   }

--- a/008/books_literary_form/books_literary_form.jsonld
+++ b/008/books_literary_form/books_literary_form.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#j",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Short story or collection of short stories."
+        "@value": "Novels."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,26 +17,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "short stories"
+        "@value": "novels"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#m",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#1",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Represents a variety of literary forms (e.g., poetry and short stories)."
+        "@value": "Work of fiction but no further identification of the literary form is desired."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -46,14 +45,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "m"
+        "@value": "1"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "mixed forms"
+        "@value": "fiction (not further specified)"
       }
     ]
   },
@@ -126,7 +124,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -155,122 +153,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dramas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dramas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comic strips"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Literary form of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#1",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work of fiction but no further identification of the literary form is desired."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "1"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fiction (not further specified)"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -292,7 +181,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -321,7 +209,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "s"
       }
     ],
@@ -333,14 +220,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#0",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Not a work of fiction and no further identification of the literary form is desired."
+        "@value": "Literary form of the item is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -350,26 +237,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "0"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not fiction (not further specified)"
+        "@value": "unknown"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#f",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Novels."
+        "@value": "Short story or collection of short stories."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -379,26 +265,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "novels"
+        "@value": "short stories"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#i",
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comic strips"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Single letter or collection of correspondence."
+        "@value": "Represents a variety of literary forms (e.g., poetry and short stories)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -408,14 +315,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "letters"
+        "@value": "mixed forms"
       }
     ]
   },
@@ -437,7 +343,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -445,6 +350,34 @@
       {
         "@language": "en",
         "@value": "humor, satires, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#0",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not a work of fiction and no further identification of the literary form is desired."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "0"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not fiction (not further specified)"
       }
     ]
   },
@@ -466,7 +399,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],
@@ -474,6 +406,62 @@
       {
         "@language": "en",
         "@value": "poetry"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dramas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dramas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.f447-ax91#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Single letter or collection of correspondence."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.f447-ax91"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "letters"
       }
     ]
   }

--- a/008/books_literary_form/books_literary_form.nt
+++ b/008/books_literary_form/books_literary_form.nt
@@ -1,86 +1,86 @@
-<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#definition> "Short story or collection of short stories."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.rdf> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for books expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
 <https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "letters"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/title> "Books: literary form"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dramas"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#definition> "Essays."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#definition> "Represents a variety of literary forms (e.g., poetry and short stories)."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "novels"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#definition> "Novels."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#notation> "1" .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.rdf> .
 <https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "essays"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "comic strips"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#notation> "1"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "speeches"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#definition> "Single letter or collection of correspondence."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "humor, satires, etc."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#definition> "Speech or collection of speeches."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#definition> "Literary form of the item is unknown."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/description> "Indicates the literary form of an item."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#definition> "Work of fiction but no further identification of the literary form is desired."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#prefLabel> "not fiction (not further specified)"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#definition> "Dramas."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "mixed forms"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "short stories"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#notation> "0"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#prefLabel> "fiction (not further specified)"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#definition> "Humorous work, satire, or of similar literary form."@en .
 <https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#definition> "Not a work of fiction and no further identification of the literary form is desired."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#definition> "Essays."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#definition> "Dramas."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#definition> "Work of fiction but no further identification of the literary form is desired."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for books expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/title> "Books: literary form"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "speeches"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#prefLabel> "not fiction (not further specified)"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
 <https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#definition> "Poem or collection of poems."@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "poetry"@en .
-<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#definition> "Humorous work, satire, or of similar literary form."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#definition> "Literary form of the item is unknown."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "comic strips"@en .
 <https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "short stories"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dramas"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "humor, satires, etc."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#definition> "Novels."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#definition> "Represents a variety of literary forms (e.g., poetry and short stories)."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#0> <http://www.w3.org/2004/02/skos/core#notation> "0" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "mixed forms"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/2004/02/skos/core#prefLabel> "fiction (not further specified)"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "poetry"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#s> <http://www.w3.org/2004/02/skos/core#definition> "Speech or collection of speeches."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/description> "Indicates the literary form of an item."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#j> <http://www.w3.org/2004/02/skos/core#definition> "Short story or collection of short stories."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#p> <http://www.w3.org/2004/02/skos/core#definition> "Poem or collection of poems."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.f447-ax91> .
+<https://doi.org/10.6069/uwlswd.f447-ax91#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.f447-ax91#i> <http://www.w3.org/2004/02/skos/core#definition> "Single letter or collection of correspondence."@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "novels"@en .
+<https://doi.org/10.6069/uwlswd.f447-ax91> <http://purl.org/dc/terms/issued> "2023" .

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -1,59 +1,53 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">novels</skos:prefLabel>
     <skos:definition xml:lang="en">Novels.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">short stories</skos:prefLabel>
     <skos:definition xml:lang="en">Short story or collection of short stories.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Speech or collection of speeches.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Work of fiction but no further identification of the literary form is desired.</skos:definition>
-    <skos:notation xml:lang="en">1</skos:notation>
+    <skos:notation>1</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">mixed forms</skos:prefLabel>
     <skos:definition xml:lang="en">Represents a variety of literary forms (e.g., poetry and short stories).</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poem or collection of poems.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -61,7 +55,7 @@
     <dct:title xml:lang="en">Books: literary form</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the literary form of an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -83,41 +77,41 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">comic strips</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">letters</skos:prefLabel>
     <skos:definition xml:lang="en">Single letter or collection of correspondence.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Literary form of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">dramas</skos:prefLabel>
     <skos:definition xml:lang="en">Dramas.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">humor, satires, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Humorous work, satire, or of similar literary form.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">not fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Not a work of fiction and no further identification of the literary form is desired.</skos:definition>
-    <skos:notation xml:lang="en">0</skos:notation>
+    <skos:notation>0</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -1,25 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">novels</skos:prefLabel>
-    <skos:definition xml:lang="en">Novels.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">short stories</skos:prefLabel>
-    <skos:definition xml:lang="en">Short story or collection of short stories.</skos:definition>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">speeches</skos:prefLabel>
-    <skos:definition xml:lang="en">Speech or collection of speeches.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:prefLabel xml:lang="en">letters</skos:prefLabel>
+    <skos:definition xml:lang="en">Single letter or collection of correspondence.</skos:definition>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -28,26 +20,26 @@
     <skos:definition xml:lang="en">Work of fiction but no further identification of the literary form is desired.</skos:definition>
     <skos:notation>1</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">mixed forms</skos:prefLabel>
-    <skos:definition xml:lang="en">Represents a variety of literary forms (e.g., poetry and short stories).</skos:definition>
-    <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
-    <skos:definition xml:lang="en">Poem or collection of poems.</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
     <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">not fiction (not further specified)</skos:prefLabel>
+    <skos:definition xml:lang="en">Not a work of fiction and no further identification of the literary form is desired.</skos:definition>
+    <skos:notation>0</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">dramas</skos:prefLabel>
+    <skos:definition xml:lang="en">Dramas.</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -73,19 +65,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">comic strips</skos:prefLabel>
-    <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">letters</skos:prefLabel>
-    <skos:definition xml:lang="en">Single letter or collection of correspondence.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
@@ -93,12 +72,25 @@
     <skos:definition xml:lang="en">Literary form of the item is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">dramas</skos:prefLabel>
-    <skos:definition xml:lang="en">Dramas.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:prefLabel xml:lang="en">short stories</skos:prefLabel>
+    <skos:definition xml:lang="en">Short story or collection of short stories.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">speeches</skos:prefLabel>
+    <skos:definition xml:lang="en">Speech or collection of speeches.</skos:definition>
+    <skos:notation>s</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">comic strips</skos:prefLabel>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -107,11 +99,25 @@
     <skos:definition xml:lang="en">Humorous work, satire, or of similar literary form.</skos:definition>
     <skos:notation>h</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
-    <skos:prefLabel xml:lang="en">not fiction (not further specified)</skos:prefLabel>
-    <skos:definition xml:lang="en">Not a work of fiction and no further identification of the literary form is desired.</skos:definition>
-    <skos:notation>0</skos:notation>
+    <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
+    <skos:definition xml:lang="en">Poem or collection of poems.</skos:definition>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">novels</skos:prefLabel>
+    <skos:definition xml:lang="en">Novels.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
+    <skos:prefLabel xml:lang="en">mixed forms</skos:prefLabel>
+    <skos:definition xml:lang="en">Represents a variety of literary forms (e.g., poetry and short stories).</skos:definition>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -1,59 +1,53 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">novels</skos:prefLabel>
     <skos:definition xml:lang="en">Novels.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">short stories</skos:prefLabel>
     <skos:definition xml:lang="en">Short story or collection of short stories.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Speech or collection of speeches.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Work of fiction but no further identification of the literary form is desired.</skos:definition>
-    <skos:notation xml:lang="en">1</skos:notation>
+    <skos:notation>1</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">mixed forms</skos:prefLabel>
     <skos:definition xml:lang="en">Represents a variety of literary forms (e.g., poetry and short stories).</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poem or collection of poems.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -61,7 +55,7 @@
     <dct:title xml:lang="en">Books: literary form</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the literary form of an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -72,7 +66,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld"/>
@@ -83,41 +77,41 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">comic strips</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">letters</skos:prefLabel>
     <skos:definition xml:lang="en">Single letter or collection of correspondence.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Literary form of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">dramas</skos:prefLabel>
     <skos:definition xml:lang="en">Dramas.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">humor, satires, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Humorous work, satire, or of similar literary form.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">not fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Not a work of fiction and no further identification of the literary form is desired.</skos:definition>
-    <skos:notation xml:lang="en">0</skos:notation>
+    <skos:notation>0</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -59,7 +59,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -1,53 +1,59 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">novels</skos:prefLabel>
     <skos:definition xml:lang="en">Novels.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">short stories</skos:prefLabel>
     <skos:definition xml:lang="en">Short story or collection of short stories.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Speech or collection of speeches.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Work of fiction but no further identification of the literary form is desired.</skos:definition>
-    <skos:notation>1</skos:notation>
+    <skos:notation xml:lang="en">1</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">mixed forms</skos:prefLabel>
     <skos:definition xml:lang="en">Represents a variety of literary forms (e.g., poetry and short stories).</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poem or collection of poems.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -55,7 +61,7 @@
     <dct:title xml:lang="en">Books: literary form</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the literary form of an item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -66,7 +72,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld"/>
@@ -77,41 +83,41 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">comic strips</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">letters</skos:prefLabel>
     <skos:definition xml:lang="en">Single letter or collection of correspondence.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Literary form of the item is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">dramas</skos:prefLabel>
     <skos:definition xml:lang="en">Dramas.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">humor, satires, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Humorous work, satire, or of similar literary form.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.f447-ax91#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.f447-ax91"/>
     <skos:prefLabel xml:lang="en">not fiction (not further specified)</skos:prefLabel>
     <skos:definition xml:lang="en">Not a work of fiction and no further identification of the literary form is desired.</skos:definition>
-    <skos:notation>0</skos:notation>
+    <skos:notation xml:lang="en">0</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_literary_form/books_literary_form.rdf
+++ b/008/books_literary_form/books_literary_form.rdf
@@ -66,7 +66,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.jsonld"/>

--- a/008/books_literary_form/books_literary_form.ttl
+++ b/008/books_literary_form/books_literary_form.ttl
@@ -6,78 +6,78 @@
 <https://doi.org/10.6069/uwlswd.f447-ax91#0> a skos:Concept ;
     skos:definition "Not a work of fiction and no further identification of the literary form is desired."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "0"@en ;
+    skos:notation "0" ;
     skos:prefLabel "not fiction (not further specified)"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#1> a skos:Concept ;
     skos:definition "Work of fiction but no further identification of the literary form is desired."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "1"@en ;
+    skos:notation "1" ;
     skos:prefLabel "fiction (not further specified)"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#c> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "comic strips"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#d> a skos:Concept ;
     skos:definition "Dramas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "dramas"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#e> a skos:Concept ;
     skos:definition "Essays."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "essays"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#f> a skos:Concept ;
     skos:definition "Novels."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "novels"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#h> a skos:Concept ;
     skos:definition "Humorous work, satire, or of similar literary form."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "humor, satires, etc."@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#i> a skos:Concept ;
     skos:definition "Single letter or collection of correspondence."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "letters"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#j> a skos:Concept ;
     skos:definition "Short story or collection of short stories."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "short stories"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#m> a skos:Concept ;
     skos:definition "Represents a variety of literary forms (e.g., poetry and short stories)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "mixed forms"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#p> a skos:Concept ;
     skos:definition "Poem or collection of poems."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "poetry"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#s> a skos:Concept ;
     skos:definition "Speech or collection of speeches."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "speeches"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91#u> a skos:Concept ;
     skos:definition "Literary form of the item is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.f447-ax91> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.f447-ax91> a skos:ConceptScheme ;
@@ -94,12 +94,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_literary_form/books_literary_form.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Books: literary form"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/books_nature_of_contents/books_nature_of_contents.html
+++ b/008/books_nature_of_contents/books_nature_of_contents.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-0" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -73,10 +73,10 @@
         "encodingFormat" : "text/html" 
         } 
     </script>
-        <link rel="alternate" type="application/n-triples" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt">
-        <link rel="alternate" type="application/rdf+xml" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">
-        <link rel="alternate" type="text/turtle" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl">
-        <link rel="alternate" type="application/ld+json" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld">
+        <link rel="alternate" type="application/n-triples" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt">
+        <link rel="alternate" type="application/rdf+xml" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">
+        <link rel="alternate" type="text/turtle" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl">
+        <link rel="alternate" type="application/ld+json" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld">
     </head>
     <body about="https://doi.org/10.6069/uwlswd.633m-h220">
         <script type="text/javascript" src="https://uwlib-cams.github.io/webviews/js/uwlswd.js"></script>
@@ -211,8 +211,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>
                         </td>
-                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">
-                            <a href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf</a>
+                        <td property="dct:hasFormat" resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">
+                            <a href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf">https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.633m-h220">
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.633m-h220">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.633m-h220">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-0</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.633m-h220#2">
                         <td id="2">
@@ -2017,7 +2017,7 @@
             </table>
         </div>
         <div id="rdfxml" class="tabcontent">
-            <a class="download" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf" download="" target="_blank" rel="noopener noreferrer">Download RDF/XML</a>
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf" download="" target="_blank" rel="noopener noreferrer">Download RDF/XML</a>
             <pre>&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;rdf:RDF
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -2026,13 +2026,92 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#k"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;directories&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Directory or register of persons or corporate bodies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for monographic biographical dictionaries.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a discography or discographies, or other bibliography of recorded sound.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the discography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#3"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;discographies [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;3&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#v"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a filmography or other bibliography of moving images.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the filmography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;reviews&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;no specified nature of contents&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;No specified nature of contents.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Contains substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;abstracts/summaries&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Abstracts or summaries of other publications.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication includes an abstract or summary of its own content.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a collection of statistical data on a subject.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#t"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical reports&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#5"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;5&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2042,18 +2121,28 @@
     &lt;skos:notation&gt;c&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#g"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Contains substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;encyclopedias&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Encyclopedia or an encyclopedic treatment of a specific topic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#3"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;discographies [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;3&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;directories&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Directory or register of persons or corporate bodies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for monographic biographical dictionaries.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;All or part of the item is a bibliography or bibliographies.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2075,66 +2164,23 @@
     &lt;dct:title xml:lang="en"&gt;Books: nature of contents&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/24-27 values for books expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether a significant part of the item is or contains certain types of material.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a discography or discographies, or other bibliography of recorded sound.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the discography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;no specified nature of contents&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;No specified nature of contents.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#t"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical reports&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Handbooks.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;surveys of literature in a subject area&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Composed entirely of authored surveys that summarize what has been published about a subject.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Usually contains a list of references either in the body of the work or as a bibliography.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#xx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical reports [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;x&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#2"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2144,58 +2190,6 @@
     &lt;skos:scopeNote xml:lang="en"&gt;Includes preprints and postprints.&lt;/skos:scopeNote&gt;
     &lt;skos:notation&gt;2&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;encyclopedias&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Encyclopedia or an encyclopedic treatment of a specific topic.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;dictionaries&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Dictionaries.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;reviews&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legislation&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;All or part of the item is a bibliography or bibliographies.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;programmed texts&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Programmed texts.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a filmography or other bibliography of moving images.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the filmography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#y"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
@@ -2203,78 +2197,6 @@
     &lt;skos:definition xml:lang="en"&gt;Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;y&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for annual reports, which are administrative overviews of an organization.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#4"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmographies [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;4&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#v"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a collection of statistical data on a subject.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#w"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Also used when an item includes texts of digests of such decisions.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#6"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;6&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#5"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;5&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;abstracts/summaries&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Abstracts or summaries of other publications.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication includes an abstract or summary of its own content.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#j"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;patent document&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#hx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;handbooks [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2284,11 +2206,89 @@
     &lt;skos:notation&gt;i&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication contains an index to its own content.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;dictionaries&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Dictionaries.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;surveys of literature in a subject area&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Composed entirely of authored surveys that summarize what has been published about a subject.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Usually contains a list of references either in the body of the work or as a bibliography.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Handbooks.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legislation&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#xx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical reports [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;x&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#hx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;handbooks [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#4"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmographies [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;4&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#w"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Also used when an item includes texts of digests of such decisions.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#j"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;patent document&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;programmed texts&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Programmed texts.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#6"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;6&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
         </div>
         <div id="ttl" class="tabcontent">
-            <a class="download" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl" download="" target="_blank" rel="noopener noreferrer">Download Turtle</a>
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl" download="" target="_blank" rel="noopener noreferrer">Download Turtle</a>
             <pre>@prefix dc: &lt;http://purl.org/dc/elements/1.1/&gt; .
 @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
 @prefix schema: &lt;https://schema.org/&gt; .
@@ -2510,215 +2510,215 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Books: nature of contents"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
-            <a class="download" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for monographic biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal articles"@en .
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
+            <pre>&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Handbooks."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes preprints and postprints."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "All or part of the item is a bibliography or bibliographies."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no specified nature of contents"@en .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a filmography or other bibliography of moving images."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24-27 values for books expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified nature of contents."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts/summaries"@en .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Texts of decisions of courts or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "3" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards/specifications"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a collection of statistical data on a subject."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication includes an abstract or summary of its own content."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no specified nature of contents"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Programmed texts."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether a significant part of the item is or contains certain types of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "4" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "2" .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "encyclopedias"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "patent document"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts/summaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "All or part of the item is a bibliography or bibliographies."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes preprints and postprints."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Contains substantive articles on legal topics, such as those published in law school reviews."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication includes an abstract or summary of its own content."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for monographic biographical dictionaries."@en .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether a significant part of the item is or contains certain types of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Handbooks."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified nature of contents."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "3" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when an item includes texts of digests of such decisions."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Composed entirely of authored surveys that summarize what has been published about a subject."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#3&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "patent document"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24-27 values for books expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Texts of decisions of courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "4" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: nature of contents"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Programmed texts."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication contains an index to its own content."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Usually contains a list of references either in the body of the work or as a bibliography."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "offprints"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a collection of statistical data on a subject."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "2" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal articles"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards/specifications"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks [obsolete]"@en .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "programmed texts"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication contains an index to its own content."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#4&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/title&gt; "Books: nature of contents"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Composed entirely of authored surveys that summarize what has been published about a subject."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "offprints"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when an item includes texts of digests of such decisions."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#2&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;https://schema.org/version&gt; "1-0-0" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Usually contains a list of references either in the body of the work or as a bibliography."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
 &lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Contains substantive articles on legal topics, such as those published in law school reviews."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.633m-h220&gt; .
-&lt;https://doi.org/10.6069/uwlswd.633m-h220#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.633m-h220#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
-            <a class="download" href="https://uwlib-cams.github.iouwlswd//uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
+            <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
     "@id": "https://doi.org/10.6069/uwlswd.633m-h220#q",
@@ -2755,14 +2755,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#2",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#z",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."
+        "@value": "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2772,115 +2772,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "2"
+        "@value": "z"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "offprints"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes preprints and postprints."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when an item includes texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication contains an index to its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "encyclopedias"
+        "@value": "treaties"
       }
     ]
   },
@@ -2903,34 +2801,6 @@
       {
         "@language": "en",
         "@value": "technical reports [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes"
       }
     ]
   },
@@ -2969,236 +2839,6 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "treaties"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Composed entirely of authored surveys that summarize what has been published about a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Usually contains a list of references either in the body of the work or as a bibliography."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#3",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Contains substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Programmed texts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "programmed texts"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.633m-h220#r",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -3229,220 +2869,6 @@
       {
         "@language": "en",
         "@value": "Not used for monographic biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Handbooks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#6",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comics or graphic novels"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "All or part of the item is a bibliography or bibliographies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts/summaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication includes an abstract or summary of its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
       }
     ]
   },
@@ -3515,7 +2941,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -3544,46 +2970,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#4",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#l",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3593,26 +2998,20 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "l"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "legislation"
+        "@value": "theses"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#y",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#hx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -3621,81 +3020,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "y"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards/specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dictionaries."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dictionaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."
+        "@value": "handbooks [obsolete]"
       }
     ]
   },
@@ -3734,6 +3065,56 @@
     ]
   },
   {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#4",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.633m-h220#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -3762,7 +3143,283 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#hx",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when an item includes texts of digests of such decisions."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "encyclopedias"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards/specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Composed entirely of authored surveys that summarize what has been published about a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Usually contains a list of references either in the body of the work or as a bibliography."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "offprints"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes preprints and postprints."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Handbooks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#3",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -3773,13 +3430,357 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "h"
+        "@value": "3"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "handbooks [obsolete]"
+        "@value": "discographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Programmed texts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts/summaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication includes an abstract or summary of its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a collection of statistical data on a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "statistics"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for works about statistical methodology."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dictionaries."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dictionaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication contains an index to its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Contains substantive articles on legal topics, such as those published in law school reviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legislation"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "All or part of the item is a bibliography or bibliographies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
       }
     ]
   }

--- a/008/books_nature_of_contents/books_nature_of_contents.jsonld
+++ b/008/books_nature_of_contents/books_nature_of_contents.jsonld
@@ -34,14 +34,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#2",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#z",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."
+        "@value": "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -51,115 +51,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "2"
+        "@value": "z"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "offprints"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes preprints and postprints."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when an item includes texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication contains an index to its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "encyclopedias"
+        "@value": "treaties"
       }
     ]
   },
@@ -182,34 +80,6 @@
       {
         "@language": "en",
         "@value": "technical reports [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes"
       }
     ]
   },
@@ -248,236 +118,6 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "treaties"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Composed entirely of authored surveys that summarize what has been published about a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Usually contains a list of references either in the body of the work or as a bibliography."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#3",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Contains substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Programmed texts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "programmed texts"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.633m-h220#r",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -508,220 +148,6 @@
       {
         "@language": "en",
         "@value": "Not used for monographic biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Handbooks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#6",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comics or graphic novels"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "All or part of the item is a bibliography or bibliographies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts/summaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication includes an abstract or summary of its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
       }
     ]
   },
@@ -794,7 +220,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -823,46 +249,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#4",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#l",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#m",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -872,26 +277,20 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "l"
+        "@value": "m"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "legislation"
+        "@value": "theses"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#y",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#hx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -900,81 +299,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "y"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards/specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dictionaries."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dictionaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."
+        "@value": "handbooks [obsolete]"
       }
     ]
   },
@@ -1013,6 +344,56 @@
     ]
   },
   {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#4",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.633m-h220#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -1041,7 +422,283 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#hx",
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when an item includes texts of digests of such decisions."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "encyclopedias"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards/specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Composed entirely of authored surveys that summarize what has been published about a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Usually contains a list of references either in the body of the work or as a bibliography."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "offprints"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes preprints and postprints."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Handbooks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#3",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -1052,13 +709,357 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "h"
+        "@value": "3"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "handbooks [obsolete]"
+        "@value": "discographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Programmed texts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts/summaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication includes an abstract or summary of its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a collection of statistical data on a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "statistics"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for works about statistical methodology."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dictionaries."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dictionaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication contains an index to its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Contains substantive articles on legal topics, such as those published in law school reviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legislation"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.633m-h220#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "All or part of the item is a bibliography or bibliographies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.633m-h220"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
       }
     ]
   }

--- a/008/books_nature_of_contents/books_nature_of_contents.nt
+++ b/008/books_nature_of_contents/books_nature_of_contents.nt
@@ -1,192 +1,192 @@
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for monographic biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal articles"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
-<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
 <https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl> .
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#definition> "Handbooks."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf> .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
-<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes preprints and postprints."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#definition> "All or part of the item is a bibliography or bibliographies."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no specified nature of contents"@en .
 <https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a filmography or other bibliography of moving images."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#definition> "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#notation> "y" .
-<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
-<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/alternative> "MARC21 008/24-27 values for books expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified nature of contents."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts/summaries"@en .
 <https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html> .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#definition> "Texts of decisions of courts or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#notation> "3" .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
-<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards/specifications"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
-<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a collection of statistical data on a subject."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication includes an abstract or summary of its own content."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no specified nature of contents"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#definition> "Programmed texts."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
-<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
-<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#definition> "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/description> "Indicates whether a significant part of the item is or contains certain types of material."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#notation> "x" .
+<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#notation> "5" .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
 <https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#notation> "4" .
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
-<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
-<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
-<https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#definition> "Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#notation> "2" .
 <https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "encyclopedias"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
-<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "patent document"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts/summaries"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#definition> "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#definition> "All or part of the item is a bibliography or bibliographies."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#definition> "Either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#definition> "Treaty or accord negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes preprints and postprints."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#definition> "Contains substantive articles on legal topics, such as those published in law school reviews."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication includes an abstract or summary of its own content."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for monographic biographical dictionaries."@en .
 <https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#definition> "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/description> "Indicates whether a significant part of the item is or contains certain types of material."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#definition> "Handbooks."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#definition> "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#notation> "x" .
+<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified nature of contents."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#notation> "3" .
+<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when an item includes texts of digests of such decisions."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#definition> "Composed entirely of authored surveys that summarize what has been published about a subject."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#3> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "patent document"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/alternative> "MARC21 008/24-27 values for books expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#definition> "Texts of decisions of courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#notation> "4" .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#definition> "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/title> "Books: nature of contents"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#definition> "Programmed texts."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#definition> "Dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication contains an index to its own content."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Usually contains a list of references either in the body of the work or as a bibliography."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
+<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#prefLabel> "offprints"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html> .
+<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld> .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a collection of statistical data on a subject."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/2004/02/skos/core#definition> "Detailed description of an invention or discovery of a new and useful process, machine, manufacture, composition of matter, or improvements thereof."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#definition> "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#notation> "6" .
+<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#notation> "2" .
+<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#t> <http://www.w3.org/2004/02/skos/core#definition> "Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/2004/02/skos/core#notation> "y" .
+<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal articles"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards/specifications"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
+<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks [obsolete]"@en .
 <https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "programmed texts"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication contains an index to its own content."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#notation> "5" .
-<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
-<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.633m-h220#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#4> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
-<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/title> "Books: nature of contents"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#definition> "Composed entirely of authored surveys that summarize what has been published about a subject."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#prefLabel> "offprints"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when an item includes texts of digests of such decisions."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#2> <http://www.w3.org/2004/02/skos/core#definition> "Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <https://schema.org/version> "1-0-0" .
-<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Usually contains a list of references either in the body of the work or as a bibliography."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/2004/02/skos/core#definition> "Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
 <https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld> .
-<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#d> <http://www.w3.org/2004/02/skos/core#definition> "Dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#definition> "Contains substantive articles on legal topics, such as those published in law school reviews."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
-<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
-<https://doi.org/10.6069/uwlswd.633m-h220#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
-<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#definition> "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.633m-h220#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
-<https://doi.org/10.6069/uwlswd.633m-h220#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#6> <http://www.w3.org/2004/02/skos/core#notation> "6" .
-<https://doi.org/10.6069/uwlswd.633m-h220#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
-<https://doi.org/10.6069/uwlswd.633m-h220#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
-<https://doi.org/10.6069/uwlswd.633m-h220#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.633m-h220> .
-<https://doi.org/10.6069/uwlswd.633m-h220#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.633m-h220#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.633m-h220#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
@@ -49,7 +55,7 @@
     <dct:title xml:lang="en">Books: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-27 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -60,7 +66,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld"/>

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -53,7 +53,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -60,7 +60,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld"/>

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
@@ -55,7 +49,7 @@
     <dct:title xml:lang="en">Books: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-27 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -66,7 +60,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.jsonld"/>

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
@@ -55,7 +49,7 @@
     <dct:title xml:lang="en">Books: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-27 values for books expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>

--- a/008/books_nature_of_contents/books_nature_of_contents.rdf
+++ b/008/books_nature_of_contents/books_nature_of_contents.rdf
@@ -1,12 +1,97 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
-    <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
-    <skos:notation>r</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for monographic biographical dictionaries.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a discography or discographies, or other bibliography of recorded sound.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the discography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#3">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">discographies [obsolete]</skos:prefLabel>
+    <skos:notation>3</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#v">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
+    <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
+    <skos:notation>v</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a filmography or other bibliography of moving images.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the filmography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
+    <skos:definition xml:lang="en">Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">no specified nature of contents</skos:prefLabel>
+    <skos:definition xml:lang="en">No specified nature of contents.</skos:definition>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#g">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
+    <skos:definition xml:lang="en">Contains substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#m">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
+    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
+    <skos:notation>m</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">abstracts/summaries</skos:prefLabel>
+    <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
+    <skos:notation>a</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used when a publication includes an abstract or summary of its own content.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a collection of statistical data on a subject.</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#t">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
+    <skos:definition xml:lang="en">Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
+    <skos:notation>t</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#5">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
+    <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
+    <skos:notation>5</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -16,18 +101,28 @@
     <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#g">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
-    <skos:definition xml:lang="en">Contains substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:prefLabel xml:lang="en">encyclopedias</skos:prefLabel>
+    <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#3">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">discographies [obsolete]</skos:prefLabel>
-    <skos:notation>3</skos:notation>
+    <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
+    <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
+    <skos:notation>r</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for monographic biographical dictionaries.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
+    <skos:definition xml:lang="en">All or part of the item is a bibliography or bibliographies.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.</skos:scopeNote>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -67,49 +162,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a discography or discographies, or other bibliography of recorded sound.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the discography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">no specified nature of contents</skos:prefLabel>
-    <skos:definition xml:lang="en">No specified nature of contents.</skos:definition>
-    <skos:notation>#</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#t">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
-    <skos:definition xml:lang="en">Work that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation>t</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:definition xml:lang="en">Handbooks.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
-    <skos:definition xml:lang="en">Composed entirely of authored surveys that summarize what has been published about a subject.</skos:definition>
-    <skos:notation>n</skos:notation>
-    <skos:scopeNote xml:lang="en">Usually contains a list of references either in the body of the work or as a bibliography.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#xx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">technical reports [obsolete]</skos:prefLabel>
-    <skos:notation>x</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#2">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
@@ -117,58 +169,6 @@
     <skos:definition xml:lang="en">Publication that originally was published as an article in a monograph or a serial and that is also issued separately and independently.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes preprints and postprints.</skos:scopeNote>
     <skos:notation>2</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">encyclopedias</skos:prefLabel>
-    <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">dictionaries</skos:prefLabel>
-    <skos:definition xml:lang="en">Dictionaries.</skos:definition>
-    <skos:notation>d</skos:notation>
-    <skos:scopeNote xml:lang="en">Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#o">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
-    <skos:definition xml:lang="en">Devoted entirely to critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation>o</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">legislation</skos:prefLabel>
-    <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
-    <skos:notation>l</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:definition xml:lang="en">All or part of the item is a bibliography or bibliographies.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.</skos:scopeNote>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
-    <skos:definition xml:lang="en">Programmed texts.</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a filmography or other bibliography of moving images.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the filmography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
-    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -178,26 +178,61 @@
     <skos:notation>y</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
+    <skos:definition xml:lang="en">Index to bibliographical material other than itself.</skos:definition>
+    <skos:notation>i</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used when a publication contains an index to its own content.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">dictionaries</skos:prefLabel>
+    <skos:definition xml:lang="en">Dictionaries.</skos:definition>
+    <skos:notation>d</skos:notation>
+    <skos:scopeNote xml:lang="en">Used for a glossary or a gazetteer. Not used for concordances or monographic biographical dictionaries.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#n">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
+    <skos:definition xml:lang="en">Composed entirely of authored surveys that summarize what has been published about a subject.</skos:definition>
+    <skos:notation>n</skos:notation>
+    <skos:scopeNote xml:lang="en">Usually contains a list of references either in the body of the work or as a bibliography.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
+    <skos:definition xml:lang="en">Handbooks.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">legislation</skos:prefLabel>
+    <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
+    <skos:notation>l</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#xx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">technical reports [obsolete]</skos:prefLabel>
+    <skos:notation>x</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#hx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
+    <skos:prefLabel xml:lang="en">handbooks [obsolete]</skos:prefLabel>
+    <skos:notation>h</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#4">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
     <skos:prefLabel xml:lang="en">filmographies [obsolete]</skos:prefLabel>
     <skos:notation>4</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#v">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
-    <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation>v</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a collection of statistical data on a subject.</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -207,35 +242,6 @@
     <skos:notation>w</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when an item includes texts of digests of such decisions.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#6">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
-    <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
-    <skos:notation>6</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#5">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
-    <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
-    <skos:notation>5</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
-    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">abstracts/summaries</skos:prefLabel>
-    <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
-    <skos:notation>a</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used when a publication includes an abstract or summary of its own content.</skos:scopeNote>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
@@ -244,18 +250,18 @@
     <skos:notation>j</skos:notation>
     <skos:scopeNote xml:lang="en">A patent document may be one of several kinds of documents: a patent or similar document (e.g., inventor's certificate), a patent application (domestic, foreign, priority application, etc.), or a continuation/division of one of the above.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#hx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">handbooks [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
+    <skos:definition xml:lang="en">Programmed texts.</skos:definition>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#i">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.633m-h220#6">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.633m-h220"/>
-    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
-    <skos:definition xml:lang="en">Index to bibliographical material other than itself.</skos:definition>
-    <skos:notation>i</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used when a publication contains an index to its own content.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
+    <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
+    <skos:notation>6</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/books_nature_of_contents/books_nature_of_contents.ttl
+++ b/008/books_nature_of_contents/books_nature_of_contents.ttl
@@ -219,12 +219,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/books_nature_of_contents/books_nature_of_contents.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Books: nature of contents"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/computer_form_of_item/computer_form_of_item.html
+++ b/008/computer_form_of_item/computer_form_of_item.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23#o">
                         <td id="o">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23#o">
                         <td>
@@ -406,7 +406,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound">
                         <td>
@@ -456,7 +456,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
                         <td>
@@ -480,31 +480,24 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
     &lt;dct:title xml:lang="en"&gt;Computer: form of item&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/23 values for computer files expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Specifies the form of material for the computer file.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld"/&gt;
@@ -516,13 +509,20 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown or not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -537,18 +537,18 @@
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "unknown or not specified"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; a skos:ConceptScheme ;
@@ -565,69 +565,69 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Computer: form of item"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/title&gt; "Computer: form of item"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material for the computer file."@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for computer files expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material for the computer file."@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown or not specified"@en .
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
 &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/title&gt; "Computer: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for computer files expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.3d5s-zx23#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#o",
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -637,37 +637,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "o"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown or not specified"
+        "@value": "direct electronic"
       }
     ]
   },
@@ -740,7 +716,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -769,24 +745,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#q",
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+        "@value": "Accessed by means of hardware and software connections to a communications network."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -796,14 +795,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "q"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "direct electronic"
+        "@value": "online"
       }
     ]
   }

--- a/008/computer_form_of_item/computer_form_of_item.jsonld
+++ b/008/computer_form_of_item/computer_form_of_item.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#o",
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,37 +17,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "o"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown or not specified"
+        "@value": "direct electronic"
       }
     ]
   },
@@ -120,7 +96,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -149,24 +125,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#q",
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.3d5s-zx23#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+        "@value": "Accessed by means of hardware and software connections to a communications network."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -176,14 +175,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "q"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "direct electronic"
+        "@value": "online"
       }
     ]
   }

--- a/008/computer_form_of_item/computer_form_of_item.nt
+++ b/008/computer_form_of_item/computer_form_of_item.nt
@@ -1,36 +1,36 @@
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/title> "Computer: form of item"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/description> "Specifies the form of material for the computer file."@en .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for computer files expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/description> "Specifies the form of material for the computer file."@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown or not specified"@en .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.rdf> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl> .
-<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/title> "Computer: form of item"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.3d5s-zx23> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for computer files expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.3d5s-zx23#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Computer: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material for the computer file.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -30,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld"/>
@@ -42,12 +36,12 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -24,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld"/>

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Computer: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material for the computer file.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -42,12 +36,12 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -1,12 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -37,6 +36,13 @@
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
     <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -17,7 +17,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/computer_form_of_item/computer_form_of_item.rdf
+++ b/008/computer_form_of_item/computer_form_of_item.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -13,7 +19,7 @@
     <dct:title xml:lang="en">Computer: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material for the computer file.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -24,7 +30,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.jsonld"/>
@@ -36,12 +42,12 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.3d5s-zx23#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.3d5s-zx23"/>
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_form_of_item/computer_form_of_item.ttl
+++ b/008/computer_form_of_item/computer_form_of_item.ttl
@@ -6,18 +6,18 @@
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#o> a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.3d5s-zx23> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#pound> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.3d5s-zx23> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "unknown or not specified"@en .
 
 <https://doi.org/10.6069/uwlswd.3d5s-zx23#q> a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.3d5s-zx23> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 <https://doi.org/10.6069/uwlswd.3d5s-zx23> a skos:ConceptScheme ;
@@ -34,12 +34,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_form_of_item/computer_form_of_item.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Computer: form of item"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.html
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a">
                         <td id="a">
@@ -369,7 +369,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a">
                         <td>
@@ -420,7 +420,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
                         <td>
@@ -480,7 +480,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c">
                         <td>
@@ -540,7 +540,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d">
                         <td>
@@ -601,7 +601,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e">
                         <td>
@@ -662,7 +662,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
                         <td>
@@ -712,7 +712,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
                         <td>
@@ -770,7 +770,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
                         <td>
@@ -821,7 +821,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
                         <td>
@@ -870,7 +870,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
                         <td>
@@ -933,7 +933,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#m">
                         <td>
@@ -982,7 +982,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
                         <td>
@@ -1033,7 +1033,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
                         <td>
@@ -1057,104 +1057,118 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;online system or service&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Supports system-based user interaction.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;interactive multimedia&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
     &lt;dct:title xml:lang="en"&gt;Computer: type of computer file&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/26 values for computer files expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the type of computer file described in the bibliographic record.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;numeric data&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for recreational or educational use. Generally games consist of text and software.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for a videogame.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bibliographic data&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Data with bibliographic citations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Type of file is unknown.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;sound&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Data encoding sounds producible by the computer.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;online system or service&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Supports system-based user interaction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;computer program&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for game, font.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;font&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Information for a computer to produce fonts.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended for recreational or educational use. Generally games consist of text and software.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for a videogame.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bibliographic data&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Data with bibliographic citations.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;numeric data&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;representational&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Does not include a document in image format.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;computer program&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for game, font.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;document&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#m"&gt;
@@ -1162,21 +1176,7 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;combination&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Combination of two or more types of files.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;interactive multimedia&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Type of file is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1191,85 +1191,85 @@
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; a skos:Concept ;
     skos:definition "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "numeric data"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; a skos:Concept ;
     skos:definition "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "computer program"@en ;
     skos:scopeNote "Not used for game, font."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; a skos:Concept ;
     skos:definition "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "representational"@en ;
     skos:scopeNote "Does not include a document in image format."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; a skos:Concept ;
     skos:definition "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "document"@en ;
     skos:scopeNote "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; a skos:Concept ;
     skos:definition "Data with bibliographic citations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "bibliographic data"@en ;
     skos:scopeNote "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; a skos:Concept ;
     skos:definition "Information for a computer to produce fonts."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "font"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; a skos:Concept ;
     skos:definition "Intended for recreational or educational use. Generally games consist of text and software."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "game"@en ;
     skos:scopeNote "Used for a videogame."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; a skos:Concept ;
     skos:definition "Data encoding sounds producible by the computer."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "sound"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; a skos:Concept ;
     skos:definition "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "interactive multimedia"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; a skos:Concept ;
     skos:definition "Supports system-based user interaction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "online system or service"@en ;
     skos:scopeNote "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; a skos:Concept ;
     skos:definition "Combination of two or more types of files."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "combination"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; a skos:Concept ;
     skos:definition "Type of file is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; a skos:Concept ;
     skos:definition "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; a skos:ConceptScheme ;
@@ -1286,117 +1286,331 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Computer: type of computer file"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Data with bibliographic citations."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sound"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "font"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "representational"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "numeric data"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "combination"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "computer program"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of computer file described in the bibliographic record."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Information for a computer to produce fonts."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "document"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "interactive multimedia"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for recreational or educational use. Generally games consist of text and software."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Data encoding sounds producible by the computer."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "font"@en .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Combination of two or more types of files."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for recreational or educational use. Generally games consist of text and software."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for game, font."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl&gt; .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Combination of two or more types of files."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sound"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of computer file described in the bibliographic record."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online system or service"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "interactive multimedia"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "representational"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "numeric data"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "computer program"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "combination"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Does not include a document in image format."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Information for a computer to produce fonts."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/26 values for computer files expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Data with bibliographic citations."@en .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/title&gt; "Computer: type of computer file"@en .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographic data"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Does not include a document in image format."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for game, font."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Supports system-based user interaction."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online system or service"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of file is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Data encoding sounds producible by the computer."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of file is unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Supports system-based user interaction."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/26 values for computer files expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#e&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "document"@en .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; .
 &lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a videogame."@en .
-&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.mkjn-bp10#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Supports system-based user interaction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online system or service"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Information for a computer to produce fonts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "font"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Combination of two or more types of files."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "combination"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "numeric data"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Data with bibliographic citations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographic data"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for recreational or educational use. Generally games consist of text and software."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for a videogame."
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10",
     "@type": [
@@ -1466,7 +1680,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1495,41 +1709,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of file is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1551,7 +1737,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -1569,14 +1754,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#j",
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Supports system-based user interaction."
+        "@value": "Type of file is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1586,200 +1771,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online system or service"
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "computer program"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Information for a computer to produce fonts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "font"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Intended for recreational or educational use. Generally games consist of text and software."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "game"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for a videogame."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "numeric data"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Data encoding sounds producible by the computer."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sound"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Combination of two or more types of files."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "combination"
+        "@value": "Not used for game, font."
       }
     ]
   },
@@ -1801,7 +1833,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -1830,7 +1861,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -1848,14 +1878,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#b",
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#h",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."
+        "@value": "Data encoding sounds producible by the computer."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1865,55 +1895,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "computer program"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for game, font."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Data with bibliographic citations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographic data"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."
+        "@value": "sound"
       }
     ]
   }

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld
@@ -1,5 +1,219 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Supports system-based user interaction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online system or service"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Information for a computer to produce fonts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "font"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Combination of two or more types of files."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "combination"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "numeric data"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Data with bibliographic citations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographic data"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for recreational or educational use. Generally games consist of text and software."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for a videogame."
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +282,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,41 +311,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of file is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -153,7 +339,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -171,14 +356,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#j",
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Supports system-based user interaction."
+        "@value": "Type of file is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -188,200 +373,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online system or service"
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "computer program"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Information for a computer to produce fonts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "font"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Intended for recreational or educational use. Generally games consist of text and software."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "game"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for a videogame."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "numeric data"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Data encoding sounds producible by the computer."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sound"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Combination of two or more types of files."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "combination"
+        "@value": "Not used for game, font."
       }
     ]
   },
@@ -403,7 +435,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -432,7 +463,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -450,14 +480,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#b",
+    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#h",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."
+        "@value": "Data encoding sounds producible by the computer."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -467,55 +497,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "computer program"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for game, font."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Data with bibliographic citations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.mkjn-bp10"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographic data"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."
+        "@value": "sound"
       }
     ]
   }

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.nt
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.nt
@@ -1,93 +1,93 @@
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#definition> "Data with bibliographic citations."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "sound"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#definition> "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "font"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#definition> "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "representational"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "numeric data"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "combination"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "computer program"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/description> "Indicates the type of computer file described in the bibliographic record."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#definition> "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#definition> "Information for a computer to produce fonts."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#definition> "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "document"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "interactive multimedia"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#definition> "Intended for recreational or educational use. Generally games consist of text and software."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#definition> "Data encoding sounds producible by the computer."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "font"@en .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#definition> "Combination of two or more types of files."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#definition> "Intended for recreational or educational use. Generally games consist of text and software."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for game, font."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl> .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#definition> "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#definition> "Combination of two or more types of files."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#definition> "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "sound"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/description> "Indicates the type of computer file described in the bibliographic record."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "online system or service"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "interactive multimedia"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "representational"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "numeric data"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "computer program"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "combination"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Does not include a document in image format."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#definition> "Information for a computer to produce fonts."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/alternative> "MARC21 008/26 values for computer files expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#definition> "Data with bibliographic citations."@en .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/title> "Computer: type of computer file"@en .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographic data"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#definition> "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#definition> "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Does not include a document in image format."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for game, font."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#definition> "Supports system-based user interaction."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "online system or service"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#definition> "Type of file is unknown."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#h> <http://www.w3.org/2004/02/skos/core#definition> "Data encoding sounds producible by the computer."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#u> <http://www.w3.org/2004/02/skos/core#definition> "Type of file is unknown."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#j> <http://www.w3.org/2004/02/skos/core#definition> "Supports system-based user interaction."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#definition> "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/alternative> "MARC21 008/26 values for computer files expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#e> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#a> <http://www.w3.org/2004/02/skos/core#definition> "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "document"@en .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.mkjn-bp10> .
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a videogame."@en .
-<https://doi.org/10.6069/uwlswd.mkjn-bp10> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.mkjn-bp10#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld"/>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Computer: type of computer file</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/26 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of computer file described in the bibliographic record.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">numeric data</skos:prefLabel>
     <skos:definition xml:lang="en">Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">bibliographic data</skos:prefLabel>
     <skos:definition xml:lang="en">Data with bibliographic citations.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
@@ -50,21 +44,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">sound</skos:prefLabel>
     <skos:definition xml:lang="en">Data encoding sounds producible by the computer.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">online system or service</skos:prefLabel>
     <skos:definition xml:lang="en">Supports system-based user interaction.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
     <skos:scopeNote xml:lang="en">May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
@@ -72,7 +66,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">computer program</skos:prefLabel>
     <skos:definition xml:lang="en">Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for game, font.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
@@ -80,14 +74,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">font</skos:prefLabel>
     <skos:definition xml:lang="en">Information for a computer to produce fonts.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for recreational or educational use. Generally games consist of text and software.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a videogame.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c">
@@ -95,7 +89,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">representational</skos:prefLabel>
     <skos:definition xml:lang="en">Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Does not include a document in image format.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d">
@@ -103,7 +97,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">document</skos:prefLabel>
     <skos:definition xml:lang="en">Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#m">
@@ -111,20 +105,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">combination</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of two or more types of files.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">interactive multimedia</skos:prefLabel>
     <skos:definition xml:lang="en">Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Type of file is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Computer: type of computer file</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/26 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of computer file described in the bibliographic record.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.jsonld"/>
@@ -29,14 +35,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">numeric data</skos:prefLabel>
     <skos:definition xml:lang="en">Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">bibliographic data</skos:prefLabel>
     <skos:definition xml:lang="en">Data with bibliographic citations.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
@@ -44,21 +50,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">sound</skos:prefLabel>
     <skos:definition xml:lang="en">Data encoding sounds producible by the computer.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">online system or service</skos:prefLabel>
     <skos:definition xml:lang="en">Supports system-based user interaction.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
     <skos:scopeNote xml:lang="en">May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
@@ -66,7 +72,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">computer program</skos:prefLabel>
     <skos:definition xml:lang="en">Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for game, font.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
@@ -74,14 +80,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">font</skos:prefLabel>
     <skos:definition xml:lang="en">Information for a computer to produce fonts.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for recreational or educational use. Generally games consist of text and software.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a videogame.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c">
@@ -89,7 +95,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">representational</skos:prefLabel>
     <skos:definition xml:lang="en">Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
     <skos:scopeNote xml:lang="en">Does not include a document in image format.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d">
@@ -97,7 +103,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">document</skos:prefLabel>
     <skos:definition xml:lang="en">Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
     <skos:scopeNote xml:lang="en">Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#m">
@@ -105,20 +111,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">combination</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of two or more types of files.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">interactive multimedia</skos:prefLabel>
     <skos:definition xml:lang="en">Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Type of file is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -1,5 +1,26 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">online system or service</skos:prefLabel>
+    <skos:definition xml:lang="en">Supports system-based user interaction.</skos:definition>
+    <skos:notation>j</skos:notation>
+    <skos:scopeNote xml:lang="en">May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">interactive multimedia</skos:prefLabel>
+    <skos:definition xml:lang="en">Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,12 +45,34 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">numeric data</skos:prefLabel>
-    <skos:definition xml:lang="en">Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">game</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for recreational or educational use. Generally games consist of text and software.</skos:definition>
+    <skos:notation>g</skos:notation>
+    <skos:scopeNote xml:lang="en">Used for a videogame.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Type of file is unknown.</skos:definition>
+    <skos:notation>u</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">sound</skos:prefLabel>
+    <skos:definition xml:lang="en">Data encoding sounds producible by the computer.</skos:definition>
+    <skos:notation>h</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">font</skos:prefLabel>
+    <skos:definition xml:lang="en">Information for a computer to produce fonts.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -39,50 +82,12 @@
     <skos:notation>e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.</skos:definition>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">sound</skos:prefLabel>
-    <skos:definition xml:lang="en">Data encoding sounds producible by the computer.</skos:definition>
-    <skos:notation>h</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">online system or service</skos:prefLabel>
-    <skos:definition xml:lang="en">Supports system-based user interaction.</skos:definition>
-    <skos:notation>j</skos:notation>
-    <skos:scopeNote xml:lang="en">May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">computer program</skos:prefLabel>
-    <skos:definition xml:lang="en">Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.</skos:definition>
-    <skos:notation>b</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for game, font.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">font</skos:prefLabel>
-    <skos:definition xml:lang="en">Information for a computer to produce fonts.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">game</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended for recreational or educational use. Generally games consist of text and software.</skos:definition>
-    <skos:notation>g</skos:notation>
-    <skos:scopeNote xml:lang="en">Used for a videogame.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">numeric data</skos:prefLabel>
+    <skos:definition xml:lang="en">Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -91,6 +96,21 @@
     <skos:definition xml:lang="en">Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information.</skos:definition>
     <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Does not include a document in image format.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.</skos:definition>
+    <skos:notation>z</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
+    <skos:prefLabel xml:lang="en">computer program</skos:prefLabel>
+    <skos:definition xml:lang="en">Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.</skos:definition>
+    <skos:notation>b</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for game, font.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -106,19 +126,5 @@
     <skos:prefLabel xml:lang="en">combination</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of two or more types of files.</skos:definition>
     <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">interactive multimedia</skos:prefLabel>
-    <skos:definition xml:lang="en">Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
-    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Type of file is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Computer: type of computer file</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/26 values for computer files expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of computer file described in the bibliographic record.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">numeric data</skos:prefLabel>
     <skos:definition xml:lang="en">Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">bibliographic data</skos:prefLabel>
     <skos:definition xml:lang="en">Data with bibliographic citations.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#z">
@@ -50,21 +44,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">sound</skos:prefLabel>
     <skos:definition xml:lang="en">Data encoding sounds producible by the computer.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">online system or service</skos:prefLabel>
     <skos:definition xml:lang="en">Supports system-based user interaction.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
     <skos:scopeNote xml:lang="en">May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#b">
@@ -72,7 +66,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">computer program</skos:prefLabel>
     <skos:definition xml:lang="en">Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for game, font.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#f">
@@ -80,14 +74,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">font</skos:prefLabel>
     <skos:definition xml:lang="en">Information for a computer to produce fonts.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for recreational or educational use. Generally games consist of text and software.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a videogame.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#c">
@@ -95,7 +89,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">representational</skos:prefLabel>
     <skos:definition xml:lang="en">Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Does not include a document in image format.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#d">
@@ -103,7 +97,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">document</skos:prefLabel>
     <skos:definition xml:lang="en">Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#m">
@@ -111,20 +105,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">combination</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of two or more types of files.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">interactive multimedia</skos:prefLabel>
     <skos:definition xml:lang="en">Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.mkjn-bp10#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.mkjn-bp10"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Type of file is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl
+++ b/008/computer_type_of_computer_file/computer_type_of_computer_file.ttl
@@ -6,85 +6,85 @@
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#a> a skos:Concept ;
     skos:definition "Mostly numbers or representation by numbers, such as records containing all information on student test scores, all information on football team statistics, etc. Information may be original surveys and/or information that has been summarized or statistically manipulated."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "numeric data"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#b> a skos:Concept ;
     skos:definition "Ordered set of instructions directing the computer to perform basic operations and identifying the information and mechanisms required. Includes videogames and microcomputer software and computer models."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "computer program"@en ;
     skos:scopeNote "Not used for game, font."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#c> a skos:Concept ;
     skos:definition "Pictorial or graphic information that can be manipulated in conjunction with other types of files to produce graphic patterns that can be used to interpret and give meaning to the information."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "representational"@en ;
     skos:scopeNote "Does not include a document in image format."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#d> a skos:Concept ;
     skos:definition "Textual, consisting mostly of alphabetic information (words or sentences) converted into a coded format that can be processed, sorted, and manipulated by machine, and then retrieved in many optional formats."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "document"@en ;
     skos:scopeNote "Includes language material intended to constitute a textual document, whether represented as ASCII or image data. Includes both single bibliographic entities or a collection of bibliographic entities. Includes documents whose primary purpose is textual, even if search software is present."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#e> a skos:Concept ;
     skos:definition "Data with bibliographic citations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "bibliographic data"@en ;
     skos:scopeNote "Includes data from library catalogs or citation databases. The data may be in a structured or unstructured form. Search software may be present, but the purpose of the record is description of the content of the bibliographic data or database, rather than description of the online system or service."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#f> a skos:Concept ;
     skos:definition "Information for a computer to produce fonts."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "font"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#g> a skos:Concept ;
     skos:definition "Intended for recreational or educational use. Generally games consist of text and software."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "game"@en ;
     skos:scopeNote "Used for a videogame."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#h> a skos:Concept ;
     skos:definition "Data encoding sounds producible by the computer."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "sound"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#i> a skos:Concept ;
     skos:definition "Supports navigation through and manipulation of many kinds of media (i.e., audio, video, etc.). Interactive multimedia usually gives the user a high level of control, often allowing almost conversational interaction with the computer and data."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "interactive multimedia"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#j> a skos:Concept ;
     skos:definition "Supports system-based user interaction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "online system or service"@en ;
     skos:scopeNote "May contain nonbibliographic information. If the focus of the record is to describe the system itself, with the content of the databases incidental contained therein, it is coded here. If the resource is an online file where the system is incidental to the description, it falls into another catagory. Examples are: online library systems (consisting of a variety of databases), FTP sites, electronic bulletin boards, network information centers."@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#m> a skos:Concept ;
     skos:definition "Combination of two or more types of files."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "combination"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#u> a skos:Concept ;
     skos:definition "Type of file is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10#z> a skos:Concept ;
     skos:definition "Type of computer file other than numeric data, computer program, representational, document, bibliographic data, font, game, sound, interactive multimedia, online system or service, or a combination of these listed files."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.mkjn-bp10> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.mkjn-bp10> a skos:ConceptScheme ;
@@ -101,12 +101,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/computer_type_of_computer_file/computer_type_of_computer_file.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Computer: type of computer file"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_entry_convention/continuing_entry_convention.html
+++ b/008/continuing_entry_convention/continuing_entry_convention.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
                         <td id="0">
@@ -359,7 +359,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">0</td>
+                        <td property="skos:notation">0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
                         <td>
@@ -399,7 +399,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">1</td>
+                        <td property="skos:notation">1</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
                         <td>
@@ -439,7 +439,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">2</td>
+                        <td property="skos:notation">2</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ypcx-6882#2">
                         <td>
@@ -469,41 +469,41 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: entry convention&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/34 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#2"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;integrated entry&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;2&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;latest entry&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;1&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#0"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;successive entry&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;0&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;0&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#2"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;latest entry&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;1&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;integrated entry&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;2&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -517,17 +517,17 @@
 
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; ;
-    skos:notation "0"@en ;
+    skos:notation "0" ;
     skos:prefLabel "successive entry"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; ;
-    skos:notation "1"@en ;
+    skos:notation "1" ;
     skos:prefLabel "latest entry"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; ;
-    skos:notation "2"@en ;
+    skos:notation "2" ;
     skos:prefLabel "integrated entry"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; a skos:ConceptScheme ;
@@ -544,58 +544,80 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: entry convention"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "integrated entry"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "0"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "2"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: entry convention"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "successive entry"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "1"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "latest entry"@en .
-&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions."@en .
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
 &lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "latest entry"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: entry convention"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "successive entry"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "1" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "2" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions."@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "0" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#1&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#0&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.ypcx-6882#2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "integrated entry"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "integrated entry"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#1",
     "@type": [
@@ -608,7 +630,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "1"
       }
     ],
@@ -688,7 +709,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -717,12 +738,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -738,7 +760,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "0"
       }
     ],
@@ -746,29 +767,6 @@
       {
         "@language": "en",
         "@value": "successive entry"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#2",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "integrated entry"
       }
     ]
   }

--- a/008/continuing_entry_convention/continuing_entry_convention.jsonld
+++ b/008/continuing_entry_convention/continuing_entry_convention.jsonld
@@ -1,5 +1,27 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "2"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "integrated entry"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#1",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -11,7 +33,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "1"
       }
     ],
@@ -91,7 +112,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -120,12 +141,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -141,7 +163,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "0"
       }
     ],
@@ -149,29 +170,6 @@
       {
         "@language": "en",
         "@value": "successive entry"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882#2",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ypcx-6882"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "2"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "integrated entry"
       }
     ]
   }

--- a/008/continuing_entry_convention/continuing_entry_convention.nt
+++ b/008/continuing_entry_convention/continuing_entry_convention.nt
@@ -1,34 +1,34 @@
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ypcx-6882> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#prefLabel> "integrated entry"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/2004/02/skos/core#notation> "0"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#notation> "2"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/title> "Continuing: entry convention"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/2004/02/skos/core#prefLabel> "successive entry"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
 <https://doi.org/10.6069/uwlswd.ypcx-6882> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/2004/02/skos/core#notation> "1"@en .
 <https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ypcx-6882> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/2004/02/skos/core#prefLabel> "latest entry"@en .
-<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/description> "Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions."@en .
 <https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
 <https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ypcx-6882> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/2004/02/skos/core#prefLabel> "latest entry"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/title> "Continuing: entry convention"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/2004/02/skos/core#prefLabel> "successive entry"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/2004/02/skos/core#notation> "1" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ypcx-6882> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#notation> "2" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/description> "Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions."@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/2004/02/skos/core#notation> "0" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ypcx-6882> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.ypcx-6882#2> <http://www.w3.org/2004/02/skos/core#prefLabel> "integrated entry"@en .

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: entry convention</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -34,18 +28,18 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">integrated entry</skos:prefLabel>
-    <skos:notation xml:lang="en">2</skos:notation>
+    <skos:notation>2</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">successive entry</skos:prefLabel>
-    <skos:notation xml:lang="en">0</skos:notation>
+    <skos:notation>0</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">latest entry</skos:prefLabel>
-    <skos:notation xml:lang="en">1</skos:notation>
+    <skos:notation>1</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld"/>

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,11 +30,11 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#2">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
-    <skos:prefLabel xml:lang="en">integrated entry</skos:prefLabel>
-    <skos:notation>2</skos:notation>
+    <skos:prefLabel xml:lang="en">latest entry</skos:prefLabel>
+    <skos:notation>1</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -36,10 +42,10 @@
     <skos:prefLabel xml:lang="en">successive entry</skos:prefLabel>
     <skos:notation>0</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#2">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
-    <skos:prefLabel xml:lang="en">latest entry</skos:prefLabel>
-    <skos:notation>1</skos:notation>
+    <skos:prefLabel xml:lang="en">integrated entry</skos:prefLabel>
+    <skos:notation>2</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: entry convention</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld"/>
@@ -28,18 +34,18 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">integrated entry</skos:prefLabel>
-    <skos:notation>2</skos:notation>
+    <skos:notation xml:lang="en">2</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">successive entry</skos:prefLabel>
-    <skos:notation>0</skos:notation>
+    <skos:notation xml:lang="en">0</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">latest entry</skos:prefLabel>
-    <skos:notation>1</skos:notation>
+    <skos:notation xml:lang="en">1</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_entry_convention/continuing_entry_convention.rdf
+++ b/008/continuing_entry_convention/continuing_entry_convention.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: entry convention</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item was cataloged according to successive entry, latest entry, or integrated entry cataloging conventions.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.jsonld"/>
@@ -34,18 +28,18 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">integrated entry</skos:prefLabel>
-    <skos:notation xml:lang="en">2</skos:notation>
+    <skos:notation>2</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#0">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">successive entry</skos:prefLabel>
-    <skos:notation xml:lang="en">0</skos:notation>
+    <skos:notation>0</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ypcx-6882#1">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ypcx-6882"/>
     <skos:prefLabel xml:lang="en">latest entry</skos:prefLabel>
-    <skos:notation xml:lang="en">1</skos:notation>
+    <skos:notation>1</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_entry_convention/continuing_entry_convention.ttl
+++ b/008/continuing_entry_convention/continuing_entry_convention.ttl
@@ -5,17 +5,17 @@
 
 <https://doi.org/10.6069/uwlswd.ypcx-6882#0> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ypcx-6882> ;
-    skos:notation "0"@en ;
+    skos:notation "0" ;
     skos:prefLabel "successive entry"@en .
 
 <https://doi.org/10.6069/uwlswd.ypcx-6882#1> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ypcx-6882> ;
-    skos:notation "1"@en ;
+    skos:notation "1" ;
     skos:prefLabel "latest entry"@en .
 
 <https://doi.org/10.6069/uwlswd.ypcx-6882#2> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ypcx-6882> ;
-    skos:notation "2"@en ;
+    skos:notation "2" ;
     skos:prefLabel "integrated entry"@en .
 
 <https://doi.org/10.6069/uwlswd.ypcx-6882> a skos:ConceptScheme ;
@@ -32,12 +32,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_entry_convention/continuing_entry_convention.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: entry convention"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.html
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
                         <td id="a">
@@ -357,7 +357,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
                         <td>
@@ -397,7 +397,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#b">
                         <td>
@@ -437,7 +437,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
                         <td>
@@ -477,7 +477,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
                         <td>
@@ -526,7 +526,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#e">
                         <td>
@@ -566,7 +566,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
                         <td>
@@ -606,7 +606,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
                         <td>
@@ -646,7 +646,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
                         <td>
@@ -686,7 +686,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
                         <td>
@@ -735,7 +735,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#o">
                         <td>
@@ -785,7 +785,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
                         <td>
@@ -835,7 +835,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
                         <td>
@@ -886,7 +886,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
                         <td>
@@ -936,7 +936,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">x</td>
+                        <td property="skos:notation">x</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx">
                         <td>
@@ -976,7 +976,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
                         <td>
@@ -1000,23 +1000,23 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other physical medium (z) [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;punched paper tape [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1024,101 +1024,101 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: form of original item&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/22 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the form of material in which an item was originally published.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#b"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;newspaper format&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;On newsprint and/or looks like a newspaper.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other physical medium (z) [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other physical medium (x) [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;x&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;x&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;punched paper tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;multimedia [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#b"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;multimedia [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1132,83 +1132,83 @@
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "microfilm"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "microfiche"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "microopaque"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "large print"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; a skos:Concept ;
     skos:definition "On newsprint and/or looks like a newspaper."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "newspaper format"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "braille"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "punched paper tape [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "magnetic tape [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "multimedia [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; a skos:Concept ;
     skos:definition "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; a skos:Concept ;
     skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "electronic"@en ;
     skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "other physical medium (x) [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other physical medium (z) [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; a skos:ConceptScheme ;
@@ -1225,107 +1225,107 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: form of original item"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "On newsprint and/or looks like a newspaper."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other physical medium (z) [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other physical medium (x) [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newspaper format"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: form of original item"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the form of material in which an item was originally published."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x"@en .
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "punched paper tape [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newspaper format"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other physical medium (x) [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the form of material in which an item was originally published."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: form of original item"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "On newsprint and/or looks like a newspaper."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other physical medium (z) [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.42d2-ca58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
@@ -1343,7 +1343,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -1355,7 +1354,7 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#xx",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -1366,26 +1365,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "x"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other physical medium (x) [obsolete]"
+        "@value": "microfiche"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#s",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#e",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+        "@value": "On newsprint and/or looks like a newspaper."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1395,20 +1393,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "s"
+        "@value": "e"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "electronic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+        "@value": "newspaper format"
       }
     ]
   },
@@ -1430,7 +1421,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "o"
       }
     ],
@@ -1438,6 +1428,50 @@
       {
         "@language": "en",
         "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#zx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other physical medium (z) [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
       }
     ]
   },
@@ -1453,7 +1487,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -1461,6 +1494,50 @@
       {
         "@language": "en",
         "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other physical medium (x) [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
       }
     ]
   },
@@ -1476,7 +1553,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -1499,7 +1575,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -1507,87 +1582,6 @@
       {
         "@language": "en",
         "@value": "magnetic tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfilm"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "On newsprint and/or looks like a newspaper."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newspaper format"
       }
     ]
   },
@@ -1609,7 +1603,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "q"
       }
     ],
@@ -1689,7 +1682,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1718,35 +1711,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#zx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other physical medium (z) [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1762,7 +1733,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -1774,9 +1744,15 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#b",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1785,21 +1761,32 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfiche"
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#f",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1808,14 +1795,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "braille"
+        "@value": "none of the following"
       }
     ]
   }

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld
@@ -11,7 +11,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -23,7 +22,7 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#xx",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -34,26 +33,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "x"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other physical medium (x) [obsolete]"
+        "@value": "microfiche"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#s",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#e",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+        "@value": "On newsprint and/or looks like a newspaper."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -63,20 +61,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "s"
+        "@value": "e"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "electronic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
+        "@value": "newspaper format"
       }
     ]
   },
@@ -98,7 +89,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "o"
       }
     ],
@@ -106,6 +96,50 @@
       {
         "@language": "en",
         "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#zx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other physical medium (z) [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
       }
     ]
   },
@@ -121,7 +155,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -129,6 +162,50 @@
       {
         "@language": "en",
         "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other physical medium (x) [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
       }
     ]
   },
@@ -144,7 +221,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -167,7 +243,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -175,87 +250,6 @@
       {
         "@language": "en",
         "@value": "magnetic tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfilm"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "On newsprint and/or looks like a newspaper."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newspaper format"
       }
     ]
   },
@@ -277,7 +271,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "q"
       }
     ],
@@ -357,7 +350,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -386,35 +379,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#zx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other physical medium (z) [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -430,7 +401,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -442,9 +412,15 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#b",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -453,21 +429,32 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "b"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfiche"
+        "@value": "electronic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#f",
+    "@id": "https://doi.org/10.6069/uwlswd.42d2-ca58#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -476,14 +463,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "braille"
+        "@value": "none of the following"
       }
     ]
   }

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.nt
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.nt
@@ -1,88 +1,88 @@
-<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#definition> "On newsprint and/or looks like a newspaper."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other physical medium (z) [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other physical medium (x) [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/alternative> "MARC21 008/22 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "newspaper format"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/title> "Continuing: form of original item"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#notation> "z" .
 <https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/description> "Indicates the form of material in which an item was originally published."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#notation> "x"@en .
 <https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "punched paper tape [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "newspaper format"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other physical medium (x) [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/description> "Indicates the form of material in which an item was originally published."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/title> "Continuing: form of original item"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#definition> "On newsprint and/or looks like a newspaper."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/alternative> "MARC21 008/22 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other physical medium (z) [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
 <https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
-<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/2004/02/skos/core#notation> "x" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.42d2-ca58> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.42d2-ca58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.42d2-ca58#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -35,7 +35,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld"/>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -1,22 +1,28 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">other physical medium (z) [obsolete]</skos:prefLabel>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -42,18 +48,18 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#b">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-    <skos:notation>b</skos:notation>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -62,18 +68,17 @@
     <skos:definition xml:lang="en">On newsprint and/or looks like a newspaper.</skos:definition>
     <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">other physical medium (z) [obsolete]</skos:prefLabel>
-    <skos:notation>z</skos:notation>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -81,19 +86,24 @@
     <skos:prefLabel xml:lang="en">other physical medium (x) [obsolete]</skos:prefLabel>
     <skos:notation>x</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
+    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -102,22 +112,18 @@
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
     <skos:notation>o</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation>i</skos:notation>
+    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
-    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -1,28 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -30,7 +24,7 @@
     <dct:title xml:lang="en">Continuing: form of original item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of material in which an item was originally published.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -52,53 +46,53 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">newspaper format</skos:prefLabel>
     <skos:definition xml:lang="en">On newsprint and/or looks like a newspaper.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (z) [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (x) [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#o">
@@ -106,24 +100,24 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -1,22 +1,28 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -24,7 +30,7 @@
     <dct:title xml:lang="en">Continuing: form of original item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of material in which an item was originally published.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,7 +41,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld"/>
@@ -46,53 +52,53 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">newspaper format</skos:prefLabel>
     <skos:definition xml:lang="en">On newsprint and/or looks like a newspaper.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (z) [obsolete]</skos:prefLabel>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (x) [obsolete]</skos:prefLabel>
-    <skos:notation>x</skos:notation>
+    <skos:notation xml:lang="en">x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#o">
@@ -100,24 +106,24 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -1,28 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -30,7 +24,7 @@
     <dct:title xml:lang="en">Continuing: form of original item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of material in which an item was originally published.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -41,7 +35,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.jsonld"/>
@@ -52,53 +46,53 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">newspaper format</skos:prefLabel>
     <skos:definition xml:lang="en">On newsprint and/or looks like a newspaper.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (z) [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">other physical medium (x) [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#o">
@@ -106,24 +100,24 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.42d2-ca58#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.42d2-ca58"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf
@@ -28,7 +28,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl
+++ b/008/continuing_form_of_original_item/continuing_form_of_original_item.ttl
@@ -5,83 +5,83 @@
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#a> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "microfilm"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#b> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "microfiche"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#c> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "microopaque"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#d> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "large print"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#e> a skos:Concept ;
     skos:definition "On newsprint and/or looks like a newspaper."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "newspaper format"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#f> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "braille"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#gx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "punched paper tape [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#hx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "magnetic tape [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#ix> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "multimedia [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#o> a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#pound> a skos:Concept ;
     skos:definition "Form of original item other than microfilm, microfiche, microopaque, large print, newspaper format, braille, online, direct electronic, or electronic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#q> a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#s> a skos:Concept ;
     skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "electronic"@en ;
     skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#xx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "other physical medium (x) [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58#zx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.42d2-ca58> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other physical medium (z) [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.42d2-ca58> a skos:ConceptScheme ;
@@ -98,12 +98,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_form_of_original_item/continuing_form_of_original_item.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: form of original item"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_frequency/continuing_frequency.html
+++ b/008/continuing_frequency/continuing_frequency.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
                         <td id="a">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
                         <td>
@@ -475,7 +475,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
                         <td>
@@ -524,7 +524,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
                         <td>
@@ -582,7 +582,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
                         <td>
@@ -631,7 +631,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
                         <td>
@@ -680,7 +680,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
                         <td>
@@ -729,7 +729,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h">
                         <td>
@@ -769,7 +769,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i">
                         <td>
@@ -809,7 +809,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
                         <td>
@@ -858,7 +858,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
                         <td>
@@ -898,7 +898,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m">
                         <td>
@@ -956,7 +956,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
                         <td>
@@ -1005,7 +1005,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
                         <td>
@@ -1063,7 +1063,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
                         <td>
@@ -1103,7 +1103,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#t">
                         <td>
@@ -1152,7 +1152,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
                         <td>
@@ -1201,7 +1201,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">w</td>
+                        <td property="skos:notation">w</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
                         <td>
@@ -1253,7 +1253,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
                         <td>
@@ -1277,162 +1277,162 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;continuously updated&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;More frequent than daily.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;daily&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Once a day.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;This may include Saturday and Sunday.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;semimonthly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Twice a month.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biweekly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Every two weeks.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
     &lt;dct:title xml:lang="en"&gt;Continuing: frequency&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/18 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the frequency of an item. In the case of integrating resources, updates to an item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#t"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;three times a year&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;weekly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Once a week.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;w&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;semiweekly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Twice a week.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biennial&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Every two years.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;no determinable frequency&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Used when the frequency is known to be intentionally irregular.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bimonthly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Every two months.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes publications whose frequency is 6, 7, or 8 times a year.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;annual&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Once a year.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;triennial&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Every three years.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;quarterly&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Every three months.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Includes publications whose frequency is 4 times a year.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#t"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;three times a month&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Current frequency of the item is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;three times a year&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;monthly&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes publications whose frequency is 9, 10, 11, or 12 times a year.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;three times a week&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;semiannual&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Twice a year.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;semimonthly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Twice a month.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Current frequency of the item is unknown.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;annual&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Once a year.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;triennial&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Every three years.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;no determinable frequency&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Used when the frequency is known to be intentionally irregular.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;daily&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Once a day.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;This may include Saturday and Sunday.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biennial&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Every two years.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bimonthly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Every two months.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes publications whose frequency is 6, 7, or 8 times a year.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;monthly&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes publications whose frequency is 9, 10, 11, or 12 times a year.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;continuously updated&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;More frequent than daily.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biweekly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Every two weeks.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;weekly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Once a week.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;three times a week&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;three times a month&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;semiweekly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Twice a week.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1447,115 +1447,115 @@
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; a skos:Concept ;
     skos:definition "Once a year."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "annual"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; a skos:Concept ;
     skos:definition "Every two months."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bimonthly"@en ;
     skos:scopeNote "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; a skos:Concept ;
     skos:definition "Twice a week."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "semiweekly"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; a skos:Concept ;
     skos:definition "Once a day."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "daily"@en ;
     skos:scopeNote "This may include Saturday and Sunday."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; a skos:Concept ;
     skos:definition "Every two weeks."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "biweekly"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; a skos:Concept ;
     skos:definition "Twice a year."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "semiannual"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; a skos:Concept ;
     skos:definition "Every two years."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "biennial"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; a skos:Concept ;
     skos:definition "Every three years."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "triennial"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "three times a week"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "three times a month"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; a skos:Concept ;
     skos:definition "More frequent than daily."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "continuously updated"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "monthly"@en ;
     skos:scopeNote "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; a skos:Concept ;
     skos:definition "Used when the frequency is known to be intentionally irregular."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no determinable frequency"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; a skos:Concept ;
     skos:definition "Every three months."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "quarterly"@en ;
     skos:scopeNote "Includes publications whose frequency is 4 times a year."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; a skos:Concept ;
     skos:definition "Twice a month."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "semimonthly"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "three times a year"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; a skos:Concept ;
     skos:definition "Current frequency of the item is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; a skos:Concept ;
     skos:definition "Once a week."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "weekly"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; a skos:Concept ;
     skos:definition "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; a skos:ConceptScheme ;
@@ -1572,141 +1572,331 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: frequency"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuously updated"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "daily"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semimonthly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a year"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used when the frequency is known to be intentionally irregular."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every three years."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biennial"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every three months."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two months."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a month"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two years."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "monthly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a month."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "weekly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biweekly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "triennial"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18 values for continuing resources expressed using RDF"@en .
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "quarterly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a week."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a year."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semiweekly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "More frequent than daily."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a year."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no determinable frequency"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: frequency"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semiannual"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bimonthly"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two weeks."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the frequency of an item. In the case of integrating resources, updates to an item."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "annual"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a week"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a week."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 4 times a year."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This may include Saturday and Sunday."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a year"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a day."@en .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the frequency of an item. In the case of integrating resources, updates to an item."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semimonthly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Current frequency of the item is unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "annual"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Used when the frequency is known to be intentionally irregular."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no determinable frequency"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biennial"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two months."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "triennial"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two weeks."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a year."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a month."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: frequency"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bimonthly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semiannual"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a month"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a year."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "daily"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a week."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This may include Saturday and Sunday."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "continuously updated"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Twice a week."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "monthly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "weekly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes publications whose frequency is 4 times a year."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "three times a week"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "semiweekly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biweekly"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every three months."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every two years."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Once a day."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ggnh-4s58&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "More frequent than daily."@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.ggnh-4s58#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Every three years."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Twice a month."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "semimonthly"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every two weeks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biweekly"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Twice a year."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "semiannual"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "three times a week"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every two years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biennial"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "monthly"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes publications whose frequency is 9, 10, 11, or 12 times a year."
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58",
     "@type": [
@@ -1776,7 +1966,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1805,279 +1995,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Twice a month."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "semimonthly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every three months."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "quarterly"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes publications whose frequency is 4 times a year."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every two weeks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biweekly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every three years."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "triennial"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a day."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "daily"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "This may include Saturday and Sunday."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a week."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "weekly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three times a week"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Current frequency of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -2099,7 +2023,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "#"
       }
     ],
@@ -2111,15 +2034,9 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#a",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a year."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -2128,14 +2045,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "annual"
+        "@value": "three times a month"
       }
     ]
   },
@@ -2157,7 +2073,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -2169,14 +2084,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#g",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#h",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Every two years."
+        "@value": "Every three years."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2186,21 +2101,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "biennial"
+        "@value": "triennial"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#m",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a year."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -2209,20 +2129,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "m"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "monthly"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes publications whose frequency is 9, 10, 11, or 12 times a year."
+        "@value": "annual"
       }
     ]
   },
@@ -2244,7 +2157,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -2256,37 +2168,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three times a month"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#f",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Twice a year."
+        "@value": "Current frequency of the item is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2296,14 +2185,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "semiannual"
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a day."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "daily"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "This may include Saturday and Sunday."
       }
     ]
   },
@@ -2325,7 +2247,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -2343,6 +2264,68 @@
     ]
   },
   {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every three months."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "quarterly"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes publications whose frequency is 4 times a year."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a week."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "weekly"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#t",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -2354,7 +2337,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],

--- a/008/continuing_frequency/continuing_frequency.jsonld
+++ b/008/continuing_frequency/continuing_frequency.jsonld
@@ -1,5 +1,195 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Twice a month."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "semimonthly"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every two weeks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biweekly"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Twice a year."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "semiannual"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "three times a week"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every two years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biennial"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "monthly"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes publications whose frequency is 9, 10, 11, or 12 times a year."
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +258,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,279 +287,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Twice a month."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "semimonthly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every three months."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "quarterly"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes publications whose frequency is 4 times a year."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every two weeks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biweekly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Every three years."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "triennial"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a day."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "daily"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "This may include Saturday and Sunday."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a week."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "weekly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three times a week"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Current frequency of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -391,7 +315,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "#"
       }
     ],
@@ -403,15 +326,9 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#a",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#j",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Once a year."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -420,14 +337,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "j"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "annual"
+        "@value": "three times a month"
       }
     ]
   },
@@ -449,7 +365,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -461,14 +376,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#g",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#h",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Every two years."
+        "@value": "Every three years."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -478,21 +393,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "biennial"
+        "@value": "triennial"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#m",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a year."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -501,20 +421,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "m"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "monthly"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes publications whose frequency is 9, 10, 11, or 12 times a year."
+        "@value": "annual"
       }
     ]
   },
@@ -536,7 +449,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -548,37 +460,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "three times a month"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#f",
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Twice a year."
+        "@value": "Current frequency of the item is unknown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -588,14 +477,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "semiannual"
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a day."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "daily"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "This may include Saturday and Sunday."
       }
     ]
   },
@@ -617,7 +539,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -635,6 +556,68 @@
     ]
   },
   {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Every three months."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "quarterly"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes publications whose frequency is 4 times a year."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Once a week."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "weekly"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.ggnh-4s58#t",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -646,7 +629,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],

--- a/008/continuing_frequency/continuing_frequency.nt
+++ b/008/continuing_frequency/continuing_frequency.nt
@@ -1,117 +1,117 @@
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuously updated"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "daily"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "semimonthly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a year"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#definition> "Used when the frequency is known to be intentionally irregular."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#definition> "Every three years."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "biennial"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#definition> "Every three months."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#definition> "Every two months."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a month"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#definition> "Every two years."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "monthly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#definition> "Twice a month."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "weekly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/alternative> "MARC21 008/18 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "biweekly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "triennial"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#definition> "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "quarterly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#definition> "Twice a week."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#definition> "Twice a year."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "semiweekly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#definition> "More frequent than daily."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#definition> "Once a year."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no determinable frequency"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/title> "Continuing: frequency"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "semiannual"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bimonthly"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#definition> "Every two weeks."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/description> "Indicates the frequency of an item. In the case of integrating resources, updates to an item."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "annual"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a week"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#definition> "Once a week."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 4 times a year."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "This may include Saturday and Sunday."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#notation> "w"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a year"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#definition> "Once a day."@en .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/description> "Indicates the frequency of an item. In the case of integrating resources, updates to an item."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "semimonthly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#definition> "Current frequency of the item is unknown."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "annual"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#definition> "Used when the frequency is known to be intentionally irregular."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no determinable frequency"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "biennial"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#definition> "Every two months."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "triennial"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#definition> "Every two weeks."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#definition> "Twice a year."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#definition> "Twice a month."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/title> "Continuing: frequency"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#definition> "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bimonthly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "semiannual"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a month"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#definition> "Once a year."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "daily"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#definition> "Once a week."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "This may include Saturday and Sunday."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "continuously updated"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#definition> "Twice a week."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "monthly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "weekly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes publications whose frequency is 4 times a year."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "three times a week"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "semiweekly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "biweekly"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#definition> "Every three months."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#definition> "Every two years."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#d> <http://www.w3.org/2004/02/skos/core#definition> "Once a day."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ggnh-4s58> .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#k> <http://www.w3.org/2004/02/skos/core#definition> "More frequent than daily."@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.ggnh-4s58#h> <http://www.w3.org/2004/02/skos/core#definition> "Every three years."@en .

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -39,7 +39,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -1,34 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">continuously updated</skos:prefLabel>
-    <skos:definition xml:lang="en">More frequent than daily.</skos:definition>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">daily</skos:prefLabel>
-    <skos:definition xml:lang="en">Once a day.</skos:definition>
-    <skos:notation>d</skos:notation>
-    <skos:scopeNote xml:lang="en">This may include Saturday and Sunday.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">semimonthly</skos:prefLabel>
-    <skos:definition xml:lang="en">Twice a month.</skos:definition>
-    <skos:notation>s</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">biweekly</skos:prefLabel>
-    <skos:definition xml:lang="en">Every two weeks.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -53,47 +30,47 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
+    <skos:prefLabel xml:lang="en">quarterly</skos:prefLabel>
+    <skos:definition xml:lang="en">Every three months.</skos:definition>
+    <skos:notation>q</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes publications whose frequency is 4 times a year.</skos:scopeNote>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a year</skos:prefLabel>
     <skos:notation>t</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">weekly</skos:prefLabel>
-    <skos:definition xml:lang="en">Once a week.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.</skos:definition>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">semiweekly</skos:prefLabel>
-    <skos:definition xml:lang="en">Twice a week.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">semiannual</skos:prefLabel>
+    <skos:definition xml:lang="en">Twice a year.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">biennial</skos:prefLabel>
-    <skos:definition xml:lang="en">Every two years.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:prefLabel xml:lang="en">semimonthly</skos:prefLabel>
+    <skos:definition xml:lang="en">Twice a month.</skos:definition>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">no determinable frequency</skos:prefLabel>
-    <skos:definition xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:definition>
-    <skos:notation>#</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">bimonthly</skos:prefLabel>
-    <skos:definition xml:lang="en">Every two months.</skos:definition>
-    <skos:notation>b</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes publications whose frequency is 6, 7, or 8 times a year.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Current frequency of the item is unknown.</skos:definition>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -109,33 +86,35 @@
     <skos:definition xml:lang="en">Every three years.</skos:definition>
     <skos:notation>h</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">quarterly</skos:prefLabel>
-    <skos:definition xml:lang="en">Every three months.</skos:definition>
-    <skos:notation>q</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes publications whose frequency is 4 times a year.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">no determinable frequency</skos:prefLabel>
+    <skos:definition xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:definition>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">three times a month</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:prefLabel xml:lang="en">daily</skos:prefLabel>
+    <skos:definition xml:lang="en">Once a day.</skos:definition>
+    <skos:notation>d</skos:notation>
+    <skos:scopeNote xml:lang="en">This may include Saturday and Sunday.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Current frequency of the item is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:prefLabel xml:lang="en">biennial</skos:prefLabel>
+    <skos:definition xml:lang="en">Every two years.</skos:definition>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:prefLabel xml:lang="en">bimonthly</skos:prefLabel>
+    <skos:definition xml:lang="en">Every two months.</skos:definition>
+    <skos:notation>b</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes publications whose frequency is 6, 7, or 8 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -144,17 +123,44 @@
     <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 9, 10, 11, or 12 times a year.</skos:scopeNote>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
+    <skos:prefLabel xml:lang="en">continuously updated</skos:prefLabel>
+    <skos:definition xml:lang="en">More frequent than daily.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
+    <skos:prefLabel xml:lang="en">biweekly</skos:prefLabel>
+    <skos:definition xml:lang="en">Every two weeks.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
+    <skos:prefLabel xml:lang="en">weekly</skos:prefLabel>
+    <skos:definition xml:lang="en">Once a week.</skos:definition>
+    <skos:notation>w</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a week</skos:prefLabel>
     <skos:notation>i</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
-    <skos:prefLabel xml:lang="en">semiannual</skos:prefLabel>
-    <skos:definition xml:lang="en">Twice a year.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">three times a month</skos:prefLabel>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
+    <skos:prefLabel xml:lang="en">semiweekly</skos:prefLabel>
+    <skos:definition xml:lang="en">Twice a week.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -46,7 +46,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld"/>

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -1,24 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">continuously updated</skos:prefLabel>
     <skos:definition xml:lang="en">More frequent than daily.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">daily</skos:prefLabel>
     <skos:definition xml:lang="en">Once a day.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">This may include Saturday and Sunday.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
@@ -26,14 +20,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a month.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two weeks.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -41,7 +35,7 @@
     <dct:title xml:lang="en">Continuing: frequency</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the frequency of an item. In the case of integrating resources, updates to an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -52,7 +46,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld"/>
@@ -63,42 +57,42 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a year</skos:prefLabel>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">weekly</skos:prefLabel>
     <skos:definition xml:lang="en">Once a week.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a week.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every two years.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">no determinable frequency</skos:prefLabel>
     <skos:definition xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">bimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two months.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 6, 7, or 8 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
@@ -106,61 +100,61 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">annual</skos:prefLabel>
     <skos:definition xml:lang="en">Once a year.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">triennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every three years.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">quarterly</skos:prefLabel>
     <skos:definition xml:lang="en">Every three months.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 4 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a month</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Current frequency of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">monthly</skos:prefLabel>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 9, 10, 11, or 12 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a week</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiannual</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a year.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -1,18 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">continuously updated</skos:prefLabel>
     <skos:definition xml:lang="en">More frequent than daily.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">daily</skos:prefLabel>
     <skos:definition xml:lang="en">Once a day.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
     <skos:scopeNote xml:lang="en">This may include Saturday and Sunday.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
@@ -20,14 +26,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a month.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two weeks.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -35,7 +41,7 @@
     <dct:title xml:lang="en">Continuing: frequency</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the frequency of an item. In the case of integrating resources, updates to an item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -46,7 +52,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.jsonld"/>
@@ -57,42 +63,42 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a year</skos:prefLabel>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">weekly</skos:prefLabel>
     <skos:definition xml:lang="en">Once a week.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:notation xml:lang="en">w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a week.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every two years.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">no determinable frequency</skos:prefLabel>
     <skos:definition xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">bimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two months.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 6, 7, or 8 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
@@ -100,61 +106,61 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">annual</skos:prefLabel>
     <skos:definition xml:lang="en">Once a year.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">triennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every three years.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">quarterly</skos:prefLabel>
     <skos:definition xml:lang="en">Every three months.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 4 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a month</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Current frequency of the item is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">monthly</skos:prefLabel>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 9, 10, 11, or 12 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a week</skos:prefLabel>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiannual</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a year.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_frequency/continuing_frequency.rdf
+++ b/008/continuing_frequency/continuing_frequency.rdf
@@ -1,24 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">continuously updated</skos:prefLabel>
     <skos:definition xml:lang="en">More frequent than daily.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">daily</skos:prefLabel>
     <skos:definition xml:lang="en">Once a day.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">This may include Saturday and Sunday.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#s">
@@ -26,14 +20,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a month.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two weeks.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -41,7 +35,7 @@
     <dct:title xml:lang="en">Continuing: frequency</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the frequency of an item. In the case of integrating resources, updates to an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -63,42 +57,42 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a year</skos:prefLabel>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">weekly</skos:prefLabel>
     <skos:definition xml:lang="en">Once a week.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiweekly</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a week.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">biennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every two years.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">no determinable frequency</skos:prefLabel>
     <skos:definition xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">bimonthly</skos:prefLabel>
     <skos:definition xml:lang="en">Every two months.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 6, 7, or 8 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#a">
@@ -106,61 +100,61 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">annual</skos:prefLabel>
     <skos:definition xml:lang="en">Once a year.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">triennial</skos:prefLabel>
     <skos:definition xml:lang="en">Every three years.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">quarterly</skos:prefLabel>
     <skos:definition xml:lang="en">Every three months.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 4 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a month</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Current frequency of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">monthly</skos:prefLabel>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Includes publications whose frequency is 9, 10, 11, or 12 times a year.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">three times a week</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ggnh-4s58#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ggnh-4s58"/>
     <skos:prefLabel xml:lang="en">semiannual</skos:prefLabel>
     <skos:definition xml:lang="en">Twice a year.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_frequency/continuing_frequency.ttl
+++ b/008/continuing_frequency/continuing_frequency.ttl
@@ -6,115 +6,115 @@
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#a> a skos:Concept ;
     skos:definition "Once a year."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "annual"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#b> a skos:Concept ;
     skos:definition "Every two months."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bimonthly"@en ;
     skos:scopeNote "Includes publications whose frequency is 6, 7, or 8 times a year."@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#c> a skos:Concept ;
     skos:definition "Twice a week."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "semiweekly"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#d> a skos:Concept ;
     skos:definition "Once a day."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "daily"@en ;
     skos:scopeNote "This may include Saturday and Sunday."@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#e> a skos:Concept ;
     skos:definition "Every two weeks."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "biweekly"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#f> a skos:Concept ;
     skos:definition "Twice a year."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "semiannual"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#g> a skos:Concept ;
     skos:definition "Every two years."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "biennial"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#h> a skos:Concept ;
     skos:definition "Every three years."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "triennial"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#i> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "three times a week"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#j> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "three times a month"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#k> a skos:Concept ;
     skos:definition "More frequent than daily."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "continuously updated"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#m> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "monthly"@en ;
     skos:scopeNote "Includes publications whose frequency is 9, 10, 11, or 12 times a year."@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#pound> a skos:Concept ;
     skos:definition "Used when the frequency is known to be intentionally irregular."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no determinable frequency"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#q> a skos:Concept ;
     skos:definition "Every three months."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "quarterly"@en ;
     skos:scopeNote "Includes publications whose frequency is 4 times a year."@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#s> a skos:Concept ;
     skos:definition "Twice a month."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "semimonthly"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#t> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "three times a year"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#u> a skos:Concept ;
     skos:definition "Current frequency of the item is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#w> a skos:Concept ;
     skos:definition "Once a week."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "weekly"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58#z> a skos:Concept ;
     skos:definition "Frequency other than intentionally irregulay, annual, bimonthly, semiweekly, daily, biweekly, semiannual, biennial, triennial, three times a week, three times a month, continuously updated, monthly, quarterly, semimonthly, three times a year, weekly, or unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ggnh-4s58> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.ggnh-4s58> a skos:ConceptScheme ;
@@ -131,12 +131,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_frequency/continuing_frequency.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: frequency"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.html
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-0" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.cr35-yd51">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.cr35-yd51">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-0</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.cr35-yd51#3">
                         <td id="3">
@@ -1924,13 +1924,25 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#5"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;directories&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Directory or register of persons or corporate bodies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for serial biographical dictionaries.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;5&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#nx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1938,31 +1950,51 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: nature of contents&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/25-27 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether a significant part of the item is or contains certain types of material.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#h"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for genealogy.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not specified&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;No specified nature of contents.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#6"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;6&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;treaties&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#v"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1972,27 +2004,12 @@
     &lt;skos:notation&gt;a&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication includes an abstract or summary of its own content.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#nx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;catalogs&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;List of items in a collection.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a discography or discographies, or other bibliography of recorded sound.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the discography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#y"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2002,19 +2019,20 @@
     &lt;skos:notation&gt;y&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for annual reports, which are administrative overviews of an organization.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#6"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#t"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;6&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical reports&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#5"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#q"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;5&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a filmography or other bibliography of moving images.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the filmography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#p"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2023,18 +2041,71 @@
     &lt;skos:definition xml:lang="en"&gt;Programmed texts.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;p&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a discography or discographies, or other bibliography of recorded sound.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the discography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#3"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;discographies [obsolete]&lt;/skos:prefLabel&gt;
     &lt;skos:notation&gt;3&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#pound"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;No specified nature of contents.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Handbooks.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;directories&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Directory or register of persons or corporate bodies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for serial biographical dictionaries.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;reviews&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a bibliography or bibliographies.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;catalogs&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;List of items in a collection.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#4"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmographies [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;4&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#w"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Also used when an item includes texts of digests of such decisions.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2044,12 +2115,20 @@
     &lt;skos:notation&gt;d&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#o"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;reviews&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a collection of statistical data on a subject.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#u"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;standards/specifications&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#l"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2058,12 +2137,13 @@
     &lt;skos:definition xml:lang="en"&gt;Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;l&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#m"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;indexes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Index to bibliographical material other than itself (e.g., an indexing journal).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication contains an index to its own content.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -2080,93 +2160,13 @@
     &lt;skos:definition xml:lang="en"&gt;Encyclopedia or an encyclopedic treatment of a specific topic.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#t"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#h"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical reports&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#4"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmographies [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation&gt;4&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a filmography or other bibliography of moving images.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the filmography is substantial enough to be mentioned in the bibliographic record.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a collection of statistical data on a subject.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;indexes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Index to bibliographical material other than itself (e.g., an indexing journal).&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used when a publication contains an index to its own content.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#w"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Also used when an item includes texts of digests of such decisions.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Handbooks.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant part of the item is a bibliography or bibliographies.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;treaties&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;standards/specifications&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#v"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for genealogy.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -2382,206 +2382,296 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: nature of contents"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/25-27 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes authored surveys that summarize what has been published about a subject."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "encyclopedias"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts/summaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a collection of statistical data on a subject."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serial biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "3" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "4" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when an item includes texts of digests of such decisions."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not specified"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;https://schema.org/version&gt; "1-0-0" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for genealogy."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards/specifications"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified nature of contents."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a bibliography or bibliographies."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether a significant part of the item is or contains certain types of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
 &lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Substantive articles on legal topics, such as those published in law school reviews."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication contains an index to its own content."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a filmography or other bibliography of moving images."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: nature of contents"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Usually has a list of references either in the body of the work or as a bibliography."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Handbooks."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6" .
 &lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "programmed texts"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
 &lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication includes an abstract or summary of its own content."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Programmed texts."@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes texts of decisions of courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
 &lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal articles"@en .
 &lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts/summaries"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a filmography or other bibliography of moving images."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "3" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "4" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a bibliography or bibliographies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serial biographical dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item is a collection of statistical data on a subject."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether a significant part of the item is or contains certain types of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/25-27 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards/specifications"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "programmed texts"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes authored surveys that summarize what has been published about a subject."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for genealogy."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified nature of contents."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used when a publication contains an index to its own content."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "encyclopedias"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#4&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: nature of contents"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#3&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Handbooks."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when an item includes texts of digests of such decisions."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Usually has a list of references either in the body of the work or as a bibliography."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Programmed texts."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes texts of decisions of courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.cr35-yd51&gt; .
+&lt;https://doi.org/10.6069/uwlswd.cr35-yd51#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Handbooks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards/specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when an item includes texts of digests of such decisions."
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51",
     "@type": [
@@ -2651,7 +2741,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -2680,372 +2770,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#y",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes authored surveys that summarize what has been published about a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Usually has a list of references either in the body of the work or as a bibliography."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#4",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts/summaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication includes an abstract or summary of its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No specified nature of contents."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not specified"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when an item includes texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication contains an index to its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
+        "@value": "1-1-0"
       }
     ]
   },
@@ -3084,14 +2815,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#l",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+        "@value": "Significant part of the item is a collection of statistical data on a subject."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3101,289 +2832,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "l"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "legislation"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography"
+        "@value": "statistics"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Not used for genealogy."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards/specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "List of items in a collection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "catalogs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a bibliography or bibliographies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "treaties"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Handbooks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
+        "@value": "Not used for works about statistical methodology."
       }
     ]
   },
@@ -3416,14 +2877,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#q",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#g",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Significant part of the item is a filmography or other bibliography of moving images."
+        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3433,19 +2894,103 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "q"
+        "@value": "g"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "filmographies"
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "theses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
       }
     ]
   },
@@ -3484,14 +3029,36 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#6",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#4",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+        "@value": "Significant part of the item is a bibliography or bibliographies."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3501,13 +3068,401 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "6"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "comics or graphic novels"
+        "@value": "bibliographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legislation"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "treaties"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Programmed texts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#3",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes authored surveys that summarize what has been published about a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Usually has a list of references either in the body of the work or as a bibliography."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "List of items in a collection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "catalogs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for genealogy."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No specified nature of contents."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication contains an index to its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes [obsolete]"
       }
     ]
   },
@@ -3540,36 +3495,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#3",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#p",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Programmed texts."
+        "@value": "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3579,13 +3512,81 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "p"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "programmed texts"
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a filmography or other bibliography of moving images."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts/summaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication includes an abstract or summary of its own content."
       }
     ]
   }

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld
@@ -1,5 +1,95 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Handbooks."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards/specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when an item includes texts of digests of such decisions."
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +158,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,372 +187,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#y",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes authored surveys that summarize what has been published about a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Usually has a list of references either in the body of the work or as a bibliography."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#4",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "4"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts/summaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication includes an abstract or summary of its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No specified nature of contents."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not specified"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when an item includes texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used when a publication contains an index to its own content."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
+        "@value": "1-1-0"
       }
     ]
   },
@@ -501,14 +232,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#l",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+        "@value": "Significant part of the item is a collection of statistical data on a subject."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -518,289 +249,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "l"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "legislation"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography"
+        "@value": "statistics"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Not used for genealogy."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards/specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "List of items in a collection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "catalogs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant part of the item is a bibliography or bibliographies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "treaties"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Handbooks."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
+        "@value": "Not used for works about statistical methodology."
       }
     ]
   },
@@ -833,14 +294,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#q",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#g",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Significant part of the item is a filmography or other bibliography of moving images."
+        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -850,19 +311,103 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "q"
+        "@value": "g"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "filmographies"
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "theses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
       }
     ]
   },
@@ -901,14 +446,36 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#6",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#4",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "4"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+        "@value": "Significant part of the item is a bibliography or bibliographies."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -918,13 +485,401 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "6"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "comics or graphic novels"
+        "@value": "bibliographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the discography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legislation"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "treaties"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Programmed texts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#3",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "3"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes authored surveys that summarize what has been published about a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Usually has a list of references either in the body of the work or as a bibliography."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "List of items in a collection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "catalogs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for genealogy."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No specified nature of contents."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication contains an index to its own content."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes [obsolete]"
       }
     ]
   },
@@ -957,36 +912,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#3",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "3"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#p",
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Programmed texts."
+        "@value": "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -996,13 +929,81 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "p"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "programmed texts"
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant part of the item is a filmography or other bibliography of moving images."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.cr35-yd51"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts/summaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used when a publication includes an abstract or summary of its own content."
       }
     ]
   }

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.nt
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.nt
@@ -1,182 +1,182 @@
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/alternative> "MARC21 008/25-27 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#definition> "Dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#definition> "Includes authored surveys that summarize what has been published about a subject."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "encyclopedias"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#notation> "6" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts/summaries"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a collection of statistical data on a subject."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serial biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#notation> "3" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#notation> "4" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when an item includes texts of digests of such decisions."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not specified"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <https://schema.org/version> "1-0-0" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for genealogy."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#notation> "y" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards/specifications"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#definition> "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#definition> "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified nature of contents."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a bibliography or bibliographies."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/description> "Indicates whether a significant part of the item is or contains certain types of material."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#definition> "Substantive articles on legal topics, such as those published in law school reviews."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication contains an index to its own content."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a filmography or other bibliography of moving images."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/title> "Continuing: nature of contents"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Usually has a list of references either in the body of the work or as a bibliography."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#definition> "Handbooks."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/2004/02/skos/core#notation> "n" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#notation> "5" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#definition> "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#definition> "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#definition> "Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "programmed texts"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
 <https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#definition> "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#definition> "Substantive articles on legal topics, such as those published in law school reviews."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#notation> "6" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
 <https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication includes an abstract or summary of its own content."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#definition> "Programmed texts."@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
-<https://doi.org/10.6069/uwlswd.cr35-yd51> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#definition> "Includes texts of decisions of courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the filmography is substantial enough to be mentioned in the bibliographic record."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a discography or discographies, or other bibliography of recorded sound."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/2004/02/skos/core#notation> "n" .
 <https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal articles"@en .
 <https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#definition> "Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#notation> "y" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts/summaries"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#definition> "Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a filmography or other bibliography of moving images."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#notation> "3" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#notation> "4" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a bibliography or bibliographies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#definition> "Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serial biographical dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item is a collection of statistical data on a subject."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/description> "Indicates whether a significant part of the item is or contains certain types of material."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#definition> "Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/alternative> "MARC21 008/25-27 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards/specifications"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "programmed texts"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes lists of collectible objects, such as stamps and coins, or trade catalogs."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not specified"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#definition> "Includes authored surveys that summarize what has been published about a subject."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#definition> "Dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#5> <http://www.w3.org/2004/02/skos/core#notation> "5" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#definition> "Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for genealogy."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified nature of contents."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used when a publication contains an index to its own content."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "encyclopedias"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#4> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#u> <http://www.w3.org/2004/02/skos/core#definition> "Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/title> "Continuing: nature of contents"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#3> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#definition> "Handbooks."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when an item includes texts of digests of such decisions."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Usually has a list of references either in the body of the work or as a bibliography."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#p> <http://www.w3.org/2004/02/skos/core#definition> "Programmed texts."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only if the discography is substantial enough to be mentioned in the bibliographic record."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#w> <http://www.w3.org/2004/02/skos/core#definition> "Includes texts of decisions of courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.cr35-yd51> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.cr35-yd51> .
+<https://doi.org/10.6069/uwlswd.cr35-yd51#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -25,7 +25,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.nt"/>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
@@ -14,7 +20,7 @@
     <dct:title xml:lang="en">Continuing: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25-27 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -25,7 +31,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-0</schema:version>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.nt"/>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
@@ -20,7 +14,7 @@
     <dct:title xml:lang="en">Continuing: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25-27 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -1,12 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#5">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
-    <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
-    <skos:notation>r</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
+    <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
+    <skos:notation>5</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#g">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
+    <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#nx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -32,13 +50,33 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.jsonld"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.html"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#h">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
-    <skos:notation>h</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">not specified</skos:prefLabel>
+    <skos:definition xml:lang="en">No specified nature of contents.</skos:definition>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#6">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
+    <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
+    <skos:notation>6</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
+    <skos:notation>z</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#v">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -48,27 +86,12 @@
     <skos:notation>a</skos:notation>
     <skos:scopeNote xml:lang="en">Not used when a publication includes an abstract or summary of its own content.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#nx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
-    <skos:definition xml:lang="en">List of items in a collection.</skos:definition>
-    <skos:notation>c</skos:notation>
-    <skos:scopeNote xml:lang="en">Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a discography or discographies, or other bibliography of recorded sound.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the discography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
-    <skos:notation>k</skos:notation>
+    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
+    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -78,19 +101,20 @@
     <skos:notation>y</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#6">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
-    <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
-    <skos:notation>6</skos:notation>
+    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#5">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
-    <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
-    <skos:notation>5</skos:notation>
+    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a filmography or other bibliography of moving images.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the filmography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -99,18 +123,71 @@
     <skos:definition xml:lang="en">Programmed texts.</skos:definition>
     <skos:notation>p</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a discography or discographies, or other bibliography of recorded sound.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the discography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#3">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
     <skos:prefLabel xml:lang="en">discographies [obsolete]</skos:prefLabel>
     <skos:notation>3</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#pound">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">not specified</skos:prefLabel>
-    <skos:definition xml:lang="en">No specified nature of contents.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
+    <skos:definition xml:lang="en">Handbooks.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
+    <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
+    <skos:notation>r</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a bibliography or bibliographies.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.</skos:scopeNote>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
+    <skos:definition xml:lang="en">List of items in a collection.</skos:definition>
+    <skos:notation>c</skos:notation>
+    <skos:scopeNote xml:lang="en">Also includes lists of collectible objects, such as stamps and coins, or trade catalogs.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#4">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">filmographies [obsolete]</skos:prefLabel>
+    <skos:notation>4</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#w">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes texts of decisions of courts or administrative agencies.</skos:definition>
+    <skos:notation>w</skos:notation>
+    <skos:scopeNote xml:lang="en">Also used when an item includes texts of digests of such decisions.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -120,12 +197,20 @@
     <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a glossary or a gazetteer. Not used for concordances or serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#o">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item is a collection of statistical data on a subject.</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#u">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
+    <skos:prefLabel xml:lang="en">standards/specifications</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement.</skos:definition>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -134,12 +219,13 @@
     <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies, published either in statute or in code form, or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
     <skos:notation>l</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#m">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
-    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
+    <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
+    <skos:notation>i</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used when a publication contains an index to its own content.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -156,92 +242,12 @@
     <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
     <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#t">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes material that is the result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation>t</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#4">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">filmographies [obsolete]</skos:prefLabel>
-    <skos:notation>4</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a filmography or other bibliography of moving images.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the filmography is substantial enough to be mentioned in the bibliographic record.</skos:scopeNote>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a collection of statistical data on a subject.</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
-    <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
-    <skos:notation>i</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used when a publication contains an index to its own content.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#w">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes texts of decisions of courts or administrative agencies.</skos:definition>
-    <skos:notation>w</skos:notation>
-    <skos:scopeNote xml:lang="en">Also used when an item includes texts of digests of such decisions.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:definition xml:lang="en">Handbooks.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant part of the item is a bibliography or bibliographies.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only if the bibliography is substantial enough to be mentioned in the bibliographic record. Not used if also coded as a survey of literature in a subject area.</skos:scopeNote>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
-    <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#u">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">standards/specifications</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes either an international, national or industry standard or a specification which gives a precise statement of a process or a service requirement.</skos:definition>
-    <skos:notation>u</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#v">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
-    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation>v</skos:notation>
+    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant part of the item contains biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
+    <skos:notation>h</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.cr35-yd51#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.cr35-yd51"/>
@@ -20,7 +14,7 @@
     <dct:title xml:lang="en">Continuing: nature of contents</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25-27 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether a significant part of the item is or contains certain types of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -31,7 +25,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.nt"/>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf
@@ -18,7 +18,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl
+++ b/008/continuing_nature_of_contents/continuing_nature_of_contents.ttl
@@ -207,12 +207,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_contents/continuing_nature_of_contents.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: nature of contents"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-0" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
                         <td id="5">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">5</td>
+                        <td property="skos:notation">5</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
                         <td>
@@ -420,7 +420,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">6</td>
+                        <td property="skos:notation">6</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#6">
                         <td>
@@ -469,7 +469,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
                         <td>
@@ -509,7 +509,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
                         <td>
@@ -559,7 +559,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
                         <td>
@@ -599,7 +599,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#d">
                         <td>
@@ -658,7 +658,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#e">
                         <td>
@@ -698,7 +698,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
                         <td>
@@ -747,7 +747,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
                         <td>
@@ -797,7 +797,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
                         <td>
@@ -855,7 +855,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
                         <td>
@@ -904,7 +904,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
                         <td>
@@ -954,7 +954,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#l">
                         <td>
@@ -1014,7 +1014,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
                         <td>
@@ -1064,7 +1064,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
                         <td>
@@ -1104,7 +1104,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
                         <td>
@@ -1154,7 +1154,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
                         <td>
@@ -1194,7 +1194,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
                         <td>
@@ -1243,7 +1243,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound">
                         <td>
@@ -1292,7 +1292,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
                         <td>
@@ -1341,7 +1341,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#r">
                         <td>
@@ -1399,7 +1399,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
                         <td>
@@ -1458,7 +1458,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
                         <td>
@@ -1508,7 +1508,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
                         <td>
@@ -1559,7 +1559,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">v</td>
+                        <td property="skos:notation">v</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
                         <td>
@@ -1608,7 +1608,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">w</td>
+                        <td property="skos:notation">w</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
                         <td>
@@ -1668,7 +1668,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">y</td>
+                        <td property="skos:notation">y</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
                         <td>
@@ -1717,7 +1717,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">y</td>
+                        <td property="skos:notation">y</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
                         <td>
@@ -1767,7 +1767,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
                         <td>
@@ -1791,95 +1791,48 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;yearbooks&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;y&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for annual reports, which are administrative overviews of an organization.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;yearbook [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;y&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;surveys of literature in a subject area&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Discography or other bibliography of recorded sound.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;treaties&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;standards or specifications&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#l"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;legislation&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;abstracts or summaries&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Abstracts or summaries of other publications.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Filmography or other bibliography of moving images.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;surveys of literature in a subject area&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;v&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Collection of statistical data on a subject.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1887,18 +1840,18 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: nature of entire work&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/24 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the nature of an item if it consists entirely of a certain type of material.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld"/&gt;
@@ -1909,115 +1862,162 @@
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;dictionaries&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;programmed texts&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#r"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;directories&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Directory or register of persons or corporate bodies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for serial biographical dictionaries.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Nature of the entire item is not specified.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;catalogs&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;List of items in a collection, such as a collection of books, a collection of art objects, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Biographical material, whether autobiography, individual biography, or collective biography.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for genealogy.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;5&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#6"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;6&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;statistics&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Collection of statistical data on a subject.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for works about statistical methodology.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;w&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Also used when a work consists of texts of digests of such decisions.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;legal cases and case notes [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;encyclopedias&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Encyclopedia or an encyclopedic treatment of a specific topic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;standards or specifications&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;handbooks&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;reviews&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;treaties&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;theses&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not specified&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Nature of the entire item is not specified.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;yearbook [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;y&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;law reports and digests&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Texts of decisions of courts or administrative agencies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Also used when a work consists of texts of digests of such decisions.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;indexes&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Index to bibliographical material other than itself (e.g., an indexing journal).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;calendars&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;5&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#6"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;comics or graphic novels&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;6&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;catalogs&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;List of items in a collection, such as a collection of books, a collection of art objects, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;yearbooks&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;y&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for annual reports, which are administrative overviews of an organization.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;technical reports&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;programmed texts&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;encyclopedias&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Encyclopedia or an encyclopedic treatment of a specific topic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;legal articles&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Substantive articles on legal topics, such as those published in law school reviews.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Biographical material, whether autobiography, individual biography, or collective biography.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for genealogy.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Filmography or other bibliography of moving images.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;discographies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Discography or other bibliography of recorded sound.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bibliographies&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;abstracts or summaries&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Abstracts or summaries of other publications.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -2032,176 +2032,176 @@
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; a skos:Concept ;
     skos:definition "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "5"@en ;
+    skos:notation "5" ;
     skos:prefLabel "calendars"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; a skos:Concept ;
     skos:definition "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "6"@en ;
+    skos:notation "6" ;
     skos:prefLabel "comics or graphic novels"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; a skos:Concept ;
     skos:definition "Abstracts or summaries of other publications."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "abstracts or summaries"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bibliographies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; a skos:Concept ;
     skos:definition "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "catalogs"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "dictionaries"@en ;
     skos:scopeNote "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; a skos:Concept ;
     skos:definition "Encyclopedia or an encyclopedic treatment of a specific topic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "encyclopedias"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "handbooks"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; a skos:Concept ;
     skos:definition "Substantive articles on legal topics, such as those published in law school reviews."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "legal articles"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; a skos:Concept ;
     skos:definition "Biographical material, whether autobiography, individual biography, or collective biography."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "biography"@en ;
     skos:scopeNote "Not used for genealogy."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; a skos:Concept ;
     skos:definition "Index to bibliographical material other than itself (e.g., an indexing journal)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "indexes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; a skos:Concept ;
     skos:definition "Discography or other bibliography of recorded sound."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "discographies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; a skos:Concept ;
     skos:definition "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "legislation"@en ;
     skos:scopeNote "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; a skos:Concept ;
     skos:definition "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "theses"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; a skos:Concept ;
     skos:definition "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "surveys of literature in a subject area"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "legal cases and case notes [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; a skos:Concept ;
     skos:definition "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "reviews"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "programmed texts"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; a skos:Concept ;
     skos:definition "Nature of the entire item is not specified."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not specified"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; a skos:Concept ;
     skos:definition "Filmography or other bibliography of moving images."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "filmographies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; a skos:Concept ;
     skos:definition "Directory or register of persons or corporate bodies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "directories"@en ;
     skos:scopeNote "Not used for serial biographical dictionaries."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; a skos:Concept ;
     skos:definition "Collection of statistical data on a subject."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "statistics"@en ;
     skos:scopeNote "Not used for works about statistical methodology."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; a skos:Concept ;
     skos:definition "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "technical reports"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; a skos:Concept ;
     skos:definition "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "standards or specifications"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; a skos:Concept ;
     skos:definition "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "v"@en ;
+    skos:notation "v" ;
     skos:prefLabel "legal cases and case notes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; a skos:Concept ;
     skos:definition "Texts of decisions of courts or administrative agencies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "law reports and digests"@en ;
     skos:scopeNote "Also used when a work consists of texts of digests of such decisions."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; a skos:Concept ;
     skos:definition "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "y"@en ;
+    skos:notation "y" ;
     skos:prefLabel "yearbooks"@en ;
     skos:scopeNote "Not used for annual reports, which are administrative overviews of an organization."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "y"@en ;
+    skos:notation "y" ;
     skos:prefLabel "yearbook [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; a skos:Concept ;
     skos:definition "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "treaties"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; a skos:ConceptScheme ;
@@ -2218,192 +2218,270 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: nature of entire work"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal articles"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discography or other bibliography of recorded sound."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Filmography or other bibliography of moving images."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not specified"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: nature of entire work"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nature of the entire item is not specified."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Substantive articles on legal topics, such as those published in law school reviews."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards or specifications"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "encyclopedias"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts or summaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serial biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;https://schema.org/version&gt; "1-0-1" .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "programmed texts"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for genealogy."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbook [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the nature of an item if it consists entirely of a certain type of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Collection of statistical data on a subject."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biographical material, whether autobiography, individual biography, or collective biography."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when a work consists of texts of digests of such decisions."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Texts of decisions of courts or administrative agencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w"@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legislation"@en .
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "standards or specifications"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "surveys of literature in a subject area"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for works about statistical methodology."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the nature of an item if it consists entirely of a certain type of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Directory or register of persons or corporate bodies."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "treaties"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: nature of entire work"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nature of the entire item is not specified."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "law reports and digests"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendars"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reviews"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal cases and case notes [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Texts of decisions of courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical reports"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "statistics"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when a work consists of texts of digests of such decisions."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "5" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directories"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Filmography or other bibliography of moving images."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serial biographical dictionaries."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Collection of statistical data on a subject."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for annual reports, which are administrative overviews of an organization."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discography or other bibliography of recorded sound."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dictionaries"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Substantive articles on legal topics, such as those published in law school reviews."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "encyclopedias"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbook [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "legal articles"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "programmed texts"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "abstracts or summaries"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "theses"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "catalogs"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "yearbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "6" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comics or graphic novels"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#6&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for genealogy."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Abstracts or summaries of other publications."@en .
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
 &lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliographies"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#5&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handbooks"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "indexes"@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#y&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "y" .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biographical material, whether autobiography, individual biography, or collective biography."@en .
+&lt;https://doi.org/10.6069/uwlswd.jfr5-z647#yx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.jfr5-z647&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#yx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbook [obsolete]"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647",
     "@type": [
@@ -2473,7 +2551,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -2502,760 +2580,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when a work consists of texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Directory or register of persons or corporate bodies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "directories"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for serial biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "List of items in a collection, such as a collection of books, a collection of art objects, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "catalogs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#6",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comics or graphic novels"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nature of the entire item is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not specified"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards or specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "encyclopedias"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dictionaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Filmography or other bibliography of moving images."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#y",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "programmed texts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts or summaries"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discography or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#yx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbook [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -3277,7 +2608,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -3295,14 +2625,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#z",
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+        "@value": "Nature of the entire item is not specified."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3312,14 +2642,153 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "treaties"
+        "@value": "not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts or summaries"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "theses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "encyclopedias"
       }
     ]
   },
@@ -3341,7 +2810,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -3355,6 +2823,510 @@
       {
         "@language": "en",
         "@value": "Not used for genealogy."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards or specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dictionaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "List of items in a collection, such as a collection of books, a collection of art objects, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "catalogs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "treaties"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Filmography or other bibliography of moving images."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when a work consists of texts of digests of such decisions."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Collection of statistical data on a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "statistics"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for works about statistical methodology."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discography or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Directory or register of persons or corporate bodies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "directories"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for serial biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
       }
     ]
   }

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld
@@ -1,5 +1,83 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal articles"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#yx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbook [obsolete]"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +146,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,760 +175,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Texts of decisions of courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "law reports and digests"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when a work consists of texts of digests of such decisions."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Directory or register of persons or corporate bodies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "directories"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for serial biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "handbooks"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "List of items in a collection, such as a collection of books, a collection of art objects, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "catalogs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#6",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "6"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comics or graphic novels"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nature of the entire item is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not specified"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "standards or specifications"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "encyclopedias"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dictionaries"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal cases and case notes [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Filmography or other bibliography of moving images."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#y",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbooks"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for annual reports, which are administrative overviews of an organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "programmed texts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "surveys of literature in a subject area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#5",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "5"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Substantive articles on legal topics, such as those published in law school reviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "legal articles"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Abstracts or summaries of other publications."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "abstracts or summaries"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discography or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discographies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Collection of statistical data on a subject."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "statistics"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for works about statistical methodology."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#yx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "y"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "yearbook [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "indexes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "technical reports"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "theses"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -872,7 +203,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -890,14 +220,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#z",
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+        "@value": "Nature of the entire item is not specified."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -907,14 +237,153 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "treaties"
+        "@value": "not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Abstracts or summaries of other publications."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "abstracts or summaries"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "theses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "surveys of literature in a subject area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#6",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "6"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comics or graphic novels"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Encyclopedia or an encyclopedic treatment of a specific topic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "encyclopedias"
       }
     ]
   },
@@ -936,7 +405,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -950,6 +418,510 @@
       {
         "@language": "en",
         "@value": "Not used for genealogy."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "standards or specifications"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Index to bibliographical material other than itself (e.g., an indexing journal)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "indexes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dictionaries"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "List of items in a collection, such as a collection of books, a collection of art objects, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "catalogs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#5",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "5"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "treaties"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Filmography or other bibliography of moving images."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical reports"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#w",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Texts of decisions of courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "w"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "law reports and digests"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when a work consists of texts of digests of such decisions."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Collection of statistical data on a subject."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "statistics"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for works about statistical methodology."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discography or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discographies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "programmed texts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "legal cases and case notes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#y",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "y"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "yearbooks"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for annual reports, which are administrative overviews of an organization."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Directory or register of persons or corporate bodies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "directories"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for serial biographical dictionaries."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.jfr5-z647"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handbooks"
       }
     ]
   }

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt
@@ -1,168 +1,168 @@
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal articles"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#definition> "Discography or other bibliography of recorded sound."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#definition> "Filmography or other bibliography of moving images."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#definition> "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#notation> "y"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not specified"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/title> "Continuing: nature of entire work"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#definition> "Nature of the entire item is not specified."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#definition> "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#notation> "5"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#definition> "Substantive articles on legal topics, such as those published in law school reviews."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#definition> "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards or specifications"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "encyclopedias"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#notation> "y"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#notation> "6"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts or summaries"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serial biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#definition> "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "programmed texts"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for genealogy."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbook [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/alternative> "MARC21 008/24 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#definition> "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/description> "Indicates the nature of an item if it consists entirely of a certain type of material."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
 <https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#definition> "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#definition> "Collection of statistical data on a subject."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#definition> "Biographical material, whether autobiography, individual biography, or collective biography."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#notation> "v"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when a work consists of texts of digests of such decisions."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#definition> "Texts of decisions of courts or administrative agencies."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#notation> "w"@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "legislation"@en .
 <https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "standards or specifications"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "surveys of literature in a subject area"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for works about statistical methodology."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/description> "Indicates the nature of an item if it consists entirely of a certain type of material."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#definition> "Directory or register of persons or corporate bodies."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "treaties"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/title> "Continuing: nature of entire work"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#definition> "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#definition> "Nature of the entire item is not specified."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#notation> "y" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "law reports and digests"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#definition> "Index to bibliographical material other than itself (e.g., an indexing journal)."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendars"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "reviews"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal cases and case notes [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#definition> "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#definition> "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#definition> "Texts of decisions of courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical reports"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "statistics"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when a work consists of texts of digests of such decisions."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#notation> "5" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#definition> "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not specified"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "directories"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#definition> "Encyclopedia or an encyclopedic treatment of a specific topic."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#definition> "Filmography or other bibliography of moving images."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "discographies"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serial biographical dictionaries."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/2004/02/skos/core#definition> "Collection of statistical data on a subject."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for annual reports, which are administrative overviews of an organization."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#definition> "Discography or other bibliography of recorded sound."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "dictionaries"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#definition> "Substantive articles on legal topics, such as those published in law school reviews."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "encyclopedias"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.html> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#definition> "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbook [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "legal articles"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "programmed texts"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "abstracts or summaries"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmographies"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "theses"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "catalogs"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#definition> "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#v> <http://www.w3.org/2004/02/skos/core#definition> "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#prefLabel> "yearbooks"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#definition> "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#notation> "6" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/alternative> "MARC21 008/24 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#prefLabel> "comics or graphic novels"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#6> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for genealogy."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#a> <http://www.w3.org/2004/02/skos/core#definition> "Abstracts or summaries of other publications."@en .
 <https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/2004/02/skos/core#definition> "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en .
-<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#nx> <http://www.w3.org/2004/02/skos/core#notation> "n" .
 <https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliographies"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#definition> "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "handbooks"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#o> <http://www.w3.org/2004/02/skos/core#definition> "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "indexes"@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#y> <http://www.w3.org/2004/02/skos/core#notation> "y" .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#z> <http://www.w3.org/2004/02/skos/core#definition> "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#h> <http://www.w3.org/2004/02/skos/core#definition> "Biographical material, whether autobiography, individual biography, or collective biography."@en .
+<https://doi.org/10.6069/uwlswd.jfr5-z647#yx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.jfr5-z647> .

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -100,7 +100,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -107,7 +107,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld"/>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -1,65 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">yearbooks</skos:prefLabel>
-    <skos:definition xml:lang="en">Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.</skos:definition>
-    <skos:notation>y</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
+    <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">yearbook [obsolete]</skos:prefLabel>
-    <skos:notation>y</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
-    <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
-    <skos:definition xml:lang="en">Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.</skos:definition>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
-    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
-    <skos:definition xml:lang="en">Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:prefLabel xml:lang="en">standards or specifications</skos:prefLabel>
+    <skos:definition xml:lang="en">Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.</skos:definition>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -69,26 +28,26 @@
     <skos:notation>l</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">abstracts or summaries</skos:prefLabel>
-    <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
-    <skos:definition xml:lang="en">Filmography or other bibliography of moving images.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
+    <skos:definition xml:lang="en">Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.</skos:definition>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
-    <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation>v</skos:notation>
+    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
+    <skos:definition xml:lang="en">Collection of statistical data on a subject.</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -121,12 +80,6 @@
     <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
@@ -135,6 +88,33 @@
     <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
+    <skos:definition xml:lang="en">Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
+    <skos:definition xml:lang="en">Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
+    <skos:notation>z</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
+    <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
+    <skos:notation>m</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
@@ -142,20 +122,26 @@
     <skos:definition xml:lang="en">Nature of the entire item is not specified.</skos:definition>
     <skos:notation>#</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
-    <skos:definition xml:lang="en">List of items in a collection, such as a collection of books, a collection of art objects, etc.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">yearbook [obsolete]</skos:prefLabel>
+    <skos:notation>y</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
-    <skos:definition xml:lang="en">Biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
-    <skos:notation>h</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
+    <skos:definition xml:lang="en">Texts of decisions of courts or administrative agencies.</skos:definition>
+    <skos:notation>w</skos:notation>
+    <skos:scopeNote xml:lang="en">Also used when a work consists of texts of digests of such decisions.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
+    <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -171,27 +157,33 @@
     <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
     <skos:notation>6</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
-    <skos:definition xml:lang="en">Collection of statistical data on a subject.</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
+    <skos:definition xml:lang="en">List of items in a collection, such as a collection of books, a collection of art objects, etc.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
-    <skos:definition xml:lang="en">Texts of decisions of courts or administrative agencies.</skos:definition>
-    <skos:notation>w</skos:notation>
-    <skos:scopeNote xml:lang="en">Also used when a work consists of texts of digests of such decisions.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">yearbooks</skos:prefLabel>
+    <skos:definition xml:lang="en">Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.</skos:definition>
+    <skos:notation>y</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
+    <skos:definition xml:lang="en">The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
+    <skos:notation>t</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -200,32 +192,46 @@
     <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
     <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">standards or specifications</skos:prefLabel>
-    <skos:definition xml:lang="en">Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
+    <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
-    <skos:definition xml:lang="en">Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
+    <skos:definition xml:lang="en">Biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
+    <skos:notation>h</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
-    <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Filmography or other bibliography of moving images.</skos:definition>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
-    <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
-    <skos:definition xml:lang="en">The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
+    <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
+    <skos:prefLabel xml:lang="en">abstracts or summaries</skos:prefLabel>
+    <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -1,72 +1,78 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbooks</skos:prefLabel>
     <skos:definition xml:lang="en">Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.</skos:definition>
-    <skos:notation>y</skos:notation>
+    <skos:notation xml:lang="en">y</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbook [obsolete]</skos:prefLabel>
-    <skos:notation>y</skos:notation>
+    <skos:notation xml:lang="en">y</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
     <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
     <skos:definition xml:lang="en">Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
     <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
     <skos:definition xml:lang="en">Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legislation</skos:prefLabel>
     <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
@@ -74,21 +80,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">abstracts or summaries</skos:prefLabel>
     <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
     <skos:definition xml:lang="en">Filmography or other bibliography of moving images.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
     <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation>v</skos:notation>
+    <skos:notation xml:lang="en">v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -96,7 +102,7 @@
     <dct:title xml:lang="en">Continuing: nature of entire work</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the nature of an item if it consists entirely of a certain type of material.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -107,7 +113,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld"/>
@@ -118,21 +124,21 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">dictionaries</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
     <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound">
@@ -140,21 +146,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Nature of the entire item is not specified.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
     <skos:definition xml:lang="en">List of items in a collection, such as a collection of books, a collection of art objects, etc.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
@@ -162,21 +168,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
     <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
-    <skos:notation>5</skos:notation>
+    <skos:notation xml:lang="en">5</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#6">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
     <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
-    <skos:notation>6</skos:notation>
+    <skos:notation xml:lang="en">6</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of statistical data on a subject.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
@@ -184,48 +190,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
     <skos:definition xml:lang="en">Texts of decisions of courts or administrative agencies.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:notation xml:lang="en">w</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of digests of such decisions.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">encyclopedias</skos:prefLabel>
     <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">standards or specifications</skos:prefLabel>
     <skos:definition xml:lang="en">Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
     <skos:definition xml:lang="en">Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
     <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
     <skos:definition xml:lang="en">The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -1,78 +1,72 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbooks</skos:prefLabel>
     <skos:definition xml:lang="en">Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.</skos:definition>
-    <skos:notation xml:lang="en">y</skos:notation>
+    <skos:notation>y</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbook [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">y</skos:notation>
+    <skos:notation>y</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
     <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
     <skos:definition xml:lang="en">Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
     <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
     <skos:definition xml:lang="en">Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legislation</skos:prefLabel>
     <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
@@ -80,21 +74,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">abstracts or summaries</skos:prefLabel>
     <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
     <skos:definition xml:lang="en">Filmography or other bibliography of moving images.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
     <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">v</skos:notation>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -102,7 +96,7 @@
     <dct:title xml:lang="en">Continuing: nature of entire work</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the nature of an item if it consists entirely of a certain type of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -113,7 +107,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.jsonld"/>
@@ -124,21 +118,21 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">dictionaries</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
     <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound">
@@ -146,21 +140,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Nature of the entire item is not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
     <skos:definition xml:lang="en">List of items in a collection, such as a collection of books, a collection of art objects, etc.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
@@ -168,21 +162,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
     <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
-    <skos:notation xml:lang="en">5</skos:notation>
+    <skos:notation>5</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#6">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
     <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
-    <skos:notation xml:lang="en">6</skos:notation>
+    <skos:notation>6</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of statistical data on a subject.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
@@ -190,48 +184,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
     <skos:definition xml:lang="en">Texts of decisions of courts or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of digests of such decisions.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">encyclopedias</skos:prefLabel>
     <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">standards or specifications</skos:prefLabel>
     <skos:definition xml:lang="en">Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
     <skos:definition xml:lang="en">Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
     <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
     <skos:definition xml:lang="en">The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf
@@ -1,78 +1,72 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#y">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbooks</skos:prefLabel>
     <skos:definition xml:lang="en">Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor.</skos:definition>
-    <skos:notation xml:lang="en">y</skos:notation>
+    <skos:notation>y</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for annual reports, which are administrative overviews of an organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">handbooks</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#yx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">yearbook [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">y</skos:notation>
+    <skos:notation>y</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal articles</skos:prefLabel>
     <skos:definition xml:lang="en">Substantive articles on legal topics, such as those published in law school reviews.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">surveys of literature in a subject area</skos:prefLabel>
     <skos:definition xml:lang="en">Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">theses</skos:prefLabel>
     <skos:definition xml:lang="en">Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">bibliographies</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">discographies</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">treaties</skos:prefLabel>
     <skos:definition xml:lang="en">Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legislation</skos:prefLabel>
     <skos:definition xml:lang="en">Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#a">
@@ -80,21 +74,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">abstracts or summaries</skos:prefLabel>
     <skos:definition xml:lang="en">Abstracts or summaries of other publications.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">filmographies</skos:prefLabel>
     <skos:definition xml:lang="en">Filmography or other bibliography of moving images.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes</skos:prefLabel>
     <skos:definition xml:lang="en">Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">v</skos:notation>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -102,7 +96,7 @@
     <dct:title xml:lang="en">Continuing: nature of entire work</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the nature of an item if it consists entirely of a certain type of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -124,21 +118,21 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">dictionaries</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">programmed texts</skos:prefLabel>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">directories</skos:prefLabel>
     <skos:definition xml:lang="en">Directory or register of persons or corporate bodies.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serial biographical dictionaries.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#pound">
@@ -146,21 +140,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Nature of the entire item is not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">catalogs</skos:prefLabel>
     <skos:definition xml:lang="en">List of items in a collection, such as a collection of books, a collection of art objects, etc.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biographical material, whether autobiography, individual biography, or collective biography.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for genealogy.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#5">
@@ -168,21 +162,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">calendars</skos:prefLabel>
     <skos:definition xml:lang="en">Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc.</skos:definition>
-    <skos:notation xml:lang="en">5</skos:notation>
+    <skos:notation>5</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#6">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">comics or graphic novels</skos:prefLabel>
     <skos:definition xml:lang="en">Instances of "sequential art" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple "panels" per page) presented concurrently but meant to be "read" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story.</skos:definition>
-    <skos:notation xml:lang="en">6</skos:notation>
+    <skos:notation>6</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">statistics</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of statistical data on a subject.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for works about statistical methodology.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#w">
@@ -190,48 +184,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">law reports and digests</skos:prefLabel>
     <skos:definition xml:lang="en">Texts of decisions of courts or administrative agencies.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
     <skos:scopeNote xml:lang="en">Also used when a work consists of texts of digests of such decisions.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">legal cases and case notes [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">encyclopedias</skos:prefLabel>
     <skos:definition xml:lang="en">Encyclopedia or an encyclopedic treatment of a specific topic.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">standards or specifications</skos:prefLabel>
     <skos:definition xml:lang="en">Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">reviews</skos:prefLabel>
     <skos:definition xml:lang="en">Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.).</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">indexes</skos:prefLabel>
     <skos:definition xml:lang="en">Index to bibliographical material other than itself (e.g., an indexing journal).</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.jfr5-z647#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.jfr5-z647"/>
     <skos:prefLabel xml:lang="en">technical reports</skos:prefLabel>
     <skos:definition xml:lang="en">The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl
+++ b/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.ttl
@@ -6,176 +6,176 @@
 <https://doi.org/10.6069/uwlswd.jfr5-z647#5> a skos:Concept ;
     skos:definition "Published systems of organizing days. These may be academic calendars or almanacs, calendars published by bodies, such as labor organizations, library associations, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "5"@en ;
+    skos:notation "5" ;
     skos:prefLabel "calendars"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#6> a skos:Concept ;
     skos:definition "Instances of \"sequential art\" in which a story (whether fact or fiction) is told primarily through a set of images (often in the form of multiple \"panels\" per page) presented concurrently but meant to be \"read\" sequentially by the viewer. The accompanying narrative and/or dialog text, when it occurs, works integrally with the images to tell the story."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "6"@en ;
+    skos:notation "6" ;
     skos:prefLabel "comics or graphic novels"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#a> a skos:Concept ;
     skos:definition "Abstracts or summaries of other publications."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "abstracts or summaries"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#b> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bibliographies"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#c> a skos:Concept ;
     skos:definition "List of items in a collection, such as a collection of books, a collection of art objects, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "catalogs"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#d> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "dictionaries"@en ;
     skos:scopeNote "Also includes glossaries or gazetteers. Not used for concordances or serial biographical dictionaries."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#e> a skos:Concept ;
     skos:definition "Encyclopedia or an encyclopedic treatment of a specific topic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "encyclopedias"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#f> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "handbooks"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#g> a skos:Concept ;
     skos:definition "Substantive articles on legal topics, such as those published in law school reviews."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "legal articles"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#h> a skos:Concept ;
     skos:definition "Biographical material, whether autobiography, individual biography, or collective biography."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "biography"@en ;
     skos:scopeNote "Not used for genealogy."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#i> a skos:Concept ;
     skos:definition "Index to bibliographical material other than itself (e.g., an indexing journal)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "indexes"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#k> a skos:Concept ;
     skos:definition "Discography or other bibliography of recorded sound."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "discographies"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#l> a skos:Concept ;
     skos:definition "Full or partial texts of enactments of legislative bodies or texts of rules and regulations issued by executive or administrative agencies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "legislation"@en ;
     skos:scopeNote "Also used when a work consists of texts of rules and regulations issued by executive or administrative agencies."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#m> a skos:Concept ;
     skos:definition "Thesis, dissertation, or work identified as having been created to satisfy the requirements for an academic certification or degree."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "theses"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#n> a skos:Concept ;
     skos:definition "Authored surveys that summarize what has been published about a subject. Usually has a list of references either in the body of the work or as a bibliography."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "surveys of literature in a subject area"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#nx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "legal cases and case notes [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#o> a skos:Concept ;
     skos:definition "Critical reviews of published or performed works (e.g., books, films, sound recordings, theater, etc.)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "reviews"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#p> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "programmed texts"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#pound> a skos:Concept ;
     skos:definition "Nature of the entire item is not specified."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not specified"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#q> a skos:Concept ;
     skos:definition "Filmography or other bibliography of moving images."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "filmographies"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#r> a skos:Concept ;
     skos:definition "Directory or register of persons or corporate bodies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "directories"@en ;
     skos:scopeNote "Not used for serial biographical dictionaries."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#s> a skos:Concept ;
     skos:definition "Collection of statistical data on a subject."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "statistics"@en ;
     skos:scopeNote "Not used for works about statistical methodology."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#t> a skos:Concept ;
     skos:definition "The result of scientific investigation or technical development, testing, or evaluation, presented in a form suitable for dissemination to the technical community."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "technical reports"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#u> a skos:Concept ;
     skos:definition "Either an international, national, or industry standard or a specification which gives a precise statement of a process or service requirement."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "standards or specifications"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#v> a skos:Concept ;
     skos:definition "Discussions, such as those in the case comments section of law school reviews, of particular legal cases that have been decided by, or that are pending before, courts or administrative agencies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "v"@en ;
+    skos:notation "v" ;
     skos:prefLabel "legal cases and case notes"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#w> a skos:Concept ;
     skos:definition "Texts of decisions of courts or administrative agencies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "law reports and digests"@en ;
     skos:scopeNote "Also used when a work consists of texts of digests of such decisions."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#y> a skos:Concept ;
     skos:definition "Reference publication issued on an annual or less frequent basis that contains articles summarizing the accomplishments or events of a particular year within a specific discipline or area of endeavor."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "y"@en ;
+    skos:notation "y" ;
     skos:prefLabel "yearbooks"@en ;
     skos:scopeNote "Not used for annual reports, which are administrative overviews of an organization."@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#yx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "y"@en ;
+    skos:notation "y" ;
     skos:prefLabel "yearbook [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647#z> a skos:Concept ;
     skos:definition "Treaties or accords negotiated between two or more parties to settle a disagreement, establish a relationship, grant rights, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.jfr5-z647> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "treaties"@en .
 
 <https://doi.org/10.6069/uwlswd.jfr5-z647> a skos:ConceptScheme ;
@@ -192,12 +192,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_nature_of_entire_work/continuing_nature_of_entire_work.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: nature of entire work"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#a">
                         <td id="a">
@@ -370,7 +370,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#a">
                         <td>
@@ -429,7 +429,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#b">
                         <td>
@@ -478,7 +478,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#c">
                         <td>
@@ -518,7 +518,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#d">
                         <td>
@@ -558,7 +558,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#e">
                         <td>
@@ -598,7 +598,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#f">
                         <td>
@@ -638,7 +638,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#g">
                         <td>
@@ -678,7 +678,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#h">
                         <td>
@@ -718,7 +718,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#i">
                         <td>
@@ -758,7 +758,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#j">
                         <td>
@@ -798,7 +798,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#k">
                         <td>
@@ -838,7 +838,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#l">
                         <td>
@@ -878,7 +878,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
                         <td>
@@ -927,7 +927,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#u">
                         <td>
@@ -977,7 +977,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.084w-3778#z">
                         <td>
@@ -1010,100 +1010,19 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;arabic&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;japanese&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
-    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
-    &lt;dct:title xml:lang="en"&gt;Continuing: original alphabet or script of title&lt;/dct:title&gt;
-    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
-    &lt;dct:description xml:lang="en"&gt;Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
-    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
-    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
-    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
-    &lt;dc:language&gt;en&lt;/dc:language&gt;
-    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html"/&gt;
-    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;thai&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;hebrew&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;extended roman&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes diacritics and special characters.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;cyrillic&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;tamil&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Original alphabet of the title is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;greek&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chinese&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Also used when the title incorporates words from more than one alphabet or script.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;hebrew&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1111,25 +1030,106 @@
     &lt;skos:prefLabel xml:lang="en"&gt;basic roman&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Includes no diacritics or special characters.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;korean&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;devanagari&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;no alphabet or script given/no key title&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;tamil&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Continuing: original alphabet or script of title&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html"/&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;greek&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;extended roman&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes diacritics and special characters.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chinese&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Original alphabet of the title is unknown.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;thai&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;arabic&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;korean&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;cyrillic&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;japanese&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1144,82 +1144,82 @@
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; a skos:Concept ;
     skos:definition "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "basic roman"@en ;
     skos:scopeNote "Includes no diacritics or special characters."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; a skos:Concept ;
     skos:definition "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "extended roman"@en ;
     skos:scopeNote "Includes diacritics and special characters."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "cyrillic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "japanese"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "chinese"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "arabic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "greek"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "hebrew"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "thai"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "devanagari"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "korean"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "tamil"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no alphabet or script given/no key title"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; a skos:Concept ;
     skos:definition "Original alphabet of the title is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; a skos:Concept ;
     skos:definition "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en ;
     skos:scopeNote "Also used when the title incorporates words from more than one alphabet or script."@en .
 
@@ -1237,108 +1237,108 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: original alphabet or script of title"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "arabic"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cyrillic"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "greek"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no alphabet or script given/no key title"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "tamil"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for continuing resources expressed using RDF"@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chinese"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "basic roman"@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "extended roman"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when the title incorporates words from more than one alphabet or script."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes diacritics and special characters."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "devanagari"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes no diacritics or special characters."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no alphabet or script given/no key title"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "korean"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hebrew"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "extended roman"@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is unknown."@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "thai"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes diacritics and special characters."@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hebrew"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also used when the title incorporates words from more than one alphabet or script."@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "arabic"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "greek"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes no diacritics or special characters."@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: original alphabet or script of title"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based."@en .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
 &lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "japanese"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: original alphabet or script of title"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "tamil"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "devanagari"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "korean"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.084w-3778#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cyrillic"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
@@ -1356,7 +1356,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -1364,145 +1363,6 @@
       {
         "@language": "en",
         "@value": "korean"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "thai"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "extended roman"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes diacritics and special characters."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "tamil"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when the title incorporates words from more than one alphabet or script."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "arabic"
       }
     ]
   },
@@ -1524,7 +1384,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -1538,75 +1397,6 @@
       {
         "@language": "en",
         "@value": "Includes no diacritics or special characters."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "devanagari"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "japanese"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cyrillic"
       }
     ]
   },
@@ -1679,7 +1469,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1708,17 +1498,18 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#g",
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -1729,60 +1520,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "greek"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no alphabet or script given/no key title"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "hebrew"
+        "@value": "cyrillic"
       }
     ]
   },
@@ -1798,7 +1542,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -1806,6 +1549,72 @@
       {
         "@language": "en",
         "@value": "chinese"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "thai"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "devanagari"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "hebrew"
       }
     ]
   },
@@ -1827,7 +1636,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -1835,6 +1643,184 @@
       {
         "@language": "en",
         "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "arabic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "extended roman"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes diacritics and special characters."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "greek"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "tamil"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when the title incorporates words from more than one alphabet or script."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "japanese"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no alphabet or script given/no key title"
       }
     ]
   }

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld
@@ -11,7 +11,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -19,145 +18,6 @@
       {
         "@language": "en",
         "@value": "korean"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "thai"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "extended roman"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes diacritics and special characters."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "tamil"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also used when the title incorporates words from more than one alphabet or script."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "arabic"
       }
     ]
   },
@@ -179,7 +39,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -193,75 +52,6 @@
       {
         "@language": "en",
         "@value": "Includes no diacritics or special characters."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "devanagari"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "japanese"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cyrillic"
       }
     ]
   },
@@ -334,7 +124,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -363,17 +153,18 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#g",
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
@@ -384,60 +175,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "greek"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no alphabet or script given/no key title"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "hebrew"
+        "@value": "cyrillic"
       }
     ]
   },
@@ -453,7 +197,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -461,6 +204,72 @@
       {
         "@language": "en",
         "@value": "chinese"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "thai"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "devanagari"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "hebrew"
       }
     ]
   },
@@ -482,7 +291,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -490,6 +298,184 @@
       {
         "@language": "en",
         "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "arabic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "extended roman"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes diacritics and special characters."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "greek"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "tamil"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also used when the title incorporates words from more than one alphabet or script."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "japanese"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.084w-3778#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.084w-3778"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no alphabet or script given/no key title"
       }
     ]
   }

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt
@@ -1,89 +1,89 @@
-<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "arabic"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
 <https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "cyrillic"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/description> "Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "greek"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl> .
+<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no alphabet or script given/no key title"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "tamil"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for continuing resources expressed using RDF"@en .
 <https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "chinese"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
 <https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "basic roman"@en .
 <https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "extended roman"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld> .
-<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when the title incorporates words from more than one alphabet or script."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes diacritics and special characters."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "devanagari"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes no diacritics or special characters."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
 <https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html> .
-<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no alphabet or script given/no key title"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "korean"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is unknown."@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "hebrew"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "extended roman"@en .
 <https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is unknown."@en .
 <https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "thai"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
+<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes diacritics and special characters."@en .
 <https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "hebrew"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also used when the title incorporates words from more than one alphabet or script."@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl> .
+<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "arabic"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.084w-3778#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "greek"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes no diacritics or special characters."@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/title> "Continuing: original alphabet or script of title"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld> .
+<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.084w-3778#a> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/description> "Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based."@en .
 <https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
 <https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "japanese"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/title> "Continuing: original alphabet or script of title"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "tamil"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.084w-3778#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf> .
+<https://doi.org/10.6069/uwlswd.084w-3778#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "devanagari"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.084w-3778#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.084w-3778> .
+<https://doi.org/10.6069/uwlswd.084w-3778#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "korean"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.084w-3778#b> <http://www.w3.org/2004/02/skos/core#definition> "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.084w-3778> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.084w-3778#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.084w-3778> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.084w-3778#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "cyrillic"@en .

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -22,7 +22,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -1,22 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">arabic</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">japanese</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -24,7 +18,7 @@
     <dct:title xml:lang="en">Continuing: original alphabet or script of title</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -46,13 +40,13 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">thai</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">hebrew</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -60,38 +54,38 @@
     <skos:prefLabel xml:lang="en">extended roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes diacritics and special characters.</skos:scopeNote>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">cyrillic</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">tamil</skos:prefLabel>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">greek</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">chinese</skos:prefLabel>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -99,7 +93,7 @@
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.</skos:definition>
     <skos:scopeNote xml:lang="en">Also used when the title incorporates words from more than one alphabet or script.</skos:scopeNote>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -107,24 +101,24 @@
     <skos:prefLabel xml:lang="en">basic roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes no diacritics or special characters.</skos:scopeNote>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">korean</skos:prefLabel>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">devanagari</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">no alphabet or script given/no key title</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -1,22 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">arabic</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">japanese</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -24,7 +18,7 @@
     <dct:title xml:lang="en">Continuing: original alphabet or script of title</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,7 +29,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld"/>
@@ -46,13 +40,13 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">thai</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">hebrew</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -60,38 +54,38 @@
     <skos:prefLabel xml:lang="en">extended roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes diacritics and special characters.</skos:scopeNote>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">cyrillic</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">tamil</skos:prefLabel>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">greek</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">chinese</skos:prefLabel>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -99,7 +93,7 @@
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.</skos:definition>
     <skos:scopeNote xml:lang="en">Also used when the title incorporates words from more than one alphabet or script.</skos:scopeNote>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -107,24 +101,24 @@
     <skos:prefLabel xml:lang="en">basic roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes no diacritics or special characters.</skos:scopeNote>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">korean</skos:prefLabel>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">devanagari</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">no alphabet or script given/no key title</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -1,16 +1,22 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">arabic</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">japanese</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -18,7 +24,7 @@
     <dct:title xml:lang="en">Continuing: original alphabet or script of title</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the original alphabet or script of the language of the title on the source item upon which the key title is based.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -29,7 +35,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld"/>
@@ -40,13 +46,13 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">thai</skos:prefLabel>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">hebrew</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -54,38 +60,38 @@
     <skos:prefLabel xml:lang="en">extended roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes diacritics and special characters.</skos:scopeNote>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">cyrillic</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">tamil</skos:prefLabel>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">greek</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">chinese</skos:prefLabel>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -93,7 +99,7 @@
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.</skos:definition>
     <skos:scopeNote xml:lang="en">Also used when the title incorporates words from more than one alphabet or script.</skos:scopeNote>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -101,24 +107,24 @@
     <skos:prefLabel xml:lang="en">basic roman</skos:prefLabel>
     <skos:definition xml:lang="en">Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes no diacritics or special characters.</skos:scopeNote>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">korean</skos:prefLabel>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">devanagari</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
     <skos:prefLabel xml:lang="en">no alphabet or script given/no key title</skos:prefLabel>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -29,7 +29,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.jsonld"/>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf
@@ -1,16 +1,50 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">arabic</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.</skos:definition>
+    <skos:scopeNote xml:lang="en">Also used when the title incorporates words from more than one alphabet or script.</skos:scopeNote>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">japanese</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:prefLabel xml:lang="en">hebrew</skos:prefLabel>
+    <skos:notation>h</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
+    <skos:prefLabel xml:lang="en">basic roman</skos:prefLabel>
+    <skos:definition xml:lang="en">Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.</skos:definition>
+    <skos:scopeNote xml:lang="en">Includes no diacritics or special characters.</skos:scopeNote>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
+    <skos:prefLabel xml:lang="en">devanagari</skos:prefLabel>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
+    <skos:prefLabel xml:lang="en">no alphabet or script given/no key title</skos:prefLabel>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
+    <skos:prefLabel xml:lang="en">tamil</skos:prefLabel>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -36,17 +70,11 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#i">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">thai</skos:prefLabel>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#h">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">hebrew</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:prefLabel xml:lang="en">greek</skos:prefLabel>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -56,17 +84,11 @@
     <skos:scopeNote xml:lang="en">Includes diacritics and special characters.</skos:scopeNote>
     <skos:notation>b</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">cyrillic</skos:prefLabel>
-    <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">tamil</skos:prefLabel>
-    <skos:notation>l</skos:notation>
+    <skos:prefLabel xml:lang="en">chinese</skos:prefLabel>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -75,33 +97,17 @@
     <skos:definition xml:lang="en">Original alphabet of the title is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#g">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">greek</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:prefLabel xml:lang="en">thai</skos:prefLabel>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#e">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">chinese</skos:prefLabel>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil.</skos:definition>
-    <skos:scopeNote xml:lang="en">Also used when the title incorporates words from more than one alphabet or script.</skos:scopeNote>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">basic roman</skos:prefLabel>
-    <skos:definition xml:lang="en">Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa.</skos:definition>
-    <skos:scopeNote xml:lang="en">Includes no diacritics or special characters.</skos:scopeNote>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">arabic</skos:prefLabel>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -109,16 +115,16 @@
     <skos:prefLabel xml:lang="en">korean</skos:prefLabel>
     <skos:notation>k</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#j">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">devanagari</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:prefLabel xml:lang="en">cyrillic</skos:prefLabel>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#pound">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.084w-3778#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.084w-3778"/>
-    <skos:prefLabel xml:lang="en">no alphabet or script given/no key title</skos:prefLabel>
-    <skos:notation>#</skos:notation>
+    <skos:prefLabel xml:lang="en">japanese</skos:prefLabel>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl
+++ b/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.ttl
@@ -6,82 +6,82 @@
 <https://doi.org/10.6069/uwlswd.084w-3778#a> a skos:Concept ;
     skos:definition "Original alphabet of the title is the Roman alphabet. Languages that are usually associated include: Basque, English, Latin, Welsh, and many languages of Central and Southern Africa."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "basic roman"@en ;
     skos:scopeNote "Includes no diacritics or special characters."@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#b> a skos:Concept ;
     skos:definition "Original alphabet of the title is a Roman alphabet language. Most western European lanuages, with the major exception of English, fall into this group."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "extended roman"@en ;
     skos:scopeNote "Includes diacritics and special characters."@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#c> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "cyrillic"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#d> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "japanese"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#e> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "chinese"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#f> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "arabic"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#g> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "greek"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#h> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "hebrew"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#i> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "thai"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#j> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "devanagari"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#k> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "korean"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#l> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "tamil"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#pound> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no alphabet or script given/no key title"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#u> a skos:Concept ;
     skos:definition "Original alphabet of the title is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.084w-3778#z> a skos:Concept ;
     skos:definition "Original alphabet or script of title other than basic Roman, extended Roman, cyrillic, Japanese, Chinese, Arabic, Greek, Hebrew, Thai, Devanagari, Korean, or Tamil."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.084w-3778> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en ;
     skos:scopeNote "Also used when the title incorporates words from more than one alphabet or script."@en .
 
@@ -99,12 +99,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_original_alphabet_or_script_of_title/continuing_original_alphabet_or_script_of_title.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: original alphabet or script of title"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_regularity/continuing_regularity.html
+++ b/008/continuing_regularity/continuing_regularity.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903#n">
                         <td id="n">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903#n">
                         <td>
@@ -425,7 +425,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903#r">
                         <td>
@@ -486,7 +486,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903#u">
                         <td>
@@ -535,7 +535,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">x</td>
+                        <td property="skos:notation">x</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.npns-e903#x">
                         <td>
@@ -573,23 +573,7 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Regularity of the item is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;regular&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended regular publishing pattern.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;completely irregular&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intentionally irregular.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used when the frequency is known to be intentionally irregular.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;x&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -597,23 +581,39 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: regularity&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/19 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the intended regularity of an item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended regular publishing pattern.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;completely irregular&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intentionally irregular.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used when the frequency is known to be intentionally irregular.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;x&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -621,7 +621,7 @@
     &lt;skos:prefLabel xml:lang="en"&gt;normalized irregular&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Predictable irregularity pattern.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -636,27 +636,27 @@
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; a skos:Concept ;
     skos:definition "Predictable irregularity pattern."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "normalized irregular"@en ;
     skos:scopeNote "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; a skos:Concept ;
     skos:definition "Intended regular publishing pattern."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "regular"@en ;
     skos:scopeNote "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; a skos:Concept ;
     skos:definition "Regularity of the item is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; a skos:Concept ;
     skos:definition "Intentionally irregular."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "completely irregular"@en ;
     skos:scopeNote "Used when the frequency is known to be intentionally irregular."@en .
 
@@ -674,78 +674,78 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: regularity"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
             <pre>&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended regular publishing pattern."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used when the frequency is known to be intentionally irregular."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intentionally irregular."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the intended regularity of an item."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/19 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
 &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: regularity"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the intended regularity of an item."@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended regular publishing pattern."@en .
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Regularity of the item is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intentionally irregular."@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x" .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;https://schema.org/version&gt; "1-1-0" .
 &lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Predictable irregularity pattern."@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "normalized irregular"@en .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "completely irregular"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
 &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "normalized irregular"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#n&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/19 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used when the frequency is known to be intentionally irregular."@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903#x&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "completely irregular"@en .
+&lt;https://doi.org/10.6069/uwlswd.npns-e903&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#x",
+    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intentionally irregular."
+        "@value": "Predictable irregularity pattern."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -755,20 +755,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "x"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "completely irregular"
+        "@value": "normalized irregular"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used when the frequency is known to be intentionally irregular."
+        "@value": "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."
       }
     ]
   },
@@ -790,7 +789,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -825,7 +823,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -833,41 +830,6 @@
       {
         "@language": "en",
         "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Predictable irregularity pattern."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.npns-e903"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "normalized irregular"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."
       }
     ]
   },
@@ -940,7 +902,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -969,12 +931,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#x",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intentionally irregular."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.npns-e903"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "completely irregular"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used when the frequency is known to be intentionally irregular."
       }
     ]
   }

--- a/008/continuing_regularity/continuing_regularity.jsonld
+++ b/008/continuing_regularity/continuing_regularity.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#x",
+    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intentionally irregular."
+        "@value": "Predictable irregularity pattern."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,20 +17,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "x"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "completely irregular"
+        "@value": "normalized irregular"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used when the frequency is known to be intentionally irregular."
+        "@value": "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."
       }
     ]
   },
@@ -52,7 +51,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -87,7 +85,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -95,41 +92,6 @@
       {
         "@language": "en",
         "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Predictable irregularity pattern."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.npns-e903"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "normalized irregular"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."
       }
     ]
   },
@@ -202,7 +164,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -231,12 +193,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.npns-e903#x",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intentionally irregular."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.npns-e903"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "completely irregular"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used when the frequency is known to be intentionally irregular."
       }
     ]
   }

--- a/008/continuing_regularity/continuing_regularity.nt
+++ b/008/continuing_regularity/continuing_regularity.nt
@@ -1,45 +1,45 @@
 <https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#definition> "Intended regular publishing pattern."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used when the frequency is known to be intentionally irregular."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#definition> "Intentionally irregular."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/description> "Indicates the intended regularity of an item."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/alternative> "MARC21 008/19 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf> .
-<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
 <https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/title> "Continuing: regularity"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#notation> "x"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/description> "Indicates the intended regularity of an item."@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#definition> "Intended regular publishing pattern."@en .
 <https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#definition> "Regularity of the item is unknown."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#definition> "Intentionally irregular."@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl> .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#notation> "x" .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <https://schema.org/version> "1-1-0" .
 <https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#definition> "Predictable irregularity pattern."@en .
-<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "normalized irregular"@en .
-<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#prefLabel> "completely irregular"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld> .
+<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
 <https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html> .
+<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "normalized irregular"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.npns-e903#n> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/terms/alternative> "MARC21 008/19 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.npns-e903> .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used when the frequency is known to be intentionally irregular."@en .
+<https://doi.org/10.6069/uwlswd.npns-e903#x> <http://www.w3.org/2004/02/skos/core#prefLabel> "completely irregular"@en .
+<https://doi.org/10.6069/uwlswd.npns-e903> <http://purl.org/dc/elements/1.1/language> "en" .

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Regularity of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -19,7 +13,7 @@
     <skos:prefLabel xml:lang="en">regular</skos:prefLabel>
     <skos:definition xml:lang="en">Intended regular publishing pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.</skos:scopeNote>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -27,7 +21,7 @@
     <skos:prefLabel xml:lang="en">completely irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Intentionally irregular.</skos:definition>
     <skos:scopeNote xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:scopeNote>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -35,7 +29,7 @@
     <dct:title xml:lang="en">Continuing: regularity</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/19 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the intended regularity of an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -46,7 +40,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld"/>
@@ -59,6 +53,6 @@
     <skos:prefLabel xml:lang="en">normalized irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Predictable irregularity pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation.</skos:scopeNote>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -33,7 +33,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -1,27 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Regularity of the item is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
-    <skos:prefLabel xml:lang="en">regular</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended regular publishing pattern.</skos:definition>
-    <skos:scopeNote xml:lang="en">This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.</skos:scopeNote>
-    <skos:notation>r</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
-    <skos:prefLabel xml:lang="en">completely irregular</skos:prefLabel>
-    <skos:definition xml:lang="en">Intentionally irregular.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:scopeNote>
-    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -46,6 +36,22 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
+    <skos:prefLabel xml:lang="en">regular</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended regular publishing pattern.</skos:definition>
+    <skos:scopeNote xml:lang="en">This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.</skos:scopeNote>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
+    <skos:prefLabel xml:lang="en">completely irregular</skos:prefLabel>
+    <skos:definition xml:lang="en">Intentionally irregular.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:scopeNote>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -40,7 +40,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld"/>

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Regularity of the item is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -13,7 +19,7 @@
     <skos:prefLabel xml:lang="en">regular</skos:prefLabel>
     <skos:definition xml:lang="en">Intended regular publishing pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.</skos:scopeNote>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -21,7 +27,7 @@
     <skos:prefLabel xml:lang="en">completely irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Intentionally irregular.</skos:definition>
     <skos:scopeNote xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:scopeNote>
-    <skos:notation>x</skos:notation>
+    <skos:notation xml:lang="en">x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -29,7 +35,7 @@
     <dct:title xml:lang="en">Continuing: regularity</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/19 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the intended regularity of an item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -40,7 +46,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.jsonld"/>
@@ -53,6 +59,6 @@
     <skos:prefLabel xml:lang="en">normalized irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Predictable irregularity pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation.</skos:scopeNote>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_regularity/continuing_regularity.rdf
+++ b/008/continuing_regularity/continuing_regularity.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.npns-e903"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Regularity of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -19,7 +13,7 @@
     <skos:prefLabel xml:lang="en">regular</skos:prefLabel>
     <skos:definition xml:lang="en">Intended regular publishing pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties.</skos:scopeNote>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903#x">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -27,7 +21,7 @@
     <skos:prefLabel xml:lang="en">completely irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Intentionally irregular.</skos:definition>
     <skos:scopeNote xml:lang="en">Used when the frequency is known to be intentionally irregular.</skos:scopeNote>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.npns-e903">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -35,7 +29,7 @@
     <dct:title xml:lang="en">Continuing: regularity</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/19 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the intended regularity of an item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -59,6 +53,6 @@
     <skos:prefLabel xml:lang="en">normalized irregular</skos:prefLabel>
     <skos:definition xml:lang="en">Predictable irregularity pattern.</skos:definition>
     <skos:scopeNote xml:lang="en">Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation.</skos:scopeNote>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_regularity/continuing_regularity.ttl
+++ b/008/continuing_regularity/continuing_regularity.ttl
@@ -6,27 +6,27 @@
 <https://doi.org/10.6069/uwlswd.npns-e903#n> a skos:Concept ;
     skos:definition "Predictable irregularity pattern."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.npns-e903> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "normalized irregular"@en ;
     skos:scopeNote "Used, for example, when the publishing pattern intentionally deviates from a standard pattern (example: Monthly, except July and Aug) or to accommodate an annual cumulation."@en .
 
 <https://doi.org/10.6069/uwlswd.npns-e903#r> a skos:Concept ;
     skos:definition "Intended regular publishing pattern."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.npns-e903> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "regular"@en ;
     skos:scopeNote "This may be determined from information on the piece or by examining the publishing pattern. Thus, use this pattern if an item states that it is to be issued, for example, bimonthly, even though the publishing pattern is known to have occasional variations due to publishing difficulties."@en .
 
 <https://doi.org/10.6069/uwlswd.npns-e903#u> a skos:Concept ;
     skos:definition "Regularity of the item is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.npns-e903> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.npns-e903#x> a skos:Concept ;
     skos:definition "Intentionally irregular."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.npns-e903> ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "completely irregular"@en ;
     skos:scopeNote "Used when the frequency is known to be intentionally irregular."@en .
 
@@ -44,12 +44,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_regularity/continuing_regularity.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: regularity"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
                         <td id="d">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
                         <td>
@@ -418,7 +418,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
                         <td>
@@ -470,7 +470,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
                         <td>
@@ -529,7 +529,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#j">
                         <td>
@@ -588,7 +588,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
                         <td>
@@ -638,7 +638,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#m">
                         <td>
@@ -701,7 +701,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#n">
                         <td>
@@ -752,7 +752,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
                         <td>
@@ -812,7 +812,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#pound">
                         <td>
@@ -872,7 +872,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#r">
                         <td>
@@ -932,7 +932,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
                         <td>
@@ -992,7 +992,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#t">
                         <td>
@@ -1050,7 +1050,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">w</td>
+                        <td property="skos:notation">w</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
                         <td>
@@ -1090,114 +1090,91 @@
     &lt;dct:title xml:lang="en"&gt;Continuing: type of continuing resource&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/21 values for continuing resources expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the type of continuing resource.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;newspaper&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;blog&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Blog content may be written or collected by the site owner, or contributed by users.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;newsletter&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;updating loose-leaf&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;directory&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;updating web site&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Web site that is updated.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;w&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;updating database&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;periodical&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;repository&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;monographic series&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for any title that is a series, regardless of its treatment.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;magazine&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;updating database&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;directory&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;newsletter&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;repository&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;newspaper&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;monographic series&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for any title that is a series, regardless of its treatment.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;journal&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Journals can be print or digital.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#pound"&gt;
@@ -1205,8 +1182,31 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Used for yearbooks and annual reports.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;blog&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Blog content may be written or collected by the site owner, or contributed by users.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;periodical&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Can be print or digital.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;updating loose-leaf&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1221,87 +1221,87 @@
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; a skos:Concept ;
     skos:definition "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "updating database"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; a skos:Concept ;
     skos:definition "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "magazine"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; a skos:Concept ;
     skos:definition "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "blog"@en ;
     skos:scopeNote "Blog content may be written or collected by the site owner, or contributed by users."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; a skos:Concept ;
     skos:definition "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "journal"@en ;
     skos:scopeNote "Journals can be print or digital."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; a skos:Concept ;
     skos:definition "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "updating loose-leaf"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; a skos:Concept ;
     skos:definition "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "monographic series"@en ;
     skos:scopeNote "Used for any title that is a series, regardless of its treatment."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; a skos:Concept ;
     skos:definition "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "newspaper"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; a skos:Concept ;
     skos:definition "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "periodical"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; a skos:Concept ;
     skos:definition "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en ;
     skos:scopeNote "Used for yearbooks and annual reports."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; a skos:Concept ;
     skos:definition "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "repository"@en ;
     skos:scopeNote "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; a skos:Concept ;
     skos:definition "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "newsletter"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; a skos:Concept ;
     skos:definition "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "directory"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; a skos:Concept ;
     skos:definition "Web site that is updated."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "updating web site"@en ;
     skos:scopeNote "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
 
@@ -1319,129 +1319,129 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Continuing: type of continuing resource"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newspaper"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating web site"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Blog content may be written or collected by the site owner, or contributed by users."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/21 values for continuing resources expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for any title that is a series, regardless of its treatment."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "periodical"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "journal"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Journals can be print or digital."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating loose-leaf"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for yearbooks and annual reports."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newsletter"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "blog"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of continuing resource."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "monographic series"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "repository"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Web site that is updated."@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directory"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: type of continuing resource"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magazine"@en .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "directory"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newsletter"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating database"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of continuing resource."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for any title that is a series, regardless of its treatment."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "journal"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/21 values for continuing resources expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "repository"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating web site"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Can be print or digital."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "blog"@en .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld&gt; .
 &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Blog content may be written or collected by the site owner, or contributed by users."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#j&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Journals can be print or digital."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "newspaper"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/title&gt; "Continuing: type of continuing resource"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "monographic series"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating loose-leaf"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magazine"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "updating database"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#w&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "periodical"@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for yearbooks and annual reports."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.62zz-1534&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#pound",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#l",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."
+        "@value": "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1451,20 +1451,205 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "l"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "none of the following"
+        "@value": "updating loose-leaf"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "periodical"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used for yearbooks and annual reports."
+        "@value": "Can be print or digital."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "repository"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "blog"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Blog content may be written or collected by the site owner, or contributed by users."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "newspaper"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magazine"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "journal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Journals can be print or digital."
       }
     ]
   },
@@ -1486,7 +1671,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -1494,35 +1678,6 @@
       {
         "@language": "en",
         "@value": "updating database"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "updating loose-leaf"
       }
     ]
   },
@@ -1595,7 +1750,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1624,82 +1779,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "journal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Journals can be print or digital."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "blog"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Blog content may be written or collected by the site owner, or contributed by users."
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1721,7 +1807,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -1739,14 +1824,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#r",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."
+        "@value": "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1756,55 +1841,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "r"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "repository"
+        "@value": "none of the following"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newsletter"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Can be print or digital."
+        "@value": "Used for yearbooks and annual reports."
       }
     ]
   },
@@ -1826,7 +1875,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "w"
       }
     ],
@@ -1844,14 +1892,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#g",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."
+        "@value": "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1861,72 +1909,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "magazine"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newspaper"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "periodical"
+        "@value": "newsletter"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
@@ -1954,7 +1943,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#pound",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#l",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."
+        "@value": "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,20 +17,205 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "l"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "none of the following"
+        "@value": "updating loose-leaf"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "periodical"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used for yearbooks and annual reports."
+        "@value": "Can be print or digital."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "repository"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "blog"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Blog content may be written or collected by the site owner, or contributed by users."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "newspaper"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magazine"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "journal"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Journals can be print or digital."
       }
     ]
   },
@@ -52,7 +237,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -60,35 +244,6 @@
       {
         "@language": "en",
         "@value": "updating database"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "updating loose-leaf"
       }
     ]
   },
@@ -161,7 +316,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -190,82 +345,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "journal"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Journals can be print or digital."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "blog"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Blog content may be written or collected by the site owner, or contributed by users."
+        "@value": "1-1-0"
       }
     ]
   },
@@ -287,7 +373,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -305,14 +390,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#r",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."
+        "@value": "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -322,55 +407,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "r"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "repository"
+        "@value": "none of the following"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newsletter"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Can be print or digital."
+        "@value": "Used for yearbooks and annual reports."
       }
     ]
   },
@@ -392,7 +441,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "w"
       }
     ],
@@ -410,14 +458,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#g",
+    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."
+        "@value": "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -427,72 +475,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "magazine"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "newspaper"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.62zz-1534#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.62zz-1534"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "periodical"
+        "@value": "newsletter"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
@@ -520,7 +509,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt
@@ -1,96 +1,96 @@
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "newspaper"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#definition> "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating web site"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#definition> "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Blog content may be written or collected by the site owner, or contributed by users."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/alternative> "MARC21 008/21 values for continuing resources expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#definition> "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#definition> "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for any title that is a series, regardless of its treatment."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#definition> "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "periodical"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#definition> "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#definition> "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
 <https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "journal"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "Journals can be print or digital."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#definition> "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating loose-leaf"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for yearbooks and annual reports."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "newsletter"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#definition> "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "blog"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#notation> "w"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#definition> "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/description> "Indicates the type of continuing resource."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#definition> "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "monographic series"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "repository"@en .
 <https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#definition> "Web site that is updated."@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "directory"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf> .
-<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/title> "Continuing: type of continuing resource"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
 <https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "magazine"@en .
-<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#definition> "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "directory"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "newsletter"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#definition> "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en .
 <https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating database"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/description> "Indicates the type of continuing resource."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#definition> "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for any title that is a series, regardless of its treatment."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "journal"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#definition> "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/alternative> "MARC21 008/21 values for continuing resources expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "repository"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#definition> "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#definition> "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#definition> "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating web site"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#scopeNote> "Can be print or digital."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "blog"@en .
 <https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld> .
 <https://doi.org/10.6069/uwlswd.62zz-1534> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Blog content may be written or collected by the site owner, or contributed by users."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#j> <http://www.w3.org/2004/02/skos/core#scopeNote> "Journals can be print or digital."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#definition> "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "newspaper"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.62zz-1534> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/title> "Continuing: type of continuing resource"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "monographic series"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating loose-leaf"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#definition> "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#h> <http://www.w3.org/2004/02/skos/core#definition> "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "magazine"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#definition> "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#definition> "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "updating database"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#w> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "periodical"@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for yearbooks and annual reports."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#n> <http://www.w3.org/2004/02/skos/core#definition> "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en .
+<https://doi.org/10.6069/uwlswd.62zz-1534#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.62zz-1534#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.62zz-1534> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld"/>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,35 +30,27 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#n">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">newspaper</skos:prefLabel>
-    <skos:definition xml:lang="en">Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:prefLabel xml:lang="en">updating web site</skos:prefLabel>
+    <skos:definition xml:lang="en">Web site that is updated.</skos:definition>
+    <skos:notation>w</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">blog</skos:prefLabel>
-    <skos:definition xml:lang="en">Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.</skos:definition>
-    <skos:notation>h</skos:notation>
-    <skos:scopeNote xml:lang="en">Blog content may be written or collected by the site owner, or contributed by users.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">magazine</skos:prefLabel>
+    <skos:definition xml:lang="en">Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.</skos:definition>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">newsletter</skos:prefLabel>
-    <skos:definition xml:lang="en">Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">updating loose-leaf</skos:prefLabel>
-    <skos:definition xml:lang="en">Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:prefLabel xml:lang="en">updating database</skos:prefLabel>
+    <skos:definition xml:lang="en">Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -62,28 +60,13 @@
     <skos:notation>t</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">updating web site</skos:prefLabel>
-    <skos:definition xml:lang="en">Web site that is updated.</skos:definition>
-    <skos:notation>w</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">updating database</skos:prefLabel>
-    <skos:definition xml:lang="en">Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">periodical</skos:prefLabel>
-    <skos:definition xml:lang="en">Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.</skos:definition>
+    <skos:prefLabel xml:lang="en">newsletter</skos:prefLabel>
+    <skos:definition xml:lang="en">Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.</skos:definition>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
-    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -93,6 +76,13 @@
     <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.</skos:scopeNote>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#n">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
+    <skos:prefLabel xml:lang="en">newspaper</skos:prefLabel>
+    <skos:definition xml:lang="en">Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.</skos:definition>
+    <skos:notation>n</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
@@ -100,13 +90,6 @@
     <skos:definition xml:lang="en">A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.</skos:definition>
     <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any title that is a series, regardless of its treatment.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
-    <skos:prefLabel xml:lang="en">magazine</skos:prefLabel>
-    <skos:definition xml:lang="en">Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.</skos:definition>
-    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -123,5 +106,28 @@
     <skos:definition xml:lang="en">Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site.</skos:definition>
     <skos:notation>#</skos:notation>
     <skos:scopeNote xml:lang="en">Used for yearbooks and annual reports.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
+    <skos:prefLabel xml:lang="en">blog</skos:prefLabel>
+    <skos:definition xml:lang="en">Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.</skos:definition>
+    <skos:notation>h</skos:notation>
+    <skos:scopeNote xml:lang="en">Blog content may be written or collected by the site owner, or contributed by users.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
+    <skos:prefLabel xml:lang="en">periodical</skos:prefLabel>
+    <skos:definition xml:lang="en">Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.</skos:definition>
+    <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
+    <skos:prefLabel xml:lang="en">updating loose-leaf</skos:prefLabel>
+    <skos:definition xml:lang="en">Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.</skos:definition>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: type of continuing resource</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/21 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of continuing resource.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld"/>
@@ -29,14 +35,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newspaper</skos:prefLabel>
     <skos:definition xml:lang="en">Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">blog</skos:prefLabel>
     <skos:definition xml:lang="en">Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
     <skos:scopeNote xml:lang="en">Blog content may be written or collected by the site owner, or contributed by users.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
@@ -44,7 +50,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newsletter</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
@@ -52,14 +58,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">directory</skos:prefLabel>
     <skos:definition xml:lang="en">Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
@@ -67,7 +73,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating web site</skos:prefLabel>
     <skos:definition xml:lang="en">Web site that is updated.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:notation xml:lang="en">w</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
@@ -75,7 +81,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating database</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -83,14 +89,14 @@
     <skos:prefLabel xml:lang="en">periodical</skos:prefLabel>
     <skos:definition xml:lang="en">Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.</skos:definition>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">repository</skos:prefLabel>
     <skos:definition xml:lang="en">Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
     <skos:scopeNote xml:lang="en">Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m">
@@ -98,7 +104,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">monographic series</skos:prefLabel>
     <skos:definition xml:lang="en">A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any title that is a series, regardless of its treatment.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
@@ -106,14 +112,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">magazine</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">journal</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
     <skos:scopeNote xml:lang="en">Journals can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#pound">
@@ -121,7 +127,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
     <skos:scopeNote xml:lang="en">Used for yearbooks and annual reports.</skos:scopeNote>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: type of continuing resource</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/21 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of continuing resource.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newspaper</skos:prefLabel>
     <skos:definition xml:lang="en">Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">blog</skos:prefLabel>
     <skos:definition xml:lang="en">Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Blog content may be written or collected by the site owner, or contributed by users.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
@@ -50,7 +44,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newsletter</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
@@ -58,14 +52,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">directory</skos:prefLabel>
     <skos:definition xml:lang="en">Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
@@ -73,7 +67,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating web site</skos:prefLabel>
     <skos:definition xml:lang="en">Web site that is updated.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
@@ -81,7 +75,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating database</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -89,14 +83,14 @@
     <skos:prefLabel xml:lang="en">periodical</skos:prefLabel>
     <skos:definition xml:lang="en">Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.</skos:definition>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">repository</skos:prefLabel>
     <skos:definition xml:lang="en">Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m">
@@ -104,7 +98,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">monographic series</skos:prefLabel>
     <skos:definition xml:lang="en">A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any title that is a series, regardless of its treatment.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
@@ -112,14 +106,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">magazine</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">journal</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
     <skos:scopeNote xml:lang="en">Journals can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#pound">
@@ -127,7 +121,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
     <skos:scopeNote xml:lang="en">Used for yearbooks and annual reports.</skos:scopeNote>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Continuing: type of continuing resource</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/21 values for continuing resources expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of continuing resource.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.jsonld"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newspaper</skos:prefLabel>
     <skos:definition xml:lang="en">Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">blog</skos:prefLabel>
     <skos:definition xml:lang="en">Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Blog content may be written or collected by the site owner, or contributed by users.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#s">
@@ -50,7 +44,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">newsletter</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#l">
@@ -58,14 +52,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">directory</skos:prefLabel>
     <skos:definition xml:lang="en">Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#w">
@@ -73,7 +67,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating web site</skos:prefLabel>
     <skos:definition xml:lang="en">Web site that is updated.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#d">
@@ -81,7 +75,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">updating database</skos:prefLabel>
     <skos:definition xml:lang="en">Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -89,14 +83,14 @@
     <skos:prefLabel xml:lang="en">periodical</skos:prefLabel>
     <skos:definition xml:lang="en">Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs.</skos:definition>
     <skos:scopeNote xml:lang="en">Can be print or digital.</skos:scopeNote>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">repository</skos:prefLabel>
     <skos:definition xml:lang="en">Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#m">
@@ -104,7 +98,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">monographic series</skos:prefLabel>
     <skos:definition xml:lang="en">A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any title that is a series, regardless of its treatment.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#g">
@@ -112,14 +106,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">magazine</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">journal</skos:prefLabel>
     <skos:definition xml:lang="en">Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
     <skos:scopeNote xml:lang="en">Journals can be print or digital.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.62zz-1534#pound">
@@ -127,7 +121,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.62zz-1534"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
     <skos:scopeNote xml:lang="en">Used for yearbooks and annual reports.</skos:scopeNote>
   </rdf:Description>
 </rdf:RDF>

--- a/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl
+++ b/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.ttl
@@ -6,87 +6,87 @@
 <https://doi.org/10.6069/uwlswd.62zz-1534#d> a skos:Concept ;
     skos:definition "Collection of logically interrelated data stored together in one or more computerized files, usually created and managed by a database management system and which may be accessible via a search interface."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "updating database"@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#g> a skos:Concept ;
     skos:definition "Periodical addressing non-scientific, non-professional general interest topics. Magazines can be print or digital."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "magazine"@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#h> a skos:Concept ;
     skos:definition "Online periodical appearing on a web page that may contain web links and/or comments on a particular topic or subject (broad or narrow in scope), often in the form of short articles arranged in reverse chronological order, the most recently added piece of information appearing first."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "blog"@en ;
     skos:scopeNote "Blog content may be written or collected by the site owner, or contributed by users."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#j> a skos:Concept ;
     skos:definition "Periodical addressing readers interested in a specific subject or profession. Often includes original research and current developments."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "journal"@en ;
     skos:scopeNote "Journals can be print or digital."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#l> a skos:Concept ;
     skos:definition "Bibliographic resource that consists of a base volume(s) updated by separate pages which are inserted, removed, and/or substituted."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "updating loose-leaf"@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#m> a skos:Concept ;
     skos:definition "A group of analyzable items (i.e., each piece has a distinctive title) that are related to one another by a collective title. The individual items may or may not be numbered."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "monographic series"@en ;
     skos:scopeNote "Used for any title that is a series, regardless of its treatment."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#n> a skos:Concept ;
     skos:definition "Continuing resource that is mainly designed to be a primary source of written information on current events connected with public affairs, either local, national and/or international in scope. It contains a broad range of news on all subjects and activities and is not limited to any specific subject matter. It may include (although not primarily) articles on literary or other subjects as well as advertising, legal notices, vital statistics, and illustrations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "newspaper"@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#p> a skos:Concept ;
     skos:definition "Includes resources with separate articles, stories, other writings, etc. that are published or distributed generally more frequently than annual including journals, magazines, newsletters and blogs."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "periodical"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#pound> a skos:Concept ;
     skos:definition "Type of continuing resource other than updating database, updating loose-leaf, monographic series, newspaper, periodical, magazine, blog, journal, repository, newsletter, directory, or an updating web site."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en ;
     skos:scopeNote "Used for yearbooks and annual reports."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#r> a skos:Concept ;
     skos:definition "Online collection, often scholarly in nature, for storing the publications of an institution, a group of institutions. Can also be a collection of materials on a specific subject, or from a specific community."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "repository"@en ;
     skos:scopeNote "Materials collected include e-prints, technical reports, theses and dissertations, datasets, and teaching and learning materials."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#s> a skos:Concept ;
     skos:definition "Periodical that can be issued by an organization, generally to its members, or to a specific audience to give current information about a topic or sphere of activity."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "newsletter"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#t> a skos:Concept ;
     skos:definition "Itemized listing of information for the identification or location of persons, objects, organizations or places, arranged alphabetically, chronologically, or in other systematic order, and updated over time."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "directory"@en ;
     skos:scopeNote "Can be print or digital."@en .
 
 <https://doi.org/10.6069/uwlswd.62zz-1534#w> a skos:Concept ;
     skos:definition "Web site that is updated."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.62zz-1534> ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "updating web site"@en ;
     skos:scopeNote "Not used for periodical, newspaper, magazine, blog, journal, repository, newsletter, directory or database."@en .
 
@@ -104,12 +104,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/continuing_type_of_continuing_resource/continuing_type_of_continuing_resource.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Continuing: type of continuing resource"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/maps_form_of_item/maps_form_of_item.html
+++ b/008/maps_form_of_item/maps_form_of_item.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-0" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-0</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
                         <td id="a">
@@ -864,14 +864,14 @@
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"/&gt;
@@ -884,6 +884,57 @@
     &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -898,57 +949,6 @@
     &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1036,107 +1036,107 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf&gt; ;
     dct:issued "2024" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Maps: form of item"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
-    schema:version "1-0-0" .
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for maps expressed using RDF"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: form of item"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/version&gt; "1-0-0" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material for the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/version&gt; "1-1-0" .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
-&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
 &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for maps expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material for the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8dk4-4h49#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1146,13 +1146,69 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "o"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
       }
     ]
   },
@@ -1181,40 +1237,6 @@
       {
         "@language": "en",
         "@value": "microfilm"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not specified by one of the other codes."
       }
     ]
   },
@@ -1249,90 +1271,6 @@
       {
         "@language": "en",
         "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Large print."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print"
       }
     ]
   },
@@ -1405,7 +1343,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1440,7 +1378,35 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
       }
     ]
   },
@@ -1472,14 +1438,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microopaque."
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1489,25 +1455,31 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "c"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microopaque"
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microfiche."
+        "@value": "Large print."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1517,13 +1489,41 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "b"
+        "@value": "d"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfiche"
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
       }
     ]
   }

--- a/008/maps_form_of_item/maps_form_of_item.jsonld
+++ b/008/maps_form_of_item/maps_form_of_item.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,13 +17,69 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "o"
+        "@value": "q"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microopaque"
       }
     ]
   },
@@ -52,40 +108,6 @@
       {
         "@language": "en",
         "@value": "microfilm"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not specified by one of the other codes."
       }
     ]
   },
@@ -120,90 +142,6 @@
       {
         "@language": "en",
         "@value": "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Large print."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print"
       }
     ]
   },
@@ -276,7 +214,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -311,7 +249,35 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Braille."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "braille"
       }
     ]
   },
@@ -343,14 +309,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#c",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microopaque."
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -360,25 +326,31 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "c"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microopaque"
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#b",
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#d",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microfiche."
+        "@value": "Large print."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -388,13 +360,41 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@value": "b"
+        "@value": "d"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfiche"
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8dk4-4h49"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
       }
     ]
   }

--- a/008/maps_form_of_item/maps_form_of_item.nt
+++ b/008/maps_form_of_item/maps_form_of_item.nt
@@ -1,74 +1,74 @@
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/issued> "2024" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for maps expressed using RDF"@en .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/title> "Maps: form of item"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/version> "1-0-0" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/description> "Specifies the form of material for the item."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/version> "1-1-0" .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld> .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
-<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/issued> "2024" .
 <https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for maps expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/description> "Specifies the form of material for the item."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8dk4-4h49> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.8dk4-4h49#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -16,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.nt"/>

--- a/008/maps_form_of_item/maps_form_of_item.rdf
+++ b/008/maps_form_of_item/maps_form_of_item.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -31,6 +37,57 @@
     <skos:definition xml:lang="en">Large print.</skos:definition>
     <skos:notation>d</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+    <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:definition xml:lang="en">Braille.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
+    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfiche.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
@@ -44,56 +101,5 @@
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
     <skos:definition xml:lang="en">Microopaque.</skos:definition>
     <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
-    <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation>r</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
-    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
-    <skos:definition xml:lang="en">Microfiche.</skos:definition>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8dk4-4h49#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8dk4-4h49"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_form_of_item/maps_form_of_item.ttl
+++ b/008/maps_form_of_item/maps_form_of_item.ttl
@@ -79,12 +79,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_form_of_item/maps_form_of_item.rdf> ;
     dct:issued "2024" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Maps: form of item"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
-    schema:version "1-0-0" .
+    schema:version "1-1-0" .
 

--- a/008/maps_projection/maps_projection.html
+++ b/008/maps_projection/maps_projection.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
                         <td id="aa">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">aa</td>
+                        <td property="skos:notation">aa</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
                         <td>
@@ -415,7 +415,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ab</td>
+                        <td property="skos:notation">ab</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
                         <td>
@@ -464,7 +464,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ac</td>
+                        <td property="skos:notation">ac</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
                         <td>
@@ -513,7 +513,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ad</td>
+                        <td property="skos:notation">ad</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
                         <td>
@@ -562,7 +562,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ae</td>
+                        <td property="skos:notation">ae</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
                         <td>
@@ -611,7 +611,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">af</td>
+                        <td property="skos:notation">af</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
                         <td>
@@ -660,7 +660,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ag</td>
+                        <td property="skos:notation">ag</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
                         <td>
@@ -709,7 +709,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">am</td>
+                        <td property="skos:notation">am</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#am">
                         <td>
@@ -758,7 +758,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">an</td>
+                        <td property="skos:notation">an</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
                         <td>
@@ -807,7 +807,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ap</td>
+                        <td property="skos:notation">ap</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
                         <td>
@@ -857,7 +857,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">au</td>
+                        <td property="skos:notation">au</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
                         <td>
@@ -906,7 +906,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">az</td>
+                        <td property="skos:notation">az</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
                         <td>
@@ -955,7 +955,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ba</td>
+                        <td property="skos:notation">ba</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba">
                         <td>
@@ -1004,7 +1004,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bb</td>
+                        <td property="skos:notation">bb</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
                         <td>
@@ -1053,7 +1053,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bc</td>
+                        <td property="skos:notation">bc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
                         <td>
@@ -1102,7 +1102,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bd</td>
+                        <td property="skos:notation">bd</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
                         <td>
@@ -1151,7 +1151,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">be</td>
+                        <td property="skos:notation">be</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
                         <td>
@@ -1200,7 +1200,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bf</td>
+                        <td property="skos:notation">bf</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
                         <td>
@@ -1249,7 +1249,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bg</td>
+                        <td property="skos:notation">bg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
                         <td>
@@ -1298,7 +1298,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bh</td>
+                        <td property="skos:notation">bh</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
                         <td>
@@ -1347,7 +1347,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bi</td>
+                        <td property="skos:notation">bi</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
                         <td>
@@ -1396,7 +1396,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bj</td>
+                        <td property="skos:notation">bj</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
                         <td>
@@ -1445,7 +1445,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bk</td>
+                        <td property="skos:notation">bk</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
                         <td>
@@ -1494,7 +1494,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bl</td>
+                        <td property="skos:notation">bl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl">
                         <td>
@@ -1543,7 +1543,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bo</td>
+                        <td property="skos:notation">bo</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
                         <td>
@@ -1592,7 +1592,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">br</td>
+                        <td property="skos:notation">br</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
                         <td>
@@ -1641,7 +1641,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bs</td>
+                        <td property="skos:notation">bs</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bs">
                         <td>
@@ -1691,7 +1691,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bu</td>
+                        <td property="skos:notation">bu</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
                         <td>
@@ -1740,7 +1740,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bz</td>
+                        <td property="skos:notation">bz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz">
                         <td>
@@ -1789,7 +1789,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ca</td>
+                        <td property="skos:notation">ca</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
                         <td>
@@ -1838,7 +1838,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cb</td>
+                        <td property="skos:notation">cb</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
                         <td>
@@ -1887,7 +1887,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cc</td>
+                        <td property="skos:notation">cc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
                         <td>
@@ -1936,7 +1936,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ce</td>
+                        <td property="skos:notation">ce</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
                         <td>
@@ -1985,7 +1985,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cp</td>
+                        <td property="skos:notation">cp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
                         <td>
@@ -2035,7 +2035,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cu</td>
+                        <td property="skos:notation">cu</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
                         <td>
@@ -2084,7 +2084,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cz</td>
+                        <td property="skos:notation">cz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
                         <td>
@@ -2133,7 +2133,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">da</td>
+                        <td property="skos:notation">da</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
                         <td>
@@ -2182,7 +2182,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">db</td>
+                        <td property="skos:notation">db</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#db">
                         <td>
@@ -2231,7 +2231,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dc</td>
+                        <td property="skos:notation">dc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc">
                         <td>
@@ -2280,7 +2280,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dd</td>
+                        <td property="skos:notation">dd</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
                         <td>
@@ -2329,7 +2329,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">de</td>
+                        <td property="skos:notation">de</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
                         <td>
@@ -2378,7 +2378,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">df</td>
+                        <td property="skos:notation">df</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
                         <td>
@@ -2427,7 +2427,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dg</td>
+                        <td property="skos:notation">dg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg">
                         <td>
@@ -2476,7 +2476,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dh</td>
+                        <td property="skos:notation">dh</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh">
                         <td>
@@ -2525,7 +2525,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dl</td>
+                        <td property="skos:notation">dl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
                         <td>
@@ -2574,7 +2574,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">##</td>
+                        <td property="skos:notation">##</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
                         <td>
@@ -2641,7 +2641,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">zz</td>
+                        <td property="skos:notation">zz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
                         <td>
@@ -2665,97 +2665,68 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Miller&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Miller.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;be&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Alber's equal area&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Alber's equal area.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ca&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Goode's homolographic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Goode's homolographic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bb&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Lambert conformal&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Lambert conformal.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;dl&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Robinson&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Robinson.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;br&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;projection not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Projection not specified.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;##&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for most globes.&lt;/skos:scopeNote&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;stereographic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Stereographic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;af&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;cordiform&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Cordiform.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;dh&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;dh&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Miller's bipolar oblique conformal conic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Miller's bipolar oblique conformal conic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;de&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Alber's equal area&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Alber's equal area.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ca&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bs"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;conic, other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Conic, other.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cz&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;space oblique Mercator&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Space oblique Mercator.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bs&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;azimuthal, specific type unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;au&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;equidistant conic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Equidistant conic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ce&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;krovak&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Krovak.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bk&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;polyconic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Polyconic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cp&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;oblique Mercator&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Oblique Mercator.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bo&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Bonne&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Bonne.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cb&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#am"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;modified stereographic for Alaska&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Modified stereographic for Alaska.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;am&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;am&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;polar stereographic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Polar stereographic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ap&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -2763,261 +2734,290 @@
     &lt;dct:title xml:lang="en"&gt;Maps: projection&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/22-23 values for maps expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the projection used in producing the item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bs"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;space oblique Mercator&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Space oblique Mercator.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bs&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Eckert&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Eckert.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;dc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;general vertical near-sided&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;General vertical near-sided.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ag&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;stereographic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Stereographic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;af&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Lambert's azimuthal equal area&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Lambert's azimuthal equal area.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ac&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Aitoff&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Aitoff.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;aa&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Bonne&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Bonne.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cb&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;conic, specific type unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cu&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;cylindrical, specific type unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bu&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Cassini-Soldner&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Cassini-Soldner.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bl&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;cylindrical, other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Cylindrical, other.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bz&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Gnomic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Gnomic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ab&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;Lambert's conformal conic&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Lambert's conformal conic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;armadillo&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Armadillo.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;da&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;polar stereographic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Polar stereographic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ap&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;equidistant conic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Equidistant conic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ce&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;azimuthal equidistant&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Azimuthal equidistant.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ae&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Mollweide&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Mollweide.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bf&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;cc&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;Chamberlin trimetric&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Chamberlin trimetric.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;an&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;an&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Lambert's cylindrical equal area&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Lambert's cylindrical equal area.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Van Der Grinten&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Van Der Grinten.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;df&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;orthographic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Orthographic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ad&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Gauss-Kruger&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Gauss-Kruger.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bi&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;equirectangular&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Equirectangular.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bj&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;dimaxion&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Dimaxion.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;dg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;transverse Mercator&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Transverse Mercator.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bh&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Gnomic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Gnomic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ab&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;sinusoidal&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Sinusoidal.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;polyconic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Polyconic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cp&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;azimuthal, specific type unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;au&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;zz&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;zz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;sinusoidal&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Sinusoidal.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;projection not specified&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Projection not specified.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;##&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for most globes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Robinson&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Robinson.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;br&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;azimuthal, other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Azimuthal, other.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;az&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;butterfly&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Butterfly.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;db&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;az&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;Goode's homolosine&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Goode's homolosine.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;dd&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;dd&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;Gall&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Gall.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ba&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Lambert conformal&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Lambert conformal.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;dl&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Eckert&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Eckert.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;dc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;equirectangular&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Equirectangular.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bj&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;conic, other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Conic, other.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;azimuthal equidistant&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Azimuthal equidistant.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ae&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Miller's bipolar oblique conformal conic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Miller's bipolar oblique conformal conic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;de&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Cassini-Soldner&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Cassini-Soldner.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bl&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;cylindrical, other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Cylindrical, other.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;krovak&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Krovak.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bk&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;dimaxion&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Dimaxion.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;dg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Mollweide&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Mollweide.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bf&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Van Der Grinten&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Van Der Grinten.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;df&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Goode's homolographic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Goode's homolographic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bb&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Lambert's cylindrical equal area&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Lambert's cylindrical equal area.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;orthographic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Orthographic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ad&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Aitoff&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Aitoff.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;aa&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;Mercator&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Mercator.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bd&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;bd&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;butterfly&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Butterfly.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;db&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Gall&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Gall.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ba&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;armadillo&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Armadillo.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;da&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Miller&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Miller.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;be&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;oblique Mercator&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Oblique Mercator.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bo&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;transverse Mercator&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Transverse Mercator.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bh&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;general vertical near-sided&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;General vertical near-sided.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ag&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Gauss-Kruger&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Gauss-Kruger.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bi&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;cylindrical, specific type unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bu&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;Lambert's azimuthal equal area&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Lambert's azimuthal equal area.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ac&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;conic, specific type unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cu&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -3032,284 +3032,284 @@
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; a skos:Concept ;
     skos:definition "Aitoff."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "aa"@en ;
+    skos:notation "aa" ;
     skos:prefLabel "Aitoff"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; a skos:Concept ;
     skos:definition "Gnomic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ab"@en ;
+    skos:notation "ab" ;
     skos:prefLabel "Gnomic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; a skos:Concept ;
     skos:definition "Lambert's azimuthal equal area."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ac"@en ;
+    skos:notation "ac" ;
     skos:prefLabel "Lambert's azimuthal equal area"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; a skos:Concept ;
     skos:definition "Orthographic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ad"@en ;
+    skos:notation "ad" ;
     skos:prefLabel "orthographic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; a skos:Concept ;
     skos:definition "Azimuthal equidistant."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ae"@en ;
+    skos:notation "ae" ;
     skos:prefLabel "azimuthal equidistant"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; a skos:Concept ;
     skos:definition "Stereographic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "af"@en ;
+    skos:notation "af" ;
     skos:prefLabel "stereographic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; a skos:Concept ;
     skos:definition "General vertical near-sided."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ag"@en ;
+    skos:notation "ag" ;
     skos:prefLabel "general vertical near-sided"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; a skos:Concept ;
     skos:definition "Modified stereographic for Alaska."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "am"@en ;
+    skos:notation "am" ;
     skos:prefLabel "modified stereographic for Alaska"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; a skos:Concept ;
     skos:definition "Chamberlin trimetric."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "an"@en ;
+    skos:notation "an" ;
     skos:prefLabel "Chamberlin trimetric"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; a skos:Concept ;
     skos:definition "Polar stereographic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ap"@en ;
+    skos:notation "ap" ;
     skos:prefLabel "polar stereographic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; a skos:Concept ;
     skos:definition "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "au"@en ;
+    skos:notation "au" ;
     skos:prefLabel "azimuthal, specific type unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; a skos:Concept ;
     skos:definition "Azimuthal, other."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "az"@en ;
+    skos:notation "az" ;
     skos:prefLabel "azimuthal, other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; a skos:Concept ;
     skos:definition "Gall."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ba"@en ;
+    skos:notation "ba" ;
     skos:prefLabel "Gall"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; a skos:Concept ;
     skos:definition "Goode's homolographic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bb"@en ;
+    skos:notation "bb" ;
     skos:prefLabel "Goode's homolographic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; a skos:Concept ;
     skos:definition "Lambert's cylindrical equal area."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bc"@en ;
+    skos:notation "bc" ;
     skos:prefLabel "Lambert's cylindrical equal area"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; a skos:Concept ;
     skos:definition "Mercator."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bd"@en ;
+    skos:notation "bd" ;
     skos:prefLabel "Mercator"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; a skos:Concept ;
     skos:definition "Miller."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "be"@en ;
+    skos:notation "be" ;
     skos:prefLabel "Miller"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; a skos:Concept ;
     skos:definition "Mollweide."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bf"@en ;
+    skos:notation "bf" ;
     skos:prefLabel "Mollweide"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; a skos:Concept ;
     skos:definition "Sinusoidal."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bg"@en ;
+    skos:notation "bg" ;
     skos:prefLabel "sinusoidal"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; a skos:Concept ;
     skos:definition "Transverse Mercator."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bh"@en ;
+    skos:notation "bh" ;
     skos:prefLabel "transverse Mercator"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; a skos:Concept ;
     skos:definition "Gauss-Kruger."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bi"@en ;
+    skos:notation "bi" ;
     skos:prefLabel "Gauss-Kruger"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; a skos:Concept ;
     skos:definition "Equirectangular."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bj"@en ;
+    skos:notation "bj" ;
     skos:prefLabel "equirectangular"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; a skos:Concept ;
     skos:definition "Krovak."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bk"@en ;
+    skos:notation "bk" ;
     skos:prefLabel "krovak"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; a skos:Concept ;
     skos:definition "Cassini-Soldner."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bl"@en ;
+    skos:notation "bl" ;
     skos:prefLabel "Cassini-Soldner"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; a skos:Concept ;
     skos:definition "Oblique Mercator."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bo"@en ;
+    skos:notation "bo" ;
     skos:prefLabel "oblique Mercator"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; a skos:Concept ;
     skos:definition "Robinson."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "br"@en ;
+    skos:notation "br" ;
     skos:prefLabel "Robinson"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; a skos:Concept ;
     skos:definition "Space oblique Mercator."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bs"@en ;
+    skos:notation "bs" ;
     skos:prefLabel "space oblique Mercator"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; a skos:Concept ;
     skos:definition "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bu"@en ;
+    skos:notation "bu" ;
     skos:prefLabel "cylindrical, specific type unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; a skos:Concept ;
     skos:definition "Cylindrical, other."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "bz"@en ;
+    skos:notation "bz" ;
     skos:prefLabel "cylindrical, other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; a skos:Concept ;
     skos:definition "Alber's equal area."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ca"@en ;
+    skos:notation "ca" ;
     skos:prefLabel "Alber's equal area"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; a skos:Concept ;
     skos:definition "Bonne."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "cb"@en ;
+    skos:notation "cb" ;
     skos:prefLabel "Bonne"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; a skos:Concept ;
     skos:definition "Lambert's conformal conic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "cc"@en ;
+    skos:notation "cc" ;
     skos:prefLabel "Lambert's conformal conic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; a skos:Concept ;
     skos:definition "Equidistant conic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "ce"@en ;
+    skos:notation "ce" ;
     skos:prefLabel "equidistant conic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; a skos:Concept ;
     skos:definition "Polyconic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "cp"@en ;
+    skos:notation "cp" ;
     skos:prefLabel "polyconic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; a skos:Concept ;
     skos:definition "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "cu"@en ;
+    skos:notation "cu" ;
     skos:prefLabel "conic, specific type unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; a skos:Concept ;
     skos:definition "Conic, other."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "cz"@en ;
+    skos:notation "cz" ;
     skos:prefLabel "conic, other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; a skos:Concept ;
     skos:definition "Armadillo."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "da"@en ;
+    skos:notation "da" ;
     skos:prefLabel "armadillo"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; a skos:Concept ;
     skos:definition "Butterfly."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "db"@en ;
+    skos:notation "db" ;
     skos:prefLabel "butterfly"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; a skos:Concept ;
     skos:definition "Eckert."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "dc"@en ;
+    skos:notation "dc" ;
     skos:prefLabel "Eckert"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; a skos:Concept ;
     skos:definition "Goode's homolosine."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "dd"@en ;
+    skos:notation "dd" ;
     skos:prefLabel "Goode's homolosine"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; a skos:Concept ;
     skos:definition "Miller's bipolar oblique conformal conic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "de"@en ;
+    skos:notation "de" ;
     skos:prefLabel "Miller's bipolar oblique conformal conic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; a skos:Concept ;
     skos:definition "Van Der Grinten."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "df"@en ;
+    skos:notation "df" ;
     skos:prefLabel "Van Der Grinten"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; a skos:Concept ;
     skos:definition "Dimaxion."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "dg"@en ;
+    skos:notation "dg" ;
     skos:prefLabel "dimaxion"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; a skos:Concept ;
     skos:definition "Cordiform."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "dh"@en ;
+    skos:notation "dh" ;
     skos:prefLabel "cordiform"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; a skos:Concept ;
     skos:definition "Lambert conformal."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "dl"@en ;
+    skos:notation "dl" ;
     skos:prefLabel "Lambert conformal"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; a skos:Concept ;
     skos:definition "Projection not specified."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "##"@en ;
+    skos:notation "##" ;
     skos:prefLabel "projection not specified"@en ;
     skos:scopeNote "Used for most globes."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; a skos:Concept ;
     skos:definition "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; ;
-    skos:notation "zz"@en ;
+    skos:notation "zz" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; a skos:ConceptScheme ;
@@ -3326,340 +3326,282 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Maps: projection"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Alber's equal area"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Goode's homolographic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "br"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "projection not specified"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dh"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Conic, other."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bk"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert conformal."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cordiform"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Oblique Mercator."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "am"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dl"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bs"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "de"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ag"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's azimuthal equal area"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Bonne"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bb"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bonne."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Cassini-Soldner"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Alber's equal area."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cylindrical, other."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cc"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Robinson"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bl"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "oblique Mercator"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bu"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "da"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cylindrical, specific type unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ce"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal equidistant"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chamberlin trimetric."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Modified stereographic for Alaska."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Van Der Grinten."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert conformal"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Mollweide"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bf"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for most globes."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's cylindrical equal area"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "be"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's conformal conic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "modified stereographic for Alaska"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ad"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's azimuthal equal area."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bi"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "equidistant conic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bj"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polar stereographic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dg"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Robinson."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conic, specific type unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sinusoidal"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conic, other"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Armadillo."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "stereographic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dc"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bh"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polyconic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "General vertical near-sided."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cassini-Soldner."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "df"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ca"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal, specific type unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Aitoff"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "##"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bo"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's cylindrical equal area."@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "butterfly"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "db"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gauss-Kruger"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bg"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal, other."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polyconic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dd"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transverse Mercator"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cu"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Goode's homolosine."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Goode's homolographic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gall"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ba"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mollweide."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ae"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Stereographic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gnomic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Space oblique Mercator."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transverse Mercator."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's conformal conic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dimaxion"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "equirectangular"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Equidistant conic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eckert."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "zz"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal, other"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "az"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Orthographic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gall."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Miller"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Miller."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "aa"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gauss-Kruger."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gnomic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Butterfly."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the projection used in producing the item."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "krovak"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "general vertical near-sided"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Van Der Grinten"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Aitoff."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cb"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "au"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: projection"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cz"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "af"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal equidistant."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polar stereographic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ab"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Chamberlin trimetric"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "armadillo"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "space oblique Mercator"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bz"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Mercator"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sinusoidal."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bc"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cp"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Miller's bipolar oblique conformal conic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Goode's homolosine"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cordiform."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22-23 values for maps expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dimaxion."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Miller's bipolar oblique conformal conic."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cylindrical, other"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Equirectangular."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Eckert"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projection not specified."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "an"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bd"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ac"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ap"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Krovak."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mercator."@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "orthographic"@en .
-&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polyconic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polar stereographic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cc" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chamberlin trimetric."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "an" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bg" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the projection used in producing the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projection not specified."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dd" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert conformal."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Equidistant conic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dc" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "af" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's conformal conic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bj" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's conformal conic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Conic, other."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "de" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Cassini-Soldner"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cylindrical, other."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "modified stereographic for Alaska"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cylindrical, other"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polyconic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dg" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bf" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bz" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Equirectangular."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bk" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cb" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Krovak."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "space oblique Mercator"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Van Der Grinten."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Goode's homolographic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's cylindrical equal area."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Orthographic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dh" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "zz" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "aa" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22-23 values for maps expressed using RDF"@en .
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Aitoff."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "az" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Butterfly."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gall"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Alber's equal area"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "br" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Robinson."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cordiform"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Miller."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bo" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Mollweide"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bh" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Alber's equal area."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Armadillo."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "General vertical near-sided."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sinusoidal."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bi" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gall."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bc" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "equirectangular"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eckert."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ac" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ca" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bs" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "df" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mollweide."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Van Der Grinten"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bk&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "krovak"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "oblique Mercator"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sinusoidal"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#df&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl&gt; .
 &lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ad" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Goode's homolosine"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for most globes."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal, specific type unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "au" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Eckert"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bonne."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cassini-Soldner."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Bonne"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ap" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Space oblique Mercator."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Stereographic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "projection not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal equidistant"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gnomic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Chamberlin trimetric"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lambert's azimuthal equal area."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bb" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Goode's homolographic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conic, specific type unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cz" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cp" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#pound2&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "##" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Miller's bipolar oblique conformal conic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#an&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Gauss-Kruger"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cu" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bu" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ab" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#br&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Robinson"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bs&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mercator."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ba" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dl" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Modified stereographic for Alaska."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cylindrical, specific type unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal equidistant."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dh&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cordiform."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dimaxion"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "equidistant conic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Azimuthal, other."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bd" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "be" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Mercator"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ad&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "orthographic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ba&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transverse Mercator"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bl" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's cylindrical equal area"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ae" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ab&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gnomic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: projection"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Miller"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#af&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "stereographic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gauss-Kruger."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conic, other"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bo&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Oblique Mercator."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "butterfly"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dimaxion."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#au&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bj&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "general vertical near-sided"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ae&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert conformal"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#db&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "db" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ac&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Lambert's azimuthal equal area"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ap&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polar stereographic"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bh&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transverse Mercator."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#cu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ag&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ag" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#az&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "azimuthal, other"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "armadillo"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#da&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "da" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#am&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "am" .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#dd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Goode's homolosine."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#be&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#de&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Miller's bipolar oblique conformal conic."@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#aa&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "Aitoff"@en .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bf&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.4jrs-m847&gt; .
+&lt;https://doi.org/10.6069/uwlswd.4jrs-m847#ce&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ce" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#zz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "zz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Polyconic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "polyconic"
-      }
-    ]
-  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dd",
     "@type": [
@@ -3678,7 +3620,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dd"
       }
     ],
@@ -3686,267 +3627,6 @@
       {
         "@language": "en",
         "@value": "Goode's homolosine"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Eckert."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Eckert"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#aa",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Aitoff."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "aa"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Aitoff"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bonne."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Bonne"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert's cylindrical equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert's cylindrical equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bk",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Krovak."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bk"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "krovak"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bf",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mollweide."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bf"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Mollweide"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conic, other."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conic, other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ce",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Equidistant conic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ce"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "equidistant conic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dh",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cordiform."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dh"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cordiform"
       }
     ]
   },
@@ -3968,7 +3648,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ab"
       }
     ],
@@ -3980,14 +3659,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bz",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#zz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Cylindrical, other."
+        "@value": "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -3997,101 +3676,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bz"
+        "@value": "zz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "cylindrical, other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#an",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chamberlin trimetric."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "an"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Chamberlin trimetric"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#df",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Van Der Grinten."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "df"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Van Der Grinten"
+        "@value": "other"
       }
     ]
   },
@@ -4113,7 +3704,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ap"
       }
     ],
@@ -4125,14 +3715,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bh",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bk",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Transverse Mercator."
+        "@value": "Krovak."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4142,43 +3732,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bh"
+        "@value": "bk"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "transverse Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bi",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gauss-Kruger."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bi"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Gauss-Kruger"
+        "@value": "krovak"
       }
     ]
   },
@@ -4200,7 +3760,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dg"
       }
     ],
@@ -4208,441 +3767,6 @@
       {
         "@language": "en",
         "@value": "dimaxion"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sinusoidal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sinusoidal"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conic, specific type unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#db",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Butterfly."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "db"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "butterfly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#br",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Robinson."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "br"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Robinson"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cassini-Soldner."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Cassini-Soldner"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bo",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Oblique Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "oblique Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#da",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Armadillo."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "da"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "armadillo"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Goode's homolographic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Goode's homolographic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bs",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Space oblique Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "space oblique Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#de",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Miller's bipolar oblique conformal conic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "de"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Miller's bipolar oblique conformal conic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ca",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Alber's equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Alber's equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert conformal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert conformal"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ac",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert's azimuthal equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ac"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert's azimuthal equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ba",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gall."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ba"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Gall"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bj",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Equirectangular."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bj"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "equirectangular"
       }
     ]
   },
@@ -4715,7 +3839,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -4744,24 +3868,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ae",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#br",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal equidistant."
+        "@value": "Robinson."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4771,26 +3896,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "ae"
+        "@value": "br"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal equidistant"
+        "@value": "Robinson"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#be",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#df",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Miller."
+        "@value": "Van Der Grinten."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4800,26 +3924,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "be"
+        "@value": "df"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "Miller"
+        "@value": "Van Der Grinten"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#az",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal, other."
+        "@value": "Cylindrical, other."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4829,26 +3952,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "az"
+        "@value": "bz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal, other"
+        "@value": "cylindrical, other"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#au",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#db",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."
+        "@value": "Butterfly."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4858,26 +3980,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "au"
+        "@value": "db"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal, specific type unknown"
+        "@value": "butterfly"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#pound2",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bf",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Projection not specified."
+        "@value": "Mollweide."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -4887,136 +4008,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "##"
+        "@value": "bf"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "projection not specified"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for most globes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cylindrical, specific type unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#af",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Stereographic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "af"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "stereographic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ag",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "General vertical near-sided."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ag"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "general vertical near-sided"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#am",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Modified stereographic for Alaska."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "am"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "modified stereographic for Alaska"
+        "@value": "Mollweide"
       }
     ]
   },
@@ -5038,7 +4036,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ad"
       }
     ],
@@ -5046,6 +4043,174 @@
       {
         "@language": "en",
         "@value": "orthographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bo",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Oblique Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "oblique Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#aa",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Aitoff."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "aa"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Aitoff"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bs",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Space oblique Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "space oblique Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bonne."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Bonne"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ba",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gall."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ba"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Gall"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conic, specific type unknown"
       }
     ]
   },
@@ -5067,7 +4232,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "cc"
       }
     ],
@@ -5075,6 +4239,796 @@
       {
         "@language": "en",
         "@value": "Lambert's conformal conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bh",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transverse Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bh"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "transverse Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert's cylindrical equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert's cylindrical equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Goode's homolographic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Goode's homolographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#am",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Modified stereographic for Alaska."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "am"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "modified stereographic for Alaska"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#da",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Armadillo."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "da"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "armadillo"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Eckert."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Eckert"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert conformal."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert conformal"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#af",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Stereographic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "af"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "stereographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#be",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Miller."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "be"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Miller"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cylindrical, specific type unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conic, other."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conic, other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bj",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Equirectangular."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bj"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "equirectangular"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dh",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cordiform."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dh"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cordiform"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ac",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert's azimuthal equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ac"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert's azimuthal equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Polyconic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "polyconic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ag",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "General vertical near-sided."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ag"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "general vertical near-sided"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bi",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gauss-Kruger."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bi"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Gauss-Kruger"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#de",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Miller's bipolar oblique conformal conic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "de"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Miller's bipolar oblique conformal conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ae",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal equidistant."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ae"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal equidistant"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ca",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Alber's equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ca"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Alber's equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cassini-Soldner."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Cassini-Soldner"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Sinusoidal."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "sinusoidal"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#an",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chamberlin trimetric."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "an"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Chamberlin trimetric"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#au",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "au"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal, specific type unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#az",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal, other."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "az"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal, other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ce",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Equidistant conic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ce"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "equidistant conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#pound2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Projection not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "##"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "projection not specified"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for most globes."
       }
     ]
   }

--- a/008/maps_projection/maps_projection.jsonld
+++ b/008/maps_projection/maps_projection.jsonld
@@ -1,63 +1,5 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#zz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "zz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Polyconic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "polyconic"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dd",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -75,7 +17,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dd"
       }
     ],
@@ -83,267 +24,6 @@
       {
         "@language": "en",
         "@value": "Goode's homolosine"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Eckert."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Eckert"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#aa",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Aitoff."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "aa"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Aitoff"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bonne."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Bonne"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert's cylindrical equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert's cylindrical equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bk",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Krovak."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bk"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "krovak"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bf",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mollweide."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bf"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Mollweide"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conic, other."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conic, other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ce",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Equidistant conic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ce"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "equidistant conic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dh",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cordiform."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dh"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cordiform"
       }
     ]
   },
@@ -365,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ab"
       }
     ],
@@ -377,14 +56,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bz",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#zz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Cylindrical, other."
+        "@value": "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -394,101 +73,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bz"
+        "@value": "zz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "cylindrical, other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#an",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chamberlin trimetric."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "an"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Chamberlin trimetric"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#df",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Van Der Grinten."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "df"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Van Der Grinten"
+        "@value": "other"
       }
     ]
   },
@@ -510,7 +101,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ap"
       }
     ],
@@ -522,14 +112,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bh",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bk",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Transverse Mercator."
+        "@value": "Krovak."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -539,43 +129,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bh"
+        "@value": "bk"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "transverse Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bi",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gauss-Kruger."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bi"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Gauss-Kruger"
+        "@value": "krovak"
       }
     ]
   },
@@ -597,7 +157,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dg"
       }
     ],
@@ -605,441 +164,6 @@
       {
         "@language": "en",
         "@value": "dimaxion"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sinusoidal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sinusoidal"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conic, specific type unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#db",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Butterfly."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "db"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "butterfly"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#br",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Robinson."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "br"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Robinson"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cassini-Soldner."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Cassini-Soldner"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bo",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Oblique Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "oblique Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#da",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Armadillo."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "da"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "armadillo"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Goode's homolographic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Goode's homolographic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bs",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Space oblique Mercator."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "space oblique Mercator"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#de",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Miller's bipolar oblique conformal conic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "de"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Miller's bipolar oblique conformal conic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ca",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Alber's equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Alber's equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert conformal."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "dl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert conformal"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ac",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lambert's azimuthal equal area."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ac"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Lambert's azimuthal equal area"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ba",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gall."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ba"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "Gall"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bj",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Equirectangular."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bj"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "equirectangular"
       }
     ]
   },
@@ -1112,7 +236,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1141,24 +265,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ae",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#br",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal equidistant."
+        "@value": "Robinson."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1168,26 +293,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "ae"
+        "@value": "br"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal equidistant"
+        "@value": "Robinson"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#be",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#df",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Miller."
+        "@value": "Van Der Grinten."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1197,26 +321,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "be"
+        "@value": "df"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "Miller"
+        "@value": "Van Der Grinten"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#az",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal, other."
+        "@value": "Cylindrical, other."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1226,26 +349,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "az"
+        "@value": "bz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal, other"
+        "@value": "cylindrical, other"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#au",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#db",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."
+        "@value": "Butterfly."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1255,26 +377,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "au"
+        "@value": "db"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "azimuthal, specific type unknown"
+        "@value": "butterfly"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#pound2",
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bf",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Projection not specified."
+        "@value": "Mollweide."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1284,136 +405,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "##"
+        "@value": "bf"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "projection not specified"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for most globes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cylindrical, specific type unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#af",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Stereographic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "af"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "stereographic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ag",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "General vertical near-sided."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ag"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "general vertical near-sided"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#am",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Modified stereographic for Alaska."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "am"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "modified stereographic for Alaska"
+        "@value": "Mollweide"
       }
     ]
   },
@@ -1435,7 +433,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ad"
       }
     ],
@@ -1443,6 +440,174 @@
       {
         "@language": "en",
         "@value": "orthographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bo",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Oblique Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "oblique Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#aa",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Aitoff."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "aa"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Aitoff"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bs",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Space oblique Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "space oblique Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bonne."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Bonne"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ba",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gall."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ba"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Gall"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conic, specific type unknown"
       }
     ]
   },
@@ -1464,7 +629,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "cc"
       }
     ],
@@ -1472,6 +636,796 @@
       {
         "@language": "en",
         "@value": "Lambert's conformal conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bh",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transverse Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bh"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "transverse Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert's cylindrical equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert's cylindrical equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mercator."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Mercator"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Goode's homolographic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Goode's homolographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#am",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Modified stereographic for Alaska."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "am"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "modified stereographic for Alaska"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#da",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Armadillo."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "da"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "armadillo"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Eckert."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Eckert"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert conformal."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert conformal"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#af",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Stereographic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "af"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "stereographic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#be",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Miller."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "be"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Miller"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cylindrical, specific type unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conic, other."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conic, other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bj",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Equirectangular."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bj"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "equirectangular"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#dh",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cordiform."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "dh"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cordiform"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ac",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lambert's azimuthal equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ac"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Lambert's azimuthal equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#cp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Polyconic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "polyconic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ag",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "General vertical near-sided."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ag"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "general vertical near-sided"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bi",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gauss-Kruger."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bi"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Gauss-Kruger"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#de",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Miller's bipolar oblique conformal conic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "de"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Miller's bipolar oblique conformal conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ae",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal equidistant."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ae"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal equidistant"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ca",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Alber's equal area."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ca"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Alber's equal area"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cassini-Soldner."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Cassini-Soldner"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#bg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Sinusoidal."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "sinusoidal"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#an",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chamberlin trimetric."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "an"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Chamberlin trimetric"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#au",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "au"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal, specific type unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#az",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Azimuthal, other."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "az"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "azimuthal, other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#ce",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Equidistant conic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ce"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "equidistant conic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847#pound2",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Projection not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.4jrs-m847"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "##"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "projection not specified"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for most globes."
       }
     ]
   }

--- a/008/maps_projection/maps_projection.nt
+++ b/008/maps_projection/maps_projection.nt
@@ -1,258 +1,258 @@
-<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#prefLabel> "Alber's equal area"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#definition> "Goode's homolographic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#notation> "br"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#prefLabel> "projection not specified"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#notation> "dh"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#definition> "Conic, other."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#notation> "bk"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#definition> "Lambert conformal."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#prefLabel> "cordiform"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#definition> "Oblique Mercator."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#notation> "am"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#notation> "dl"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#notation> "bs"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#notation> "de"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#notation> "ag"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's azimuthal equal area"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#prefLabel> "Bonne"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#notation> "bb"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#definition> "Bonne."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#prefLabel> "Cassini-Soldner"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#definition> "Alber's equal area."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#definition> "Cylindrical, other."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#notation> "cc"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#prefLabel> "Robinson"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#notation> "bl"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#prefLabel> "oblique Mercator"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#notation> "bu"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#notation> "da"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#prefLabel> "cylindrical, specific type unknown"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#notation> "ce"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal equidistant"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#definition> "Chamberlin trimetric."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#definition> "Modified stereographic for Alaska."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#definition> "Van Der Grinten."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert conformal"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#prefLabel> "Mollweide"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#notation> "bf"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for most globes."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's cylindrical equal area"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#notation> "be"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's conformal conic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#prefLabel> "modified stereographic for Alaska"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#notation> "ad"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's azimuthal equal area."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#notation> "bi"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#prefLabel> "equidistant conic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#notation> "bj"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#definition> "Polar stereographic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#notation> "dg"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#definition> "Robinson."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#prefLabel> "conic, specific type unknown"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#prefLabel> "sinusoidal"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#prefLabel> "conic, other"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#definition> "Armadillo."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#prefLabel> "stereographic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#notation> "dc"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#notation> "bh"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#definition> "Polyconic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#definition> "General vertical near-sided."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#definition> "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#definition> "Cassini-Soldner."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#notation> "df"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#notation> "ca"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal, specific type unknown"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#definition> "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#prefLabel> "Aitoff"@en .
 <https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#notation> "##"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#notation> "bo"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's cylindrical equal area."@en .
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#prefLabel> "butterfly"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#notation> "db"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gauss-Kruger"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#notation> "bg"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal, other."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#prefLabel> "polyconic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#notation> "dd"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#prefLabel> "transverse Mercator"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#notation> "cu"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#definition> "Goode's homolosine."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#prefLabel> "Goode's homolographic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gall"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#notation> "ba"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#definition> "Mollweide."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#notation> "ae"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#definition> "Stereographic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gnomic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#definition> "Space oblique Mercator."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#definition> "Transverse Mercator."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's conformal conic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#prefLabel> "dimaxion"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#prefLabel> "equirectangular"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#definition> "Equidistant conic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#definition> "Eckert."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#notation> "zz"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal, other"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#notation> "az"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#definition> "Orthographic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#definition> "Gall."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#prefLabel> "Miller"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#definition> "Miller."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#notation> "aa"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#definition> "Gauss-Kruger."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#definition> "Gnomic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#definition> "Butterfly."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/description> "Indicates the projection used in producing the item."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#prefLabel> "krovak"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#prefLabel> "general vertical near-sided"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#prefLabel> "Van Der Grinten"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#definition> "Aitoff."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#notation> "cb"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#notation> "au"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/title> "Maps: projection"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#notation> "cz"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#notation> "af"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal equidistant."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#prefLabel> "polar stereographic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#notation> "ab"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#prefLabel> "Chamberlin trimetric"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#prefLabel> "armadillo"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#prefLabel> "space oblique Mercator"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#notation> "bz"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#prefLabel> "Mercator"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#definition> "Sinusoidal."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#notation> "bc"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#notation> "cp"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#prefLabel> "Miller's bipolar oblique conformal conic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#prefLabel> "Goode's homolosine"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#definition> "Cordiform."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/alternative> "MARC21 008/22-23 values for maps expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#definition> "Dimaxion."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#definition> "Miller's bipolar oblique conformal conic."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#prefLabel> "cylindrical, other"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#definition> "Equirectangular."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Eckert"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#definition> "Projection not specified."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#notation> "an"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#notation> "bd"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#notation> "ac"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#notation> "ap"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#definition> "Krovak."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#definition> "Mercator."@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#prefLabel> "orthographic"@en .
-<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#prefLabel> "polyconic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#definition> "Polar stereographic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#notation> "cc" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#definition> "Chamberlin trimetric."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#notation> "an" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#notation> "bg" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/description> "Indicates the projection used in producing the item."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#definition> "Projection not specified."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#notation> "dd" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#definition> "Lambert conformal."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#definition> "Equidistant conic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#notation> "dc" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#notation> "af" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's conformal conic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#notation> "bj" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's conformal conic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#definition> "Conic, other."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#notation> "de" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#prefLabel> "Cassini-Soldner"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#definition> "Cylindrical, other."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#prefLabel> "modified stereographic for Alaska"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#prefLabel> "cylindrical, other"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#definition> "Polyconic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#notation> "dg" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#notation> "bf" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#notation> "bz" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#definition> "Equirectangular."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#notation> "bk" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#notation> "cb" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#definition> "Krovak."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#prefLabel> "space oblique Mercator"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#definition> "Van Der Grinten."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#definition> "Goode's homolographic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's cylindrical equal area."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#definition> "Orthographic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#notation> "dh" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#notation> "zz" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#notation> "aa" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/alternative> "MARC21 008/22-23 values for maps expressed using RDF"@en .
 <https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#definition> "Aitoff."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#notation> "az" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#definition> "Butterfly."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gall"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#prefLabel> "Alber's equal area"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#notation> "br" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#definition> "Robinson."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#prefLabel> "cordiform"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#definition> "Miller."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#notation> "bo" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#prefLabel> "Mollweide"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#notation> "bh" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#definition> "Alber's equal area."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#definition> "Armadillo."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#definition> "General vertical near-sided."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#definition> "Sinusoidal."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#notation> "bi" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#definition> "Gall."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#notation> "bc" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/2004/02/skos/core#prefLabel> "equirectangular"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#definition> "Eckert."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#notation> "ac" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#notation> "ca" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#notation> "bs" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#notation> "df" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/2004/02/skos/core#definition> "Mollweide."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#prefLabel> "Van Der Grinten"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bk> <http://www.w3.org/2004/02/skos/core#prefLabel> "krovak"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#prefLabel> "oblique Mercator"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#prefLabel> "sinusoidal"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#df> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl> .
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#definition> "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#notation> "ad" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#prefLabel> "Goode's homolosine"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for most globes."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal, specific type unknown"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#notation> "au" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Eckert"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#definition> "Bonne."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#definition> "Cassini-Soldner."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/2004/02/skos/core#prefLabel> "Bonne"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#notation> "ap" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#definition> "Space oblique Mercator."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#zz> <http://www.w3.org/2004/02/skos/core#definition> "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#definition> "Stereographic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#prefLabel> "projection not specified"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#definition> "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal equidistant"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gnomic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/2004/02/skos/core#prefLabel> "Chamberlin trimetric"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#definition> "Lambert's azimuthal equal area."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#notation> "bb" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bb> <http://www.w3.org/2004/02/skos/core#prefLabel> "Goode's homolographic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#prefLabel> "conic, specific type unknown"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#notation> "cz" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cp> <http://www.w3.org/2004/02/skos/core#notation> "cp" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> <http://www.w3.org/2004/02/skos/core#notation> "##" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#prefLabel> "Miller's bipolar oblique conformal conic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#prefLabel> "Gauss-Kruger"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#notation> "cu" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#notation> "bu" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#notation> "ab" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#br> <http://www.w3.org/2004/02/skos/core#prefLabel> "Robinson"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bs> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#definition> "Mercator."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/2004/02/skos/core#notation> "ba" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#notation> "dl" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#definition> "Modified stereographic for Alaska."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bu> <http://www.w3.org/2004/02/skos/core#prefLabel> "cylindrical, specific type unknown"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal equidistant."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dh> <http://www.w3.org/2004/02/skos/core#definition> "Cordiform."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#prefLabel> "dimaxion"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#prefLabel> "equidistant conic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#definition> "Azimuthal, other."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#notation> "bd" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#notation> "be" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bd> <http://www.w3.org/2004/02/skos/core#prefLabel> "Mercator"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ad> <http://www.w3.org/2004/02/skos/core#prefLabel> "orthographic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ba> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#prefLabel> "transverse Mercator"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#notation> "bl" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bc> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's cylindrical equal area"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/2004/02/skos/core#notation> "ae" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ab> <http://www.w3.org/2004/02/skos/core#definition> "Gnomic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847> <http://purl.org/dc/terms/title> "Maps: projection"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#prefLabel> "Miller"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ca> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#af> <http://www.w3.org/2004/02/skos/core#prefLabel> "stereographic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bi> <http://www.w3.org/2004/02/skos/core#definition> "Gauss-Kruger."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cz> <http://www.w3.org/2004/02/skos/core#prefLabel> "conic, other"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bo> <http://www.w3.org/2004/02/skos/core#definition> "Oblique Mercator."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#prefLabel> "butterfly"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dg> <http://www.w3.org/2004/02/skos/core#definition> "Dimaxion."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#au> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#prefLabel> "general vertical near-sided"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ae> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dl> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert conformal"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#db> <http://www.w3.org/2004/02/skos/core#notation> "db" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ac> <http://www.w3.org/2004/02/skos/core#prefLabel> "Lambert's azimuthal equal area"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ap> <http://www.w3.org/2004/02/skos/core#prefLabel> "polar stereographic"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bh> <http://www.w3.org/2004/02/skos/core#definition> "Transverse Mercator."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#cu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ag> <http://www.w3.org/2004/02/skos/core#notation> "ag" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#az> <http://www.w3.org/2004/02/skos/core#prefLabel> "azimuthal, other"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#prefLabel> "armadillo"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#da> <http://www.w3.org/2004/02/skos/core#notation> "da" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#am> <http://www.w3.org/2004/02/skos/core#notation> "am" .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#dd> <http://www.w3.org/2004/02/skos/core#definition> "Goode's homolosine."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#be> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#de> <http://www.w3.org/2004/02/skos/core#definition> "Miller's bipolar oblique conformal conic."@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#aa> <http://www.w3.org/2004/02/skos/core#prefLabel> "Aitoff"@en .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#bl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.4jrs-m847> .
+<https://doi.org/10.6069/uwlswd.4jrs-m847#ce> <http://www.w3.org/2004/02/skos/core#notation> "ce" .

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -1,47 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Miller</skos:prefLabel>
-    <skos:definition xml:lang="en">Miller.</skos:definition>
-    <skos:notation>be</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Alber's equal area</skos:prefLabel>
-    <skos:definition xml:lang="en">Alber's equal area.</skos:definition>
-    <skos:notation>ca</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Goode's homolographic</skos:prefLabel>
-    <skos:definition xml:lang="en">Goode's homolographic.</skos:definition>
-    <skos:notation>bb</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Lambert conformal</skos:prefLabel>
-    <skos:definition xml:lang="en">Lambert conformal.</skos:definition>
-    <skos:notation>dl</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Robinson</skos:prefLabel>
-    <skos:definition xml:lang="en">Robinson.</skos:definition>
-    <skos:notation>br</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">projection not specified</skos:prefLabel>
-    <skos:definition xml:lang="en">Projection not specified.</skos:definition>
-    <skos:notation>##</skos:notation>
-    <skos:scopeNote xml:lang="en">Used for most globes.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">stereographic</skos:prefLabel>
+    <skos:definition xml:lang="en">Stereographic.</skos:definition>
+    <skos:notation>af</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -50,40 +20,40 @@
     <skos:definition xml:lang="en">Cordiform.</skos:definition>
     <skos:notation>dh</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Miller's bipolar oblique conformal conic</skos:prefLabel>
-    <skos:definition xml:lang="en">Miller's bipolar oblique conformal conic.</skos:definition>
-    <skos:notation>de</skos:notation>
+    <skos:prefLabel xml:lang="en">Alber's equal area</skos:prefLabel>
+    <skos:definition xml:lang="en">Alber's equal area.</skos:definition>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bs">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">conic, other</skos:prefLabel>
-    <skos:definition xml:lang="en">Conic, other.</skos:definition>
-    <skos:notation>cz</skos:notation>
+    <skos:prefLabel xml:lang="en">space oblique Mercator</skos:prefLabel>
+    <skos:definition xml:lang="en">Space oblique Mercator.</skos:definition>
+    <skos:notation>bs</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">azimuthal, specific type unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.</skos:definition>
-    <skos:notation>au</skos:notation>
+    <skos:prefLabel xml:lang="en">equidistant conic</skos:prefLabel>
+    <skos:definition xml:lang="en">Equidistant conic.</skos:definition>
+    <skos:notation>ce</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">krovak</skos:prefLabel>
-    <skos:definition xml:lang="en">Krovak.</skos:definition>
-    <skos:notation>bk</skos:notation>
+    <skos:prefLabel xml:lang="en">polyconic</skos:prefLabel>
+    <skos:definition xml:lang="en">Polyconic.</skos:definition>
+    <skos:notation>cp</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">oblique Mercator</skos:prefLabel>
-    <skos:definition xml:lang="en">Oblique Mercator.</skos:definition>
-    <skos:notation>bo</skos:notation>
+    <skos:prefLabel xml:lang="en">Bonne</skos:prefLabel>
+    <skos:definition xml:lang="en">Bonne.</skos:definition>
+    <skos:notation>cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#am">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -91,6 +61,13 @@
     <skos:prefLabel xml:lang="en">modified stereographic for Alaska</skos:prefLabel>
     <skos:definition xml:lang="en">Modified stereographic for Alaska.</skos:definition>
     <skos:notation>am</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">polar stereographic</skos:prefLabel>
+    <skos:definition xml:lang="en">Polar stereographic.</skos:definition>
+    <skos:notation>ap</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -116,12 +93,83 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bs">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">space oblique Mercator</skos:prefLabel>
-    <skos:definition xml:lang="en">Space oblique Mercator.</skos:definition>
-    <skos:notation>bs</skos:notation>
+    <skos:prefLabel xml:lang="en">Gnomic</skos:prefLabel>
+    <skos:definition xml:lang="en">Gnomic.</skos:definition>
+    <skos:notation>ab</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Lambert's conformal conic</skos:prefLabel>
+    <skos:definition xml:lang="en">Lambert's conformal conic.</skos:definition>
+    <skos:notation>cc</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Chamberlin trimetric</skos:prefLabel>
+    <skos:definition xml:lang="en">Chamberlin trimetric.</skos:definition>
+    <skos:notation>an</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">azimuthal, specific type unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.</skos:definition>
+    <skos:notation>au</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.</skos:definition>
+    <skos:notation>zz</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">sinusoidal</skos:prefLabel>
+    <skos:definition xml:lang="en">Sinusoidal.</skos:definition>
+    <skos:notation>bg</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">projection not specified</skos:prefLabel>
+    <skos:definition xml:lang="en">Projection not specified.</skos:definition>
+    <skos:notation>##</skos:notation>
+    <skos:scopeNote xml:lang="en">Used for most globes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Robinson</skos:prefLabel>
+    <skos:definition xml:lang="en">Robinson.</skos:definition>
+    <skos:notation>br</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">azimuthal, other</skos:prefLabel>
+    <skos:definition xml:lang="en">Azimuthal, other.</skos:definition>
+    <skos:notation>az</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Goode's homolosine</skos:prefLabel>
+    <skos:definition xml:lang="en">Goode's homolosine.</skos:definition>
+    <skos:notation>dd</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Lambert conformal</skos:prefLabel>
+    <skos:definition xml:lang="en">Lambert conformal.</skos:definition>
+    <skos:notation>dl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -130,54 +178,33 @@
     <skos:definition xml:lang="en">Eckert.</skos:definition>
     <skos:notation>dc</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">general vertical near-sided</skos:prefLabel>
-    <skos:definition xml:lang="en">General vertical near-sided.</skos:definition>
-    <skos:notation>ag</skos:notation>
+    <skos:prefLabel xml:lang="en">equirectangular</skos:prefLabel>
+    <skos:definition xml:lang="en">Equirectangular.</skos:definition>
+    <skos:notation>bj</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">stereographic</skos:prefLabel>
-    <skos:definition xml:lang="en">Stereographic.</skos:definition>
-    <skos:notation>af</skos:notation>
+    <skos:prefLabel xml:lang="en">conic, other</skos:prefLabel>
+    <skos:definition xml:lang="en">Conic, other.</skos:definition>
+    <skos:notation>cz</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Lambert's azimuthal equal area</skos:prefLabel>
-    <skos:definition xml:lang="en">Lambert's azimuthal equal area.</skos:definition>
-    <skos:notation>ac</skos:notation>
+    <skos:prefLabel xml:lang="en">azimuthal equidistant</skos:prefLabel>
+    <skos:definition xml:lang="en">Azimuthal equidistant.</skos:definition>
+    <skos:notation>ae</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Aitoff</skos:prefLabel>
-    <skos:definition xml:lang="en">Aitoff.</skos:definition>
-    <skos:notation>aa</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Bonne</skos:prefLabel>
-    <skos:definition xml:lang="en">Bonne.</skos:definition>
-    <skos:notation>cb</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">conic, specific type unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.</skos:definition>
-    <skos:notation>cu</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">cylindrical, specific type unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.</skos:definition>
-    <skos:notation>bu</skos:notation>
+    <skos:prefLabel xml:lang="en">Miller's bipolar oblique conformal conic</skos:prefLabel>
+    <skos:definition xml:lang="en">Miller's bipolar oblique conformal conic.</skos:definition>
+    <skos:notation>de</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -193,89 +220,12 @@
     <skos:definition xml:lang="en">Cylindrical, other.</skos:definition>
     <skos:notation>bz</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Lambert's conformal conic</skos:prefLabel>
-    <skos:definition xml:lang="en">Lambert's conformal conic.</skos:definition>
-    <skos:notation>cc</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">armadillo</skos:prefLabel>
-    <skos:definition xml:lang="en">Armadillo.</skos:definition>
-    <skos:notation>da</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">polar stereographic</skos:prefLabel>
-    <skos:definition xml:lang="en">Polar stereographic.</skos:definition>
-    <skos:notation>ap</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">equidistant conic</skos:prefLabel>
-    <skos:definition xml:lang="en">Equidistant conic.</skos:definition>
-    <skos:notation>ce</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">azimuthal equidistant</skos:prefLabel>
-    <skos:definition xml:lang="en">Azimuthal equidistant.</skos:definition>
-    <skos:notation>ae</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Mollweide</skos:prefLabel>
-    <skos:definition xml:lang="en">Mollweide.</skos:definition>
-    <skos:notation>bf</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Chamberlin trimetric</skos:prefLabel>
-    <skos:definition xml:lang="en">Chamberlin trimetric.</skos:definition>
-    <skos:notation>an</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Lambert's cylindrical equal area</skos:prefLabel>
-    <skos:definition xml:lang="en">Lambert's cylindrical equal area.</skos:definition>
-    <skos:notation>bc</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Van Der Grinten</skos:prefLabel>
-    <skos:definition xml:lang="en">Van Der Grinten.</skos:definition>
-    <skos:notation>df</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">orthographic</skos:prefLabel>
-    <skos:definition xml:lang="en">Orthographic.</skos:definition>
-    <skos:notation>ad</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Gauss-Kruger</skos:prefLabel>
-    <skos:definition xml:lang="en">Gauss-Kruger.</skos:definition>
-    <skos:notation>bi</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">equirectangular</skos:prefLabel>
-    <skos:definition xml:lang="en">Equirectangular.</skos:definition>
-    <skos:notation>bj</skos:notation>
+    <skos:prefLabel xml:lang="en">krovak</skos:prefLabel>
+    <skos:definition xml:lang="en">Krovak.</skos:definition>
+    <skos:notation>bk</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -284,47 +234,54 @@
     <skos:definition xml:lang="en">Dimaxion.</skos:definition>
     <skos:notation>dg</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">transverse Mercator</skos:prefLabel>
-    <skos:definition xml:lang="en">Transverse Mercator.</skos:definition>
-    <skos:notation>bh</skos:notation>
+    <skos:prefLabel xml:lang="en">Mollweide</skos:prefLabel>
+    <skos:definition xml:lang="en">Mollweide.</skos:definition>
+    <skos:notation>bf</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Gnomic</skos:prefLabel>
-    <skos:definition xml:lang="en">Gnomic.</skos:definition>
-    <skos:notation>ab</skos:notation>
+    <skos:prefLabel xml:lang="en">Van Der Grinten</skos:prefLabel>
+    <skos:definition xml:lang="en">Van Der Grinten.</skos:definition>
+    <skos:notation>df</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">sinusoidal</skos:prefLabel>
-    <skos:definition xml:lang="en">Sinusoidal.</skos:definition>
-    <skos:notation>bg</skos:notation>
+    <skos:prefLabel xml:lang="en">Goode's homolographic</skos:prefLabel>
+    <skos:definition xml:lang="en">Goode's homolographic.</skos:definition>
+    <skos:notation>bb</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">polyconic</skos:prefLabel>
-    <skos:definition xml:lang="en">Polyconic.</skos:definition>
-    <skos:notation>cp</skos:notation>
+    <skos:prefLabel xml:lang="en">Lambert's cylindrical equal area</skos:prefLabel>
+    <skos:definition xml:lang="en">Lambert's cylindrical equal area.</skos:definition>
+    <skos:notation>bc</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.</skos:definition>
-    <skos:notation>zz</skos:notation>
+    <skos:prefLabel xml:lang="en">orthographic</skos:prefLabel>
+    <skos:definition xml:lang="en">Orthographic.</skos:definition>
+    <skos:notation>ad</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">azimuthal, other</skos:prefLabel>
-    <skos:definition xml:lang="en">Azimuthal, other.</skos:definition>
-    <skos:notation>az</skos:notation>
+    <skos:prefLabel xml:lang="en">Aitoff</skos:prefLabel>
+    <skos:definition xml:lang="en">Aitoff.</skos:definition>
+    <skos:notation>aa</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Mercator</skos:prefLabel>
+    <skos:definition xml:lang="en">Mercator.</skos:definition>
+    <skos:notation>bd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -333,13 +290,6 @@
     <skos:definition xml:lang="en">Butterfly.</skos:definition>
     <skos:notation>db</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Goode's homolosine</skos:prefLabel>
-    <skos:definition xml:lang="en">Goode's homolosine.</skos:definition>
-    <skos:notation>dd</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
@@ -347,11 +297,67 @@
     <skos:definition xml:lang="en">Gall.</skos:definition>
     <skos:notation>ba</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
-    <skos:prefLabel xml:lang="en">Mercator</skos:prefLabel>
-    <skos:definition xml:lang="en">Mercator.</skos:definition>
-    <skos:notation>bd</skos:notation>
+    <skos:prefLabel xml:lang="en">armadillo</skos:prefLabel>
+    <skos:definition xml:lang="en">Armadillo.</skos:definition>
+    <skos:notation>da</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Miller</skos:prefLabel>
+    <skos:definition xml:lang="en">Miller.</skos:definition>
+    <skos:notation>be</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">oblique Mercator</skos:prefLabel>
+    <skos:definition xml:lang="en">Oblique Mercator.</skos:definition>
+    <skos:notation>bo</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">transverse Mercator</skos:prefLabel>
+    <skos:definition xml:lang="en">Transverse Mercator.</skos:definition>
+    <skos:notation>bh</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">general vertical near-sided</skos:prefLabel>
+    <skos:definition xml:lang="en">General vertical near-sided.</skos:definition>
+    <skos:notation>ag</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Gauss-Kruger</skos:prefLabel>
+    <skos:definition xml:lang="en">Gauss-Kruger.</skos:definition>
+    <skos:notation>bi</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">cylindrical, specific type unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.</skos:definition>
+    <skos:notation>bu</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">Lambert's azimuthal equal area</skos:prefLabel>
+    <skos:definition xml:lang="en">Lambert's azimuthal equal area.</skos:definition>
+    <skos:notation>ac</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
+    <skos:prefLabel xml:lang="en">conic, specific type unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.</skos:definition>
+    <skos:notation>cu</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -1,52 +1,46 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller</skos:prefLabel>
     <skos:definition xml:lang="en">Miller.</skos:definition>
-    <skos:notation xml:lang="en">be</skos:notation>
+    <skos:notation>be</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Alber's equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Alber's equal area.</skos:definition>
-    <skos:notation xml:lang="en">ca</skos:notation>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolographic</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolographic.</skos:definition>
-    <skos:notation xml:lang="en">bb</skos:notation>
+    <skos:notation>bb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert conformal</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert conformal.</skos:definition>
-    <skos:notation xml:lang="en">dl</skos:notation>
+    <skos:notation>dl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Robinson</skos:prefLabel>
     <skos:definition xml:lang="en">Robinson.</skos:definition>
-    <skos:notation xml:lang="en">br</skos:notation>
+    <skos:notation>br</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">projection not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Projection not specified.</skos:definition>
-    <skos:notation xml:lang="en">##</skos:notation>
+    <skos:notation>##</skos:notation>
     <skos:scopeNote xml:lang="en">Used for most globes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh">
@@ -54,49 +48,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cordiform</skos:prefLabel>
     <skos:definition xml:lang="en">Cordiform.</skos:definition>
-    <skos:notation xml:lang="en">dh</skos:notation>
+    <skos:notation>dh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller's bipolar oblique conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Miller's bipolar oblique conformal conic.</skos:definition>
-    <skos:notation xml:lang="en">de</skos:notation>
+    <skos:notation>de</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, other</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, other.</skos:definition>
-    <skos:notation xml:lang="en">cz</skos:notation>
+    <skos:notation>cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">au</skos:notation>
+    <skos:notation>au</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">krovak</skos:prefLabel>
     <skos:definition xml:lang="en">Krovak.</skos:definition>
-    <skos:notation xml:lang="en">bk</skos:notation>
+    <skos:notation>bk</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Oblique Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bo</skos:notation>
+    <skos:notation>bo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#am">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">modified stereographic for Alaska</skos:prefLabel>
     <skos:definition xml:lang="en">Modified stereographic for Alaska.</skos:definition>
-    <skos:notation xml:lang="en">am</skos:notation>
+    <skos:notation>am</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -104,7 +98,7 @@
     <dct:title xml:lang="en">Maps: projection</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22-23 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the projection used in producing the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -127,237 +121,237 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">space oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Space oblique Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bs</skos:notation>
+    <skos:notation>bs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Eckert</skos:prefLabel>
     <skos:definition xml:lang="en">Eckert.</skos:definition>
-    <skos:notation xml:lang="en">dc</skos:notation>
+    <skos:notation>dc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">general vertical near-sided</skos:prefLabel>
     <skos:definition xml:lang="en">General vertical near-sided.</skos:definition>
-    <skos:notation xml:lang="en">ag</skos:notation>
+    <skos:notation>ag</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Stereographic.</skos:definition>
-    <skos:notation xml:lang="en">af</skos:notation>
+    <skos:notation>af</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's azimuthal equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's azimuthal equal area.</skos:definition>
-    <skos:notation xml:lang="en">ac</skos:notation>
+    <skos:notation>ac</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Aitoff</skos:prefLabel>
     <skos:definition xml:lang="en">Aitoff.</skos:definition>
-    <skos:notation xml:lang="en">aa</skos:notation>
+    <skos:notation>aa</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Bonne</skos:prefLabel>
     <skos:definition xml:lang="en">Bonne.</skos:definition>
-    <skos:notation xml:lang="en">cb</skos:notation>
+    <skos:notation>cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">cu</skos:notation>
+    <skos:notation>cu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">bu</skos:notation>
+    <skos:notation>bu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Cassini-Soldner</skos:prefLabel>
     <skos:definition xml:lang="en">Cassini-Soldner.</skos:definition>
-    <skos:notation xml:lang="en">bl</skos:notation>
+    <skos:notation>bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, other</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, other.</skos:definition>
-    <skos:notation xml:lang="en">bz</skos:notation>
+    <skos:notation>bz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's conformal conic.</skos:definition>
-    <skos:notation xml:lang="en">cc</skos:notation>
+    <skos:notation>cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">armadillo</skos:prefLabel>
     <skos:definition xml:lang="en">Armadillo.</skos:definition>
-    <skos:notation xml:lang="en">da</skos:notation>
+    <skos:notation>da</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polar stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Polar stereographic.</skos:definition>
-    <skos:notation xml:lang="en">ap</skos:notation>
+    <skos:notation>ap</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equidistant conic</skos:prefLabel>
     <skos:definition xml:lang="en">Equidistant conic.</skos:definition>
-    <skos:notation xml:lang="en">ce</skos:notation>
+    <skos:notation>ce</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal equidistant</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal equidistant.</skos:definition>
-    <skos:notation xml:lang="en">ae</skos:notation>
+    <skos:notation>ae</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mollweide</skos:prefLabel>
     <skos:definition xml:lang="en">Mollweide.</skos:definition>
-    <skos:notation xml:lang="en">bf</skos:notation>
+    <skos:notation>bf</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Chamberlin trimetric</skos:prefLabel>
     <skos:definition xml:lang="en">Chamberlin trimetric.</skos:definition>
-    <skos:notation xml:lang="en">an</skos:notation>
+    <skos:notation>an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's cylindrical equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's cylindrical equal area.</skos:definition>
-    <skos:notation xml:lang="en">bc</skos:notation>
+    <skos:notation>bc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Van Der Grinten</skos:prefLabel>
     <skos:definition xml:lang="en">Van Der Grinten.</skos:definition>
-    <skos:notation xml:lang="en">df</skos:notation>
+    <skos:notation>df</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">orthographic</skos:prefLabel>
     <skos:definition xml:lang="en">Orthographic.</skos:definition>
-    <skos:notation xml:lang="en">ad</skos:notation>
+    <skos:notation>ad</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gauss-Kruger</skos:prefLabel>
     <skos:definition xml:lang="en">Gauss-Kruger.</skos:definition>
-    <skos:notation xml:lang="en">bi</skos:notation>
+    <skos:notation>bi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equirectangular</skos:prefLabel>
     <skos:definition xml:lang="en">Equirectangular.</skos:definition>
-    <skos:notation xml:lang="en">bj</skos:notation>
+    <skos:notation>bj</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">dimaxion</skos:prefLabel>
     <skos:definition xml:lang="en">Dimaxion.</skos:definition>
-    <skos:notation xml:lang="en">dg</skos:notation>
+    <skos:notation>dg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">transverse Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Transverse Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bh</skos:notation>
+    <skos:notation>bh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gnomic</skos:prefLabel>
     <skos:definition xml:lang="en">Gnomic.</skos:definition>
-    <skos:notation xml:lang="en">ab</skos:notation>
+    <skos:notation>ab</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">sinusoidal</skos:prefLabel>
     <skos:definition xml:lang="en">Sinusoidal.</skos:definition>
-    <skos:notation xml:lang="en">bg</skos:notation>
+    <skos:notation>bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polyconic</skos:prefLabel>
     <skos:definition xml:lang="en">Polyconic.</skos:definition>
-    <skos:notation xml:lang="en">cp</skos:notation>
+    <skos:notation>cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.</skos:definition>
-    <skos:notation xml:lang="en">zz</skos:notation>
+    <skos:notation>zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, other</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, other.</skos:definition>
-    <skos:notation xml:lang="en">az</skos:notation>
+    <skos:notation>az</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">butterfly</skos:prefLabel>
     <skos:definition xml:lang="en">Butterfly.</skos:definition>
-    <skos:notation xml:lang="en">db</skos:notation>
+    <skos:notation>db</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolosine</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolosine.</skos:definition>
-    <skos:notation xml:lang="en">dd</skos:notation>
+    <skos:notation>dd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gall</skos:prefLabel>
     <skos:definition xml:lang="en">Gall.</skos:definition>
-    <skos:notation xml:lang="en">ba</skos:notation>
+    <skos:notation>ba</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bd</skos:notation>
+    <skos:notation>bd</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -102,7 +102,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -1,52 +1,46 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller</skos:prefLabel>
     <skos:definition xml:lang="en">Miller.</skos:definition>
-    <skos:notation xml:lang="en">be</skos:notation>
+    <skos:notation>be</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Alber's equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Alber's equal area.</skos:definition>
-    <skos:notation xml:lang="en">ca</skos:notation>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolographic</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolographic.</skos:definition>
-    <skos:notation xml:lang="en">bb</skos:notation>
+    <skos:notation>bb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert conformal</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert conformal.</skos:definition>
-    <skos:notation xml:lang="en">dl</skos:notation>
+    <skos:notation>dl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Robinson</skos:prefLabel>
     <skos:definition xml:lang="en">Robinson.</skos:definition>
-    <skos:notation xml:lang="en">br</skos:notation>
+    <skos:notation>br</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">projection not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Projection not specified.</skos:definition>
-    <skos:notation xml:lang="en">##</skos:notation>
+    <skos:notation>##</skos:notation>
     <skos:scopeNote xml:lang="en">Used for most globes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh">
@@ -54,49 +48,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cordiform</skos:prefLabel>
     <skos:definition xml:lang="en">Cordiform.</skos:definition>
-    <skos:notation xml:lang="en">dh</skos:notation>
+    <skos:notation>dh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller's bipolar oblique conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Miller's bipolar oblique conformal conic.</skos:definition>
-    <skos:notation xml:lang="en">de</skos:notation>
+    <skos:notation>de</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, other</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, other.</skos:definition>
-    <skos:notation xml:lang="en">cz</skos:notation>
+    <skos:notation>cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">au</skos:notation>
+    <skos:notation>au</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">krovak</skos:prefLabel>
     <skos:definition xml:lang="en">Krovak.</skos:definition>
-    <skos:notation xml:lang="en">bk</skos:notation>
+    <skos:notation>bk</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Oblique Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bo</skos:notation>
+    <skos:notation>bo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#am">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">modified stereographic for Alaska</skos:prefLabel>
     <skos:definition xml:lang="en">Modified stereographic for Alaska.</skos:definition>
-    <skos:notation xml:lang="en">am</skos:notation>
+    <skos:notation>am</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -104,7 +98,7 @@
     <dct:title xml:lang="en">Maps: projection</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22-23 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the projection used in producing the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -115,7 +109,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld"/>
@@ -127,237 +121,237 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">space oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Space oblique Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bs</skos:notation>
+    <skos:notation>bs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Eckert</skos:prefLabel>
     <skos:definition xml:lang="en">Eckert.</skos:definition>
-    <skos:notation xml:lang="en">dc</skos:notation>
+    <skos:notation>dc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">general vertical near-sided</skos:prefLabel>
     <skos:definition xml:lang="en">General vertical near-sided.</skos:definition>
-    <skos:notation xml:lang="en">ag</skos:notation>
+    <skos:notation>ag</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Stereographic.</skos:definition>
-    <skos:notation xml:lang="en">af</skos:notation>
+    <skos:notation>af</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's azimuthal equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's azimuthal equal area.</skos:definition>
-    <skos:notation xml:lang="en">ac</skos:notation>
+    <skos:notation>ac</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Aitoff</skos:prefLabel>
     <skos:definition xml:lang="en">Aitoff.</skos:definition>
-    <skos:notation xml:lang="en">aa</skos:notation>
+    <skos:notation>aa</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Bonne</skos:prefLabel>
     <skos:definition xml:lang="en">Bonne.</skos:definition>
-    <skos:notation xml:lang="en">cb</skos:notation>
+    <skos:notation>cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">cu</skos:notation>
+    <skos:notation>cu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.</skos:definition>
-    <skos:notation xml:lang="en">bu</skos:notation>
+    <skos:notation>bu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Cassini-Soldner</skos:prefLabel>
     <skos:definition xml:lang="en">Cassini-Soldner.</skos:definition>
-    <skos:notation xml:lang="en">bl</skos:notation>
+    <skos:notation>bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, other</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, other.</skos:definition>
-    <skos:notation xml:lang="en">bz</skos:notation>
+    <skos:notation>bz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's conformal conic.</skos:definition>
-    <skos:notation xml:lang="en">cc</skos:notation>
+    <skos:notation>cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">armadillo</skos:prefLabel>
     <skos:definition xml:lang="en">Armadillo.</skos:definition>
-    <skos:notation xml:lang="en">da</skos:notation>
+    <skos:notation>da</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polar stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Polar stereographic.</skos:definition>
-    <skos:notation xml:lang="en">ap</skos:notation>
+    <skos:notation>ap</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equidistant conic</skos:prefLabel>
     <skos:definition xml:lang="en">Equidistant conic.</skos:definition>
-    <skos:notation xml:lang="en">ce</skos:notation>
+    <skos:notation>ce</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal equidistant</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal equidistant.</skos:definition>
-    <skos:notation xml:lang="en">ae</skos:notation>
+    <skos:notation>ae</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mollweide</skos:prefLabel>
     <skos:definition xml:lang="en">Mollweide.</skos:definition>
-    <skos:notation xml:lang="en">bf</skos:notation>
+    <skos:notation>bf</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Chamberlin trimetric</skos:prefLabel>
     <skos:definition xml:lang="en">Chamberlin trimetric.</skos:definition>
-    <skos:notation xml:lang="en">an</skos:notation>
+    <skos:notation>an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's cylindrical equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's cylindrical equal area.</skos:definition>
-    <skos:notation xml:lang="en">bc</skos:notation>
+    <skos:notation>bc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Van Der Grinten</skos:prefLabel>
     <skos:definition xml:lang="en">Van Der Grinten.</skos:definition>
-    <skos:notation xml:lang="en">df</skos:notation>
+    <skos:notation>df</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">orthographic</skos:prefLabel>
     <skos:definition xml:lang="en">Orthographic.</skos:definition>
-    <skos:notation xml:lang="en">ad</skos:notation>
+    <skos:notation>ad</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gauss-Kruger</skos:prefLabel>
     <skos:definition xml:lang="en">Gauss-Kruger.</skos:definition>
-    <skos:notation xml:lang="en">bi</skos:notation>
+    <skos:notation>bi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equirectangular</skos:prefLabel>
     <skos:definition xml:lang="en">Equirectangular.</skos:definition>
-    <skos:notation xml:lang="en">bj</skos:notation>
+    <skos:notation>bj</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">dimaxion</skos:prefLabel>
     <skos:definition xml:lang="en">Dimaxion.</skos:definition>
-    <skos:notation xml:lang="en">dg</skos:notation>
+    <skos:notation>dg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">transverse Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Transverse Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bh</skos:notation>
+    <skos:notation>bh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gnomic</skos:prefLabel>
     <skos:definition xml:lang="en">Gnomic.</skos:definition>
-    <skos:notation xml:lang="en">ab</skos:notation>
+    <skos:notation>ab</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">sinusoidal</skos:prefLabel>
     <skos:definition xml:lang="en">Sinusoidal.</skos:definition>
-    <skos:notation xml:lang="en">bg</skos:notation>
+    <skos:notation>bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polyconic</skos:prefLabel>
     <skos:definition xml:lang="en">Polyconic.</skos:definition>
-    <skos:notation xml:lang="en">cp</skos:notation>
+    <skos:notation>cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.</skos:definition>
-    <skos:notation xml:lang="en">zz</skos:notation>
+    <skos:notation>zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, other</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, other.</skos:definition>
-    <skos:notation xml:lang="en">az</skos:notation>
+    <skos:notation>az</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">butterfly</skos:prefLabel>
     <skos:definition xml:lang="en">Butterfly.</skos:definition>
-    <skos:notation xml:lang="en">db</skos:notation>
+    <skos:notation>db</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolosine</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolosine.</skos:definition>
-    <skos:notation xml:lang="en">dd</skos:notation>
+    <skos:notation>dd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gall</skos:prefLabel>
     <skos:definition xml:lang="en">Gall.</skos:definition>
-    <skos:notation xml:lang="en">ba</skos:notation>
+    <skos:notation>ba</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Mercator.</skos:definition>
-    <skos:notation xml:lang="en">bd</skos:notation>
+    <skos:notation>bd</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -109,7 +109,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld"/>

--- a/008/maps_projection/maps_projection.rdf
+++ b/008/maps_projection/maps_projection.rdf
@@ -1,46 +1,52 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#be">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller</skos:prefLabel>
     <skos:definition xml:lang="en">Miller.</skos:definition>
-    <skos:notation>be</skos:notation>
+    <skos:notation xml:lang="en">be</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Alber's equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Alber's equal area.</skos:definition>
-    <skos:notation>ca</skos:notation>
+    <skos:notation xml:lang="en">ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolographic</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolographic.</skos:definition>
-    <skos:notation>bb</skos:notation>
+    <skos:notation xml:lang="en">bb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert conformal</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert conformal.</skos:definition>
-    <skos:notation>dl</skos:notation>
+    <skos:notation xml:lang="en">dl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#br">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Robinson</skos:prefLabel>
     <skos:definition xml:lang="en">Robinson.</skos:definition>
-    <skos:notation>br</skos:notation>
+    <skos:notation xml:lang="en">br</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#pound2">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">projection not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Projection not specified.</skos:definition>
-    <skos:notation>##</skos:notation>
+    <skos:notation xml:lang="en">##</skos:notation>
     <skos:scopeNote xml:lang="en">Used for most globes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dh">
@@ -48,49 +54,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cordiform</skos:prefLabel>
     <skos:definition xml:lang="en">Cordiform.</skos:definition>
-    <skos:notation>dh</skos:notation>
+    <skos:notation xml:lang="en">dh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#de">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Miller's bipolar oblique conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Miller's bipolar oblique conformal conic.</skos:definition>
-    <skos:notation>de</skos:notation>
+    <skos:notation xml:lang="en">de</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, other</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, other.</skos:definition>
-    <skos:notation>cz</skos:notation>
+    <skos:notation xml:lang="en">cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#au">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection.</skos:definition>
-    <skos:notation>au</skos:notation>
+    <skos:notation xml:lang="en">au</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bk">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">krovak</skos:prefLabel>
     <skos:definition xml:lang="en">Krovak.</skos:definition>
-    <skos:notation>bk</skos:notation>
+    <skos:notation xml:lang="en">bk</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Oblique Mercator.</skos:definition>
-    <skos:notation>bo</skos:notation>
+    <skos:notation xml:lang="en">bo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#am">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">modified stereographic for Alaska</skos:prefLabel>
     <skos:definition xml:lang="en">Modified stereographic for Alaska.</skos:definition>
-    <skos:notation>am</skos:notation>
+    <skos:notation xml:lang="en">am</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -98,7 +104,7 @@
     <dct:title xml:lang="en">Maps: projection</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22-23 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the projection used in producing the item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -109,7 +115,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.jsonld"/>
@@ -121,237 +127,237 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">space oblique Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Space oblique Mercator.</skos:definition>
-    <skos:notation>bs</skos:notation>
+    <skos:notation xml:lang="en">bs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Eckert</skos:prefLabel>
     <skos:definition xml:lang="en">Eckert.</skos:definition>
-    <skos:notation>dc</skos:notation>
+    <skos:notation xml:lang="en">dc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ag">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">general vertical near-sided</skos:prefLabel>
     <skos:definition xml:lang="en">General vertical near-sided.</skos:definition>
-    <skos:notation>ag</skos:notation>
+    <skos:notation xml:lang="en">ag</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#af">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Stereographic.</skos:definition>
-    <skos:notation>af</skos:notation>
+    <skos:notation xml:lang="en">af</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ac">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's azimuthal equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's azimuthal equal area.</skos:definition>
-    <skos:notation>ac</skos:notation>
+    <skos:notation xml:lang="en">ac</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#aa">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Aitoff</skos:prefLabel>
     <skos:definition xml:lang="en">Aitoff.</skos:definition>
-    <skos:notation>aa</skos:notation>
+    <skos:notation xml:lang="en">aa</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Bonne</skos:prefLabel>
     <skos:definition xml:lang="en">Bonne.</skos:definition>
-    <skos:notation>cb</skos:notation>
+    <skos:notation xml:lang="en">cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">conic, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection.</skos:definition>
-    <skos:notation>cu</skos:notation>
+    <skos:notation xml:lang="en">cu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, specific type unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection.</skos:definition>
-    <skos:notation>bu</skos:notation>
+    <skos:notation xml:lang="en">bu</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Cassini-Soldner</skos:prefLabel>
     <skos:definition xml:lang="en">Cassini-Soldner.</skos:definition>
-    <skos:notation>bl</skos:notation>
+    <skos:notation xml:lang="en">bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">cylindrical, other</skos:prefLabel>
     <skos:definition xml:lang="en">Cylindrical, other.</skos:definition>
-    <skos:notation>bz</skos:notation>
+    <skos:notation xml:lang="en">bz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's conformal conic</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's conformal conic.</skos:definition>
-    <skos:notation>cc</skos:notation>
+    <skos:notation xml:lang="en">cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#da">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">armadillo</skos:prefLabel>
     <skos:definition xml:lang="en">Armadillo.</skos:definition>
-    <skos:notation>da</skos:notation>
+    <skos:notation xml:lang="en">da</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ap">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polar stereographic</skos:prefLabel>
     <skos:definition xml:lang="en">Polar stereographic.</skos:definition>
-    <skos:notation>ap</skos:notation>
+    <skos:notation xml:lang="en">ap</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ce">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equidistant conic</skos:prefLabel>
     <skos:definition xml:lang="en">Equidistant conic.</skos:definition>
-    <skos:notation>ce</skos:notation>
+    <skos:notation xml:lang="en">ce</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ae">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal equidistant</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal equidistant.</skos:definition>
-    <skos:notation>ae</skos:notation>
+    <skos:notation xml:lang="en">ae</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bf">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mollweide</skos:prefLabel>
     <skos:definition xml:lang="en">Mollweide.</skos:definition>
-    <skos:notation>bf</skos:notation>
+    <skos:notation xml:lang="en">bf</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Chamberlin trimetric</skos:prefLabel>
     <skos:definition xml:lang="en">Chamberlin trimetric.</skos:definition>
-    <skos:notation>an</skos:notation>
+    <skos:notation xml:lang="en">an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Lambert's cylindrical equal area</skos:prefLabel>
     <skos:definition xml:lang="en">Lambert's cylindrical equal area.</skos:definition>
-    <skos:notation>bc</skos:notation>
+    <skos:notation xml:lang="en">bc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Van Der Grinten</skos:prefLabel>
     <skos:definition xml:lang="en">Van Der Grinten.</skos:definition>
-    <skos:notation>df</skos:notation>
+    <skos:notation xml:lang="en">df</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ad">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">orthographic</skos:prefLabel>
     <skos:definition xml:lang="en">Orthographic.</skos:definition>
-    <skos:notation>ad</skos:notation>
+    <skos:notation xml:lang="en">ad</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gauss-Kruger</skos:prefLabel>
     <skos:definition xml:lang="en">Gauss-Kruger.</skos:definition>
-    <skos:notation>bi</skos:notation>
+    <skos:notation xml:lang="en">bi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bj">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">equirectangular</skos:prefLabel>
     <skos:definition xml:lang="en">Equirectangular.</skos:definition>
-    <skos:notation>bj</skos:notation>
+    <skos:notation xml:lang="en">bj</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">dimaxion</skos:prefLabel>
     <skos:definition xml:lang="en">Dimaxion.</skos:definition>
-    <skos:notation>dg</skos:notation>
+    <skos:notation xml:lang="en">dg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bh">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">transverse Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Transverse Mercator.</skos:definition>
-    <skos:notation>bh</skos:notation>
+    <skos:notation xml:lang="en">bh</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ab">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gnomic</skos:prefLabel>
     <skos:definition xml:lang="en">Gnomic.</skos:definition>
-    <skos:notation>ab</skos:notation>
+    <skos:notation xml:lang="en">ab</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">sinusoidal</skos:prefLabel>
     <skos:definition xml:lang="en">Sinusoidal.</skos:definition>
-    <skos:notation>bg</skos:notation>
+    <skos:notation xml:lang="en">bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">polyconic</skos:prefLabel>
     <skos:definition xml:lang="en">Polyconic.</skos:definition>
-    <skos:notation>cp</skos:notation>
+    <skos:notation xml:lang="en">cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal.</skos:definition>
-    <skos:notation>zz</skos:notation>
+    <skos:notation xml:lang="en">zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#az">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">azimuthal, other</skos:prefLabel>
     <skos:definition xml:lang="en">Azimuthal, other.</skos:definition>
-    <skos:notation>az</skos:notation>
+    <skos:notation xml:lang="en">az</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#db">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">butterfly</skos:prefLabel>
     <skos:definition xml:lang="en">Butterfly.</skos:definition>
-    <skos:notation>db</skos:notation>
+    <skos:notation xml:lang="en">db</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#dd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Goode's homolosine</skos:prefLabel>
     <skos:definition xml:lang="en">Goode's homolosine.</skos:definition>
-    <skos:notation>dd</skos:notation>
+    <skos:notation xml:lang="en">dd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#ba">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Gall</skos:prefLabel>
     <skos:definition xml:lang="en">Gall.</skos:definition>
-    <skos:notation>ba</skos:notation>
+    <skos:notation xml:lang="en">ba</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.4jrs-m847#bd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.4jrs-m847"/>
     <skos:prefLabel xml:lang="en">Mercator</skos:prefLabel>
     <skos:definition xml:lang="en">Mercator.</skos:definition>
-    <skos:notation>bd</skos:notation>
+    <skos:notation xml:lang="en">bd</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_projection/maps_projection.ttl
+++ b/008/maps_projection/maps_projection.ttl
@@ -6,284 +6,284 @@
 <https://doi.org/10.6069/uwlswd.4jrs-m847#aa> a skos:Concept ;
     skos:definition "Aitoff."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "aa"@en ;
+    skos:notation "aa" ;
     skos:prefLabel "Aitoff"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ab> a skos:Concept ;
     skos:definition "Gnomic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ab"@en ;
+    skos:notation "ab" ;
     skos:prefLabel "Gnomic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ac> a skos:Concept ;
     skos:definition "Lambert's azimuthal equal area."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ac"@en ;
+    skos:notation "ac" ;
     skos:prefLabel "Lambert's azimuthal equal area"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ad> a skos:Concept ;
     skos:definition "Orthographic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ad"@en ;
+    skos:notation "ad" ;
     skos:prefLabel "orthographic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ae> a skos:Concept ;
     skos:definition "Azimuthal equidistant."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ae"@en ;
+    skos:notation "ae" ;
     skos:prefLabel "azimuthal equidistant"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#af> a skos:Concept ;
     skos:definition "Stereographic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "af"@en ;
+    skos:notation "af" ;
     skos:prefLabel "stereographic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ag> a skos:Concept ;
     skos:definition "General vertical near-sided."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ag"@en ;
+    skos:notation "ag" ;
     skos:prefLabel "general vertical near-sided"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#am> a skos:Concept ;
     skos:definition "Modified stereographic for Alaska."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "am"@en ;
+    skos:notation "am" ;
     skos:prefLabel "modified stereographic for Alaska"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#an> a skos:Concept ;
     skos:definition "Chamberlin trimetric."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "an"@en ;
+    skos:notation "an" ;
     skos:prefLabel "Chamberlin trimetric"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ap> a skos:Concept ;
     skos:definition "Polar stereographic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ap"@en ;
+    skos:notation "ap" ;
     skos:prefLabel "polar stereographic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#au> a skos:Concept ;
     skos:definition "Azimuthal, specific type unknown. Only the projection type (azimuthal) is known, not the specific projection."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "au"@en ;
+    skos:notation "au" ;
     skos:prefLabel "azimuthal, specific type unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#az> a skos:Concept ;
     skos:definition "Azimuthal, other."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "az"@en ;
+    skos:notation "az" ;
     skos:prefLabel "azimuthal, other"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ba> a skos:Concept ;
     skos:definition "Gall."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ba"@en ;
+    skos:notation "ba" ;
     skos:prefLabel "Gall"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bb> a skos:Concept ;
     skos:definition "Goode's homolographic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bb"@en ;
+    skos:notation "bb" ;
     skos:prefLabel "Goode's homolographic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bc> a skos:Concept ;
     skos:definition "Lambert's cylindrical equal area."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bc"@en ;
+    skos:notation "bc" ;
     skos:prefLabel "Lambert's cylindrical equal area"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bd> a skos:Concept ;
     skos:definition "Mercator."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bd"@en ;
+    skos:notation "bd" ;
     skos:prefLabel "Mercator"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#be> a skos:Concept ;
     skos:definition "Miller."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "be"@en ;
+    skos:notation "be" ;
     skos:prefLabel "Miller"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bf> a skos:Concept ;
     skos:definition "Mollweide."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bf"@en ;
+    skos:notation "bf" ;
     skos:prefLabel "Mollweide"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bg> a skos:Concept ;
     skos:definition "Sinusoidal."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bg"@en ;
+    skos:notation "bg" ;
     skos:prefLabel "sinusoidal"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bh> a skos:Concept ;
     skos:definition "Transverse Mercator."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bh"@en ;
+    skos:notation "bh" ;
     skos:prefLabel "transverse Mercator"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bi> a skos:Concept ;
     skos:definition "Gauss-Kruger."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bi"@en ;
+    skos:notation "bi" ;
     skos:prefLabel "Gauss-Kruger"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bj> a skos:Concept ;
     skos:definition "Equirectangular."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bj"@en ;
+    skos:notation "bj" ;
     skos:prefLabel "equirectangular"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bk> a skos:Concept ;
     skos:definition "Krovak."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bk"@en ;
+    skos:notation "bk" ;
     skos:prefLabel "krovak"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bl> a skos:Concept ;
     skos:definition "Cassini-Soldner."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bl"@en ;
+    skos:notation "bl" ;
     skos:prefLabel "Cassini-Soldner"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bo> a skos:Concept ;
     skos:definition "Oblique Mercator."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bo"@en ;
+    skos:notation "bo" ;
     skos:prefLabel "oblique Mercator"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#br> a skos:Concept ;
     skos:definition "Robinson."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "br"@en ;
+    skos:notation "br" ;
     skos:prefLabel "Robinson"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bs> a skos:Concept ;
     skos:definition "Space oblique Mercator."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bs"@en ;
+    skos:notation "bs" ;
     skos:prefLabel "space oblique Mercator"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bu> a skos:Concept ;
     skos:definition "Cylindrical, specific type unknown. Only the projection type (cylindrical) is known, not the specific projection."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bu"@en ;
+    skos:notation "bu" ;
     skos:prefLabel "cylindrical, specific type unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#bz> a skos:Concept ;
     skos:definition "Cylindrical, other."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "bz"@en ;
+    skos:notation "bz" ;
     skos:prefLabel "cylindrical, other"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ca> a skos:Concept ;
     skos:definition "Alber's equal area."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ca"@en ;
+    skos:notation "ca" ;
     skos:prefLabel "Alber's equal area"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#cb> a skos:Concept ;
     skos:definition "Bonne."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "cb"@en ;
+    skos:notation "cb" ;
     skos:prefLabel "Bonne"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#cc> a skos:Concept ;
     skos:definition "Lambert's conformal conic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "cc"@en ;
+    skos:notation "cc" ;
     skos:prefLabel "Lambert's conformal conic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#ce> a skos:Concept ;
     skos:definition "Equidistant conic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "ce"@en ;
+    skos:notation "ce" ;
     skos:prefLabel "equidistant conic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#cp> a skos:Concept ;
     skos:definition "Polyconic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "cp"@en ;
+    skos:notation "cp" ;
     skos:prefLabel "polyconic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#cu> a skos:Concept ;
     skos:definition "Conic, specific type unknown. Only the projection type (conic) is known, not the specific projection."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "cu"@en ;
+    skos:notation "cu" ;
     skos:prefLabel "conic, specific type unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#cz> a skos:Concept ;
     skos:definition "Conic, other."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "cz"@en ;
+    skos:notation "cz" ;
     skos:prefLabel "conic, other"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#da> a skos:Concept ;
     skos:definition "Armadillo."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "da"@en ;
+    skos:notation "da" ;
     skos:prefLabel "armadillo"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#db> a skos:Concept ;
     skos:definition "Butterfly."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "db"@en ;
+    skos:notation "db" ;
     skos:prefLabel "butterfly"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dc> a skos:Concept ;
     skos:definition "Eckert."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "dc"@en ;
+    skos:notation "dc" ;
     skos:prefLabel "Eckert"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dd> a skos:Concept ;
     skos:definition "Goode's homolosine."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "dd"@en ;
+    skos:notation "dd" ;
     skos:prefLabel "Goode's homolosine"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#de> a skos:Concept ;
     skos:definition "Miller's bipolar oblique conformal conic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "de"@en ;
+    skos:notation "de" ;
     skos:prefLabel "Miller's bipolar oblique conformal conic"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#df> a skos:Concept ;
     skos:definition "Van Der Grinten."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "df"@en ;
+    skos:notation "df" ;
     skos:prefLabel "Van Der Grinten"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dg> a skos:Concept ;
     skos:definition "Dimaxion."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "dg"@en ;
+    skos:notation "dg" ;
     skos:prefLabel "dimaxion"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dh> a skos:Concept ;
     skos:definition "Cordiform."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "dh"@en ;
+    skos:notation "dh" ;
     skos:prefLabel "cordiform"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#dl> a skos:Concept ;
     skos:definition "Lambert conformal."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "dl"@en ;
+    skos:notation "dl" ;
     skos:prefLabel "Lambert conformal"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#pound2> a skos:Concept ;
     skos:definition "Projection not specified."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "##"@en ;
+    skos:notation "##" ;
     skos:prefLabel "projection not specified"@en ;
     skos:scopeNote "Used for most globes."@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847#zz> a skos:Concept ;
     skos:definition "Projection other than Aitoff, gnomic, Lambert's azimuthal equal area, orthographic, azimuthal equidistant, stereographic, general vertical near-sided, modified stereographic for Alaska, Chamberlin trimetric, polar stereographic, azimuthal, specific type unknown, azimuthal, other, Gall, Goode's homolographic, Lambert's cylindrical equal area, Mercator, Miller, Mollweide, sinusoidal, transverse mercator, Gauss-Kruger, equirectangular, Krovak, Cassini-Soldner, oblique Mercator, Robinson, space oblique Mercator, cylindrical, specific type unknown, cylindrical, other, Alber's equal area, Bonne, Lambert's conformal conic, equidistant conic, polyconic, conic, specific type unknown, conic, other, armadillo, butterfly, Eckert, Goode's homolosine, Miller's bipolar oblique conformal conic, Van der Grinten, dimaxion, cordiform, Lambert conformal."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.4jrs-m847> ;
-    skos:notation "zz"@en ;
+    skos:notation "zz" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.4jrs-m847> a skos:ConceptScheme ;
@@ -300,12 +300,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_projection/maps_projection.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Maps: projection"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/maps_relief/maps_relief.html
+++ b/008/maps_relief/maps_relief.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
                         <td id="a">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
                         <td>
@@ -415,7 +415,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
                         <td>
@@ -464,7 +464,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#c">
                         <td>
@@ -513,7 +513,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
                         <td>
@@ -562,7 +562,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
                         <td>
@@ -611,7 +611,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
                         <td>
@@ -660,7 +660,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
                         <td>
@@ -700,7 +700,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx">
                         <td>
@@ -750,7 +750,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
                         <td>
@@ -799,7 +799,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
                         <td>
@@ -848,7 +848,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
                         <td>
@@ -897,7 +897,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
                         <td>
@@ -946,7 +946,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound">
                         <td>
@@ -996,7 +996,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z">
                         <td>
@@ -1020,53 +1020,25 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;color [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;spot heights&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by spot heights.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;contours&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Relief shown by contours.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bathymetry/soundings&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Underwater relief (depth) shown by soundings or spot depths.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rock drawings&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief rock drawing.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;form lines&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by form lines.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;land forms&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by land forms.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;color [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;pictorially&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1074,72 +1046,100 @@
     &lt;dct:title xml:lang="en"&gt;Maps: relief&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/18-21 values for maps expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicate the relief type specified on the item.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#c"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;gradient and bathymetric tints&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by gradient or bathymetric tints.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;spot heights&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by spot heights.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;shading&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by shading (generally of a single color).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bathymetry by isolines&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Underwater relief (depth) shown by isolines (lines that represent constant depths).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;hachures&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by hachures (short lines which follow the direction of maximum slope).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;hachures&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Relief shown by hachures (short lines which follow the direction of maximum slope).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rock drawings&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief rock drawing.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;shading&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by shading (generally of a single color).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;pictorially&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;no relief shown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;No relief shown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;form lines&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by form lines.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bathymetry by isolines&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Underwater relief (depth) shown by isolines (lines that represent constant depths).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;land forms&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by land forms.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bathymetry/soundings&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Underwater relief (depth) shown by soundings or spot depths.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;gradient and bathymetric tints&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Relief shown by gradient or bathymetric tints.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1154,84 +1154,84 @@
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; a skos:Concept ;
     skos:definition "Relief shown by contours."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "contours"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; a skos:Concept ;
     skos:definition "Relief shown by shading (generally of a single color)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "shading"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; a skos:Concept ;
     skos:definition "Relief shown by gradient or bathymetric tints."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "gradient and bathymetric tints"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; a skos:Concept ;
     skos:definition "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "hachures"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; a skos:Concept ;
     skos:definition "Underwater relief (depth) shown by soundings or spot depths."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "bathymetry/soundings"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; a skos:Concept ;
     skos:definition "Relief shown by form lines."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "form lines"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; a skos:Concept ;
     skos:definition "Relief shown by spot heights."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "spot heights"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "color [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; a skos:Concept ;
     skos:definition "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "pictorially"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; a skos:Concept ;
     skos:definition "Relief shown by land forms."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "land forms"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; a skos:Concept ;
     skos:definition "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "bathymetry by isolines"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; a skos:Concept ;
     skos:definition "Relief rock drawing."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "rock drawings"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; a skos:Concept ;
     skos:definition "No relief shown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no relief shown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; a skos:Concept ;
     skos:definition "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; a skos:ConceptScheme ;
@@ -1248,125 +1248,119 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Maps: relief"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by contours."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bathymetry/soundings"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by form lines."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "land forms"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "color [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "spot heights"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bathymetry by isolines"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: relief"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicate the relief type specified on the item."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "gradient and bathymetric tints"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by spot heights."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "contours"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hachures"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief rock drawing."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by gradient or bathymetric tints."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "form lines"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-21 values for maps expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pictorially"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by land forms."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-21 values for maps expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hachures"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by shading (generally of a single color)."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no relief shown"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rock drawings"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "shading"@en .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no relief shown"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by form lines."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Underwater relief (depth) shown by soundings or spot depths."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No relief shown."@en .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rock drawings"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "gradient and bathymetric tints"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief rock drawing."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "spot heights"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "contours"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicate the relief type specified on the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bathymetry by isolines"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by contours."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by land forms."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bathymetry/soundings"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pictorially"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "land forms"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by spot heights."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by gradient or bathymetric tints."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "form lines"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "color [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No relief shown."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: relief"@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
 &lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Relief shown by shading (generally of a single color)."@en .
+&lt;https://doi.org/10.6069/uwlswd.1c2x-cj09#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#z",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#hx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1375,26 +1369,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other"
+        "@value": "color [obsolete]"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#i",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."
+        "@value": "No relief shown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1404,72 +1397,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "pictorially"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief rock drawing."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rock drawings"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Underwater relief (depth) shown by soundings or spot depths."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bathymetry/soundings"
+        "@value": "no relief shown"
       }
     ]
   },
@@ -1491,7 +1425,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -1503,14 +1436,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#f",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Relief shown by form lines."
+        "@value": "Relief shown by shading (generally of a single color)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1520,26 +1453,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "form lines"
+        "@value": "shading"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#c",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#i",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Relief shown by gradient or bathymetric tints."
+        "@value": "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1549,14 +1481,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "i"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "gradient and bathymetric tints"
+        "@value": "pictorially"
       }
     ]
   },
@@ -1578,7 +1509,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -1586,6 +1516,90 @@
       {
         "@language": "en",
         "@value": "bathymetry by isolines"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Underwater relief (depth) shown by soundings or spot depths."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bathymetry/soundings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by spot heights."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "spot heights"
       }
     ]
   },
@@ -1658,7 +1672,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1687,12 +1701,97 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by gradient or bathymetric tints."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "gradient and bathymetric tints"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief rock drawing."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rock drawings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by form lines."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "form lines"
       }
     ]
   },
@@ -1714,7 +1813,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -1722,87 +1820,6 @@
       {
         "@language": "en",
         "@value": "land forms"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No relief shown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no relief shown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief shown by shading (generally of a single color)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "shading"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "color [obsolete]"
       }
     ]
   },
@@ -1824,7 +1841,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -1832,35 +1848,6 @@
       {
         "@language": "en",
         "@value": "contours"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief shown by spot heights."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "spot heights"
       }
     ]
   }

--- a/008/maps_relief/maps_relief.jsonld
+++ b/008/maps_relief/maps_relief.jsonld
@@ -1,14 +1,8 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#z",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#hx",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."
-      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -17,26 +11,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "h"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other"
+        "@value": "color [obsolete]"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#i",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."
+        "@value": "No relief shown."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -46,72 +39,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "i"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "pictorially"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief rock drawing."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rock drawings"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Underwater relief (depth) shown by soundings or spot depths."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bathymetry/soundings"
+        "@value": "no relief shown"
       }
     ]
   },
@@ -133,7 +67,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -145,14 +78,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#f",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Relief shown by form lines."
+        "@value": "Relief shown by shading (generally of a single color)."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -162,26 +95,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "form lines"
+        "@value": "shading"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#c",
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#i",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Relief shown by gradient or bathymetric tints."
+        "@value": "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -191,14 +123,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "i"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "gradient and bathymetric tints"
+        "@value": "pictorially"
       }
     ]
   },
@@ -220,7 +151,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "k"
       }
     ],
@@ -228,6 +158,90 @@
       {
         "@language": "en",
         "@value": "bathymetry by isolines"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Underwater relief (depth) shown by soundings or spot depths."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bathymetry/soundings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by spot heights."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "spot heights"
       }
     ]
   },
@@ -300,7 +314,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -329,12 +343,97 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by gradient or bathymetric tints."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "gradient and bathymetric tints"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief rock drawing."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rock drawings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Relief shown by form lines."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "form lines"
       }
     ]
   },
@@ -356,7 +455,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -364,87 +462,6 @@
       {
         "@language": "en",
         "@value": "land forms"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No relief shown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no relief shown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief shown by shading (generally of a single color)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "shading"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "color [obsolete]"
       }
     ]
   },
@@ -466,7 +483,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "a"
       }
     ],
@@ -474,35 +490,6 @@
       {
         "@language": "en",
         "@value": "contours"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Relief shown by spot heights."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.1c2x-cj09"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "spot heights"
       }
     ]
   }

--- a/008/maps_relief/maps_relief.nt
+++ b/008/maps_relief/maps_relief.nt
@@ -1,91 +1,91 @@
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by contours."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "bathymetry/soundings"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by form lines."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "land forms"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "color [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "spot heights"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "bathymetry by isolines"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/title> "Maps: relief"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/description> "Indicate the relief type specified on the item."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "gradient and bathymetric tints"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by spot heights."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "contours"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "hachures"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#definition> "Relief rock drawing."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#definition> "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by gradient or bathymetric tints."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#definition> "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "form lines"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/alternative> "MARC21 008/18-21 values for maps expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "pictorially"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by land forms."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/alternative> "MARC21 008/18-21 values for maps expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "hachures"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/elements/1.1/language> "en" .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by shading (generally of a single color)."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no relief shown"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "rock drawings"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "shading"@en .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#definition> "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no relief shown"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by form lines."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#definition> "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#definition> "Underwater relief (depth) shown by soundings or spot depths."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#definition> "No relief shown."@en .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "rock drawings"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "gradient and bathymetric tints"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#definition> "Relief rock drawing."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "spot heights"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "contours"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/description> "Indicate the relief type specified on the item."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "bathymetry by isolines"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by contours."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by land forms."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "bathymetry/soundings"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "pictorially"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "land forms"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#g> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by spot heights."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by gradient or bathymetric tints."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "form lines"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "color [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#definition> "No relief shown."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#definition> "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.1c2x-cj09> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/title> "Maps: relief"@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#b> <http://www.w3.org/2004/02/skos/core#definition> "Relief shown by shading (generally of a single color)."@en .
+<https://doi.org/10.6069/uwlswd.1c2x-cj09#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -65,7 +65,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld"/>

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -1,52 +1,30 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">contours</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by contours.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">bathymetry/soundings</skos:prefLabel>
-    <skos:definition xml:lang="en">Underwater relief (depth) shown by soundings or spot depths.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">rock drawings</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief rock drawing.</skos:definition>
-    <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">form lines</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by form lines.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">land forms</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by land forms.</skos:definition>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">color [obsolete]</skos:prefLabel>
     <skos:notation>h</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">pictorially</skos:prefLabel>
-    <skos:definition xml:lang="en">Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:prefLabel xml:lang="en">spot heights</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by spot heights.</skos:definition>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">contours</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by contours.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -72,33 +50,12 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">gradient and bathymetric tints</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by gradient or bathymetric tints.</skos:definition>
-    <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">spot heights</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by spot heights.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">shading</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by shading (generally of a single color).</skos:definition>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">bathymetry by isolines</skos:prefLabel>
-    <skos:definition xml:lang="en">Underwater relief (depth) shown by isolines (lines that represent constant depths).</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:prefLabel xml:lang="en">hachures</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by hachures (short lines which follow the direction of maximum slope).</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -107,12 +64,26 @@
     <skos:definition xml:lang="en">Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings.</skos:definition>
     <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
-    <skos:prefLabel xml:lang="en">hachures</skos:prefLabel>
-    <skos:definition xml:lang="en">Relief shown by hachures (short lines which follow the direction of maximum slope).</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:prefLabel xml:lang="en">rock drawings</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief rock drawing.</skos:definition>
+    <skos:notation>m</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">shading</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by shading (generally of a single color).</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">pictorially</skos:prefLabel>
+    <skos:definition xml:lang="en">Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.</skos:definition>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -120,5 +91,40 @@
     <skos:prefLabel xml:lang="en">no relief shown</skos:prefLabel>
     <skos:definition xml:lang="en">No relief shown.</skos:definition>
     <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">form lines</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by form lines.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">bathymetry by isolines</skos:prefLabel>
+    <skos:definition xml:lang="en">Underwater relief (depth) shown by isolines (lines that represent constant depths).</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">land forms</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by land forms.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">bathymetry/soundings</skos:prefLabel>
+    <skos:definition xml:lang="en">Underwater relief (depth) shown by soundings or spot depths.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
+    <skos:prefLabel xml:lang="en">gradient and bathymetric tints</skos:prefLabel>
+    <skos:definition xml:lang="en">Relief shown by gradient or bathymetric tints.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -58,7 +58,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -1,52 +1,58 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">contours</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by contours.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry/soundings</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by soundings or spot depths.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">rock drawings</skos:prefLabel>
     <skos:definition xml:lang="en">Relief rock drawing.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">form lines</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by form lines.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">land forms</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by land forms.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">color [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">pictorially</skos:prefLabel>
     <skos:definition xml:lang="en">Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -54,7 +60,7 @@
     <dct:title xml:lang="en">Maps: relief</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicate the relief type specified on the item.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -65,7 +71,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld"/>
@@ -77,48 +83,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">gradient and bathymetric tints</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by gradient or bathymetric tints.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">spot heights</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by spot heights.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">shading</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by shading (generally of a single color).</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry by isolines</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by isolines (lines that represent constant depths).</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">hachures</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by hachures (short lines which follow the direction of maximum slope).</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">no relief shown</skos:prefLabel>
     <skos:definition xml:lang="en">No relief shown.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -1,58 +1,52 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">contours</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by contours.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry/soundings</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by soundings or spot depths.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">rock drawings</skos:prefLabel>
     <skos:definition xml:lang="en">Relief rock drawing.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">form lines</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by form lines.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">land forms</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by land forms.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">color [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">pictorially</skos:prefLabel>
     <skos:definition xml:lang="en">Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -60,7 +54,7 @@
     <dct:title xml:lang="en">Maps: relief</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicate the relief type specified on the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -71,7 +65,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.jsonld"/>
@@ -83,48 +77,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">gradient and bathymetric tints</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by gradient or bathymetric tints.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">spot heights</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by spot heights.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">shading</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by shading (generally of a single color).</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry by isolines</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by isolines (lines that represent constant depths).</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">hachures</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by hachures (short lines which follow the direction of maximum slope).</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">no relief shown</skos:prefLabel>
     <skos:definition xml:lang="en">No relief shown.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_relief/maps_relief.rdf
+++ b/008/maps_relief/maps_relief.rdf
@@ -1,58 +1,52 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">contours</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by contours.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry/soundings</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by soundings or spot depths.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">rock drawings</skos:prefLabel>
     <skos:definition xml:lang="en">Relief rock drawing.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">form lines</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by form lines.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">land forms</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by land forms.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">color [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">pictorially</skos:prefLabel>
     <skos:definition xml:lang="en">Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -60,7 +54,7 @@
     <dct:title xml:lang="en">Maps: relief</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/18-21 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicate the relief type specified on the item.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -83,48 +77,48 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">gradient and bathymetric tints</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by gradient or bathymetric tints.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">spot heights</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by spot heights.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">shading</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by shading (generally of a single color).</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">bathymetry by isolines</skos:prefLabel>
     <skos:definition xml:lang="en">Underwater relief (depth) shown by isolines (lines that represent constant depths).</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">hachures</skos:prefLabel>
     <skos:definition xml:lang="en">Relief shown by hachures (short lines which follow the direction of maximum slope).</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.1c2x-cj09#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.1c2x-cj09"/>
     <skos:prefLabel xml:lang="en">no relief shown</skos:prefLabel>
     <skos:definition xml:lang="en">No relief shown.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_relief/maps_relief.ttl
+++ b/008/maps_relief/maps_relief.ttl
@@ -6,84 +6,84 @@
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#a> a skos:Concept ;
     skos:definition "Relief shown by contours."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "contours"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#b> a skos:Concept ;
     skos:definition "Relief shown by shading (generally of a single color)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "shading"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#c> a skos:Concept ;
     skos:definition "Relief shown by gradient or bathymetric tints."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "gradient and bathymetric tints"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#d> a skos:Concept ;
     skos:definition "Relief shown by hachures (short lines which follow the direction of maximum slope)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "hachures"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#e> a skos:Concept ;
     skos:definition "Underwater relief (depth) shown by soundings or spot depths."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "bathymetry/soundings"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#f> a skos:Concept ;
     skos:definition "Relief shown by form lines."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "form lines"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#g> a skos:Concept ;
     skos:definition "Relief shown by spot heights."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "spot heights"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#hx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "color [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#i> a skos:Concept ;
     skos:definition "Land forms and other topographic features shown in the correct planimetric position by pictorial symbols representing their appearance from a high oblique view."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "pictorially"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#j> a skos:Concept ;
     skos:definition "Relief shown by land forms."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "land forms"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#k> a skos:Concept ;
     skos:definition "Underwater relief (depth) shown by isolines (lines that represent constant depths)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "bathymetry by isolines"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#m> a skos:Concept ;
     skos:definition "Relief rock drawing."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "rock drawings"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#pound> a skos:Concept ;
     skos:definition "No relief shown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no relief shown"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09#z> a skos:Concept ;
     skos:definition "Relief other than contours, shading, gradient and bathymetric tints, hachures, bathymetry/soundings, form lines, spot heights, pictorially, land forms, bathymetry by isolines, rock drawings."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.1c2x-cj09> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.1c2x-cj09> a skos:ConceptScheme ;
@@ -100,12 +100,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_relief/maps_relief.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Maps: relief"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.html
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
                         <td id="ax">
@@ -357,7 +357,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
                         <td>
@@ -397,7 +397,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
                         <td>
@@ -437,7 +437,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#cx">
                         <td>
@@ -477,7 +477,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#dx">
                         <td>
@@ -526,7 +526,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
                         <td>
@@ -566,7 +566,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#fx">
                         <td>
@@ -606,7 +606,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
                         <td>
@@ -646,7 +646,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
                         <td>
@@ -695,7 +695,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#j">
                         <td>
@@ -744,7 +744,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#k">
                         <td>
@@ -793,7 +793,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#l">
                         <td>
@@ -833,7 +833,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
                         <td>
@@ -882,7 +882,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
                         <td>
@@ -931,7 +931,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#o">
                         <td>
@@ -980,7 +980,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
                         <td>
@@ -1029,7 +1029,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
                         <td>
@@ -1069,7 +1069,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
                         <td>
@@ -1118,7 +1118,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
                         <td>
@@ -1177,7 +1177,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
                         <td>
@@ -1201,40 +1201,18 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;playing cards&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Playing cards.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#fx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;facsimile [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;manuscript&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Drawn or fashioned by hand.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;loose-leaf&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Separate leaves intended to be stored in a binder or case.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Loose-leaf items are often meant to be updated.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended to be used as or is part of a game.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1242,113 +1220,135 @@
     &lt;dct:title xml:lang="en"&gt;Maps: special format characteristics&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33-34 values for maps expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the special format characteristics of the map.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;puzzle&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Image may be disassembled into pieces and reassembled.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rare [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#dx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;film negative [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;braille [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended to be used as or is part of a game.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;relief model [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;picture card, post card&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Picture card, post card.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;relief model [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;playing cards&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Playing cards.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;large print [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;no specified special format characteristics&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;No specified special format characteristics.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;wall map&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Wall map.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;no specified special format characteristics&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;No specified special format characteristics.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;manuscript&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Drawn or fashioned by hand.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;photocopy, blue line print [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;large print [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#k"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;calendar&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Calendar.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;loose-leaf&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Separate leaves intended to be stored in a binder or case.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Loose-leaf items are often meant to be updated.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;puzzle&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Image may be disassembled into pieces and reassembled.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rare [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#cx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;negative photocopy [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;photocopy, blue line print [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1362,108 +1362,108 @@
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "photocopy, blue line print [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "photocopy [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "negative photocopy [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "film negative [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; a skos:Concept ;
     skos:definition "Drawn or fashioned by hand."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "manuscript"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "facsimile [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "relief model [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "rare [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; a skos:Concept ;
     skos:definition "Picture card, post card."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "picture card, post card"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; a skos:Concept ;
     skos:definition "Calendar."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "calendar"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; a skos:Concept ;
     skos:definition "Image may be disassembled into pieces and reassembled."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "puzzle"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "braille [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; a skos:Concept ;
     skos:definition "Intended to be used as or is part of a game."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "game"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; a skos:Concept ;
     skos:definition "Wall map."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "wall map"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; a skos:Concept ;
     skos:definition "Playing cards."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "playing cards"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; a skos:Concept ;
     skos:definition "No specified special format characteristics."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no specified special format characteristics"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "large print [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; a skos:Concept ;
     skos:definition "Separate leaves intended to be stored in a binder or case."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "loose-leaf"@en ;
     skos:scopeNote "Loose-leaf items are often meant to be updated."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; a skos:Concept ;
     skos:definition "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; a skos:ConceptScheme ;
@@ -1480,133 +1480,433 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Maps: special format characteristics"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "facsimile [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended to be used as or is part of a game."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rare [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the special format characteristics of the map."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "loose-leaf"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "relief model [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "puzzle"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "picture card, post card"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: special format characteristics"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Drawn or fashioned by hand."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no specified special format characteristics"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendar"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Image may be disassembled into pieces and reassembled."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy, blue line print [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33-34 values for maps expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Wall map."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Picture card, post card."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "wall map"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "film negative [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified special format characteristics."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "negative photocopy [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Playing cards."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "film negative [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended to be used as or is part of a game."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "relief model [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "wall map"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Drawn or fashioned by hand."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Calendar."@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "playing cards"@en .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Loose-leaf items are often meant to be updated."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "loose-leaf"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "playing cards"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Image may be disassembled into pieces and reassembled."@en .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Separate leaves intended to be stored in a binder or case."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "picture card, post card"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "calendar"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#mx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no specified special format characteristics"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33-34 values for maps expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "facsimile [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Playing cards."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#fx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Picture card, post card."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: special format characteristics"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "negative photocopy [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "puzzle"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the special format characteristics of the map."@en .
 &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#cx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No specified special format characteristics."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy, blue line print [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Wall map."@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#qx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "manuscript"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#bx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#dx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.rw25-p125&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.rw25-p125#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rare [obsolete]"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Calendar."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendar"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rare [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No specified special format characteristics."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no specified special format characteristics"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#cx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "negative photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Drawn or fashioned by hand."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended to be used as or is part of a game."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#fx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "facsimile [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Playing cards."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "playing cards"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#qx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#bx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#dx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "film negative [obsolete]"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.rw25-p125",
     "@type": [
@@ -1676,7 +1976,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1705,35 +2005,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rare [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1755,7 +2033,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -1773,14 +2050,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#z",
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."
+        "@value": "Wall map."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1790,49 +2067,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other"
+        "@value": "wall map"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#fx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "facsimile [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#n",
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#l",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended to be used as or is part of a game."
+        "@value": "Image may be disassembled into pieces and reassembled."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1842,14 +2095,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "l"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "game"
+        "@value": "puzzle"
       }
     ]
   },
@@ -1865,7 +2117,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -1873,6 +2124,28 @@
       {
         "@language": "en",
         "@value": "relief model [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#ax",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy, blue line print [obsolete]"
       }
     ]
   },
@@ -1888,7 +2161,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -1917,7 +2189,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -1925,295 +2196,6 @@
       {
         "@language": "en",
         "@value": "picture card, post card"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No specified special format characteristics."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no specified special format characteristics"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Drawn or fashioned by hand."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "manuscript"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#dx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "film negative [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#bx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Image may be disassembled into pieces and reassembled."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "puzzle"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Calendar."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendar"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#qx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Wall map."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "wall map"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#cx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "negative photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Playing cards."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "playing cards"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#ax",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy, blue line print [obsolete]"
       }
     ]
   }

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld
@@ -1,5 +1,305 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Calendar."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "calendar"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rare [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No specified special format characteristics."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no specified special format characteristics"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#cx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "negative photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Drawn or fashioned by hand."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "manuscript"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Intended to be used as or is part of a game."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#fx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "facsimile [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Playing cards."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "playing cards"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#qx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#bx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#dx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "film negative [obsolete]"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.rw25-p125",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +368,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,35 +397,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rare [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -147,7 +425,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -165,14 +442,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#z",
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."
+        "@value": "Wall map."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -182,49 +459,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "z"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "other"
+        "@value": "wall map"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#fx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "facsimile [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#n",
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#l",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Intended to be used as or is part of a game."
+        "@value": "Image may be disassembled into pieces and reassembled."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -234,14 +487,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "l"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "game"
+        "@value": "puzzle"
       }
     ]
   },
@@ -257,7 +509,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -265,6 +516,28 @@
       {
         "@language": "en",
         "@value": "relief model [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#ax",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy, blue line print [obsolete]"
       }
     ]
   },
@@ -280,7 +553,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -309,7 +581,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -317,295 +588,6 @@
       {
         "@language": "en",
         "@value": "picture card, post card"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No specified special format characteristics."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no specified special format characteristics"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Drawn or fashioned by hand."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "manuscript"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#dx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "film negative [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#bx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Image may be disassembled into pieces and reassembled."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "puzzle"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Calendar."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "calendar"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#qx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "large print [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Wall map."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "wall map"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#cx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "negative photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Playing cards."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "playing cards"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.rw25-p125#ax",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.rw25-p125"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy, blue line print [obsolete]"
       }
     ]
   }

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.nt
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.nt
@@ -1,109 +1,109 @@
-<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#prefLabel> "facsimile [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#definition> "Intended to be used as or is part of a game."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "rare [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/description> "Indicates the special format characteristics of the map."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "loose-leaf"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "relief model [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "puzzle"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "picture card, post card"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/title> "Maps: special format characteristics"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#definition> "Drawn or fashioned by hand."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no specified special format characteristics"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendar"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#definition> "Image may be disassembled into pieces and reassembled."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy, blue line print [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#definition> "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/alternative> "MARC21 008/33-34 values for maps expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#definition> "Wall map."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#definition> "Picture card, post card."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "wall map"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#prefLabel> "film negative [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified special format characteristics."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#prefLabel> "negative photocopy [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
 <https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#definition> "Playing cards."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#prefLabel> "film negative [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#definition> "Intended to be used as or is part of a game."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "relief model [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "wall map"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#definition> "Drawn or fashioned by hand."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#definition> "Calendar."@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "playing cards"@en .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
 <https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Loose-leaf items are often meant to be updated."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "loose-leaf"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "playing cards"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#definition> "Image may be disassembled into pieces and reassembled."@en .
 <https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#definition> "Separate leaves intended to be stored in a binder or case."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
 <https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#definition> "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "picture card, post card"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "calendar"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#mx> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no specified special format characteristics"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/alternative> "MARC21 008/33-34 values for maps expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/2004/02/skos/core#prefLabel> "facsimile [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
 <https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#p> <http://www.w3.org/2004/02/skos/core#definition> "Playing cards."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#fx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/2004/02/skos/core#definition> "Picture card, post card."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/title> "Maps: special format characteristics"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#prefLabel> "negative photocopy [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "puzzle"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/description> "Indicates the special format characteristics of the map."@en .
 <https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#cx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#pound> <http://www.w3.org/2004/02/skos/core#definition> "No specified special format characteristics."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#ax> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy, blue line print [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#o> <http://www.w3.org/2004/02/skos/core#definition> "Wall map."@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.rw25-p125> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#qx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "manuscript"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#bx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.rw25-p125#dx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.rw25-p125> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.rw25-p125#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.rw25-p125#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "rare [obsolete]"@en .

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -1,31 +1,37 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#fx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">facsimile [obsolete]</skos:prefLabel>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">manuscript</skos:prefLabel>
     <skos:definition xml:lang="en">Drawn or fashioned by hand.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Separate leaves intended to be stored in a binder or case.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
     <skos:scopeNote xml:lang="en">Loose-leaf items are often meant to be updated.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
@@ -33,7 +39,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended to be used as or is part of a game.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -41,7 +47,7 @@
     <dct:title xml:lang="en">Maps: special format characteristics</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33-34 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the special format characteristics of the map.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -52,7 +58,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld"/>
@@ -64,89 +70,89 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">puzzle</skos:prefLabel>
     <skos:definition xml:lang="en">Image may be disassembled into pieces and reassembled.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">rare [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">film negative [obsolete]</skos:prefLabel>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">braille [obsolete]</skos:prefLabel>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">picture card, post card</skos:prefLabel>
     <skos:definition xml:lang="en">Picture card, post card.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">relief model [obsolete]</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">playing cards</skos:prefLabel>
     <skos:definition xml:lang="en">Playing cards.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">large print [obsolete]</skos:prefLabel>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">no specified special format characteristics</skos:prefLabel>
     <skos:definition xml:lang="en">No specified special format characteristics.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">wall map</skos:prefLabel>
     <skos:definition xml:lang="en">Wall map.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">calendar</skos:prefLabel>
     <skos:definition xml:lang="en">Calendar.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">negative photocopy [obsolete]</skos:prefLabel>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy, blue line print [obsolete]</skos:prefLabel>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -1,37 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#fx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">facsimile [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">manuscript</skos:prefLabel>
     <skos:definition xml:lang="en">Drawn or fashioned by hand.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Separate leaves intended to be stored in a binder or case.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Loose-leaf items are often meant to be updated.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
@@ -39,7 +33,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended to be used as or is part of a game.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -47,7 +41,7 @@
     <dct:title xml:lang="en">Maps: special format characteristics</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33-34 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the special format characteristics of the map.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -58,7 +52,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld"/>
@@ -70,89 +64,89 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">puzzle</skos:prefLabel>
     <skos:definition xml:lang="en">Image may be disassembled into pieces and reassembled.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">rare [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">film negative [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">braille [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">picture card, post card</skos:prefLabel>
     <skos:definition xml:lang="en">Picture card, post card.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">relief model [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">playing cards</skos:prefLabel>
     <skos:definition xml:lang="en">Playing cards.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">large print [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">no specified special format characteristics</skos:prefLabel>
     <skos:definition xml:lang="en">No specified special format characteristics.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">wall map</skos:prefLabel>
     <skos:definition xml:lang="en">Wall map.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">calendar</skos:prefLabel>
     <skos:definition xml:lang="en">Calendar.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">negative photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy, blue line print [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -52,7 +52,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.jsonld"/>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -1,39 +1,23 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">playing cards</skos:prefLabel>
+    <skos:definition xml:lang="en">Playing cards.</skos:definition>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#fx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">facsimile [obsolete]</skos:prefLabel>
     <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.</skos:definition>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">manuscript</skos:prefLabel>
-    <skos:definition xml:lang="en">Drawn or fashioned by hand.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">loose-leaf</skos:prefLabel>
-    <skos:definition xml:lang="en">Separate leaves intended to be stored in a binder or case.</skos:definition>
-    <skos:notation>r</skos:notation>
-    <skos:scopeNote xml:lang="en">Loose-leaf items are often meant to be updated.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">game</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended to be used as or is part of a game.</skos:definition>
-    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -59,36 +43,24 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">puzzle</skos:prefLabel>
-    <skos:definition xml:lang="en">Image may be disassembled into pieces and reassembled.</skos:definition>
-    <skos:notation>l</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">rare [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">film negative [obsolete]</skos:prefLabel>
     <skos:notation>d</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">braille [obsolete]</skos:prefLabel>
-    <skos:notation>m</skos:notation>
+    <skos:prefLabel xml:lang="en">game</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended to be used as or is part of a game.</skos:definition>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation>b</skos:notation>
+    <skos:prefLabel xml:lang="en">relief model [obsolete]</skos:prefLabel>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -97,31 +69,11 @@
     <skos:definition xml:lang="en">Picture card, post card.</skos:definition>
     <skos:notation>j</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">relief model [obsolete]</skos:prefLabel>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">playing cards</skos:prefLabel>
-    <skos:definition xml:lang="en">Playing cards.</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">large print [obsolete]</skos:prefLabel>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">no specified special format characteristics</skos:prefLabel>
-    <skos:definition xml:lang="en">No specified special format characteristics.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:prefLabel xml:lang="en">braille [obsolete]</skos:prefLabel>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -130,6 +82,38 @@
     <skos:definition xml:lang="en">Wall map.</skos:definition>
     <skos:notation>o</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">no specified special format characteristics</skos:prefLabel>
+    <skos:definition xml:lang="en">No specified special format characteristics.</skos:definition>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">manuscript</skos:prefLabel>
+    <skos:definition xml:lang="en">Drawn or fashioned by hand.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">photocopy, blue line print [obsolete]</skos:prefLabel>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">large print [obsolete]</skos:prefLabel>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
@@ -137,16 +121,38 @@
     <skos:definition xml:lang="en">Calendar.</skos:definition>
     <skos:notation>k</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">loose-leaf</skos:prefLabel>
+    <skos:definition xml:lang="en">Separate leaves intended to be stored in a binder or case.</skos:definition>
+    <skos:notation>r</skos:notation>
+    <skos:scopeNote xml:lang="en">Loose-leaf items are often meant to be updated.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">puzzle</skos:prefLabel>
+    <skos:definition xml:lang="en">Image may be disassembled into pieces and reassembled.</skos:definition>
+    <skos:notation>l</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.</skos:definition>
+    <skos:notation>z</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
+    <skos:prefLabel xml:lang="en">rare [obsolete]</skos:prefLabel>
+    <skos:notation>h</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">negative photocopy [obsolete]</skos:prefLabel>
     <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
-    <skos:prefLabel xml:lang="en">photocopy, blue line print [obsolete]</skos:prefLabel>
-    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -1,37 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#fx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">facsimile [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">manuscript</skos:prefLabel>
     <skos:definition xml:lang="en">Drawn or fashioned by hand.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">loose-leaf</skos:prefLabel>
     <skos:definition xml:lang="en">Separate leaves intended to be stored in a binder or case.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Loose-leaf items are often meant to be updated.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#n">
@@ -39,7 +33,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Intended to be used as or is part of a game.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -47,7 +41,7 @@
     <dct:title xml:lang="en">Maps: special format characteristics</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33-34 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the special format characteristics of the map.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -70,89 +64,89 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">puzzle</skos:prefLabel>
     <skos:definition xml:lang="en">Image may be disassembled into pieces and reassembled.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">rare [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#dx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">film negative [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#mx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">braille [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#bx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">picture card, post card</skos:prefLabel>
     <skos:definition xml:lang="en">Picture card, post card.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">relief model [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">playing cards</skos:prefLabel>
     <skos:definition xml:lang="en">Playing cards.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#qx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">large print [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">no specified special format characteristics</skos:prefLabel>
     <skos:definition xml:lang="en">No specified special format characteristics.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">wall map</skos:prefLabel>
     <skos:definition xml:lang="en">Wall map.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">calendar</skos:prefLabel>
     <skos:definition xml:lang="en">Calendar.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#cx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">negative photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.rw25-p125#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.rw25-p125"/>
     <skos:prefLabel xml:lang="en">photocopy, blue line print [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf
@@ -45,7 +45,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl
+++ b/008/maps_special_format_characteristics/maps_special_format_characteristics.ttl
@@ -5,108 +5,108 @@
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#ax> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "photocopy, blue line print [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#bx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "photocopy [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#cx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "negative photocopy [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#dx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "film negative [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#e> a skos:Concept ;
     skos:definition "Drawn or fashioned by hand."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "manuscript"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#fx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "facsimile [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#gx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "relief model [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#hx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "rare [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#j> a skos:Concept ;
     skos:definition "Picture card, post card."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "picture card, post card"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#k> a skos:Concept ;
     skos:definition "Calendar."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "calendar"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#l> a skos:Concept ;
     skos:definition "Image may be disassembled into pieces and reassembled."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "puzzle"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#mx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "braille [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#n> a skos:Concept ;
     skos:definition "Intended to be used as or is part of a game."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "game"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#o> a skos:Concept ;
     skos:definition "Wall map."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "wall map"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#p> a skos:Concept ;
     skos:definition "Playing cards."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "playing cards"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#pound> a skos:Concept ;
     skos:definition "No specified special format characteristics."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no specified special format characteristics"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#qx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "large print [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#r> a skos:Concept ;
     skos:definition "Separate leaves intended to be stored in a binder or case."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "loose-leaf"@en ;
     skos:scopeNote "Loose-leaf items are often meant to be updated."@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125#z> a skos:Concept ;
     skos:definition "Special format characteristics other than manuscript, picture card, post card, calendar, puzzle, game, wall map, playing cards, or loose-leaf."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.rw25-p125> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.rw25-p125> a skos:ConceptScheme ;
@@ -123,12 +123,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_special_format_characteristics/maps_special_format_characteristics.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Maps: special format characteristics"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
                         <td id="a">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
                         <td>
@@ -416,7 +416,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
                         <td>
@@ -475,7 +475,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#c">
                         <td>
@@ -533,7 +533,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
                         <td>
@@ -582,7 +582,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
                         <td>
@@ -640,7 +640,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#f">
                         <td>
@@ -698,7 +698,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g">
                         <td>
@@ -756,7 +756,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u">
                         <td>
@@ -806,7 +806,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z">
                         <td>
@@ -836,38 +836,68 @@
     &lt;dct:title xml:lang="en"&gt;Maps: type of cartographic material&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/25 values for maps expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the type of cartographic item described.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;globe&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Globe.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;separate supplement to another work&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Separate supplement to another work&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Other work being supplemented does not have to be cartographic material.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;map series&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for atlas series.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;single map&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Single map.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;atlas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Atlas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes atlas series, and serially issued atlases.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;bound as part of another work&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Bound as part of another work&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Other work included does not have to be cartographic material.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#c"&gt;
@@ -875,52 +905,22 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;map serial&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for serially issued atlases.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;single map&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Single map.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;atlas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Atlas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes atlas series, and serially issued atlases.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;map series&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for atlas series.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;globe&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Globe.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -935,60 +935,60 @@
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; a skos:Concept ;
     skos:definition "Single map."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "single map"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; a skos:Concept ;
     skos:definition "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "map series"@en ;
     skos:scopeNote "Not used for atlas series."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; a skos:Concept ;
     skos:definition "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "map serial"@en ;
     skos:scopeNote "Not used for serially issued atlases."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; a skos:Concept ;
     skos:definition "Globe."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "globe"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; a skos:Concept ;
     skos:definition "Atlas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "atlas"@en ;
     skos:scopeNote "Includes atlas series, and serially issued atlases."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; a skos:Concept ;
     skos:definition "Separate supplement to another work"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "separate supplement to another work"@en ;
     skos:scopeNote "Other work being supplemented does not have to be cartographic material."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; a skos:Concept ;
     skos:definition "Bound as part of another work"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "bound as part of another work"@en ;
     skos:scopeNote "Other work included does not have to be cartographic material."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; a skos:Concept ;
     skos:definition "Unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; a skos:Concept ;
     skos:definition "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; a skos:ConceptScheme ;
@@ -1005,105 +1005,105 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Maps: type of cartographic material"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serially issued atlases."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: type of cartographic material"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "separate supplement to another work"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "map serial"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bound as part of another work"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for atlas series."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Other work being supplemented does not have to be cartographic material."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/25 values for maps expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bound as part of another work"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Atlas."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Single map."@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "globe"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "atlas"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "single map"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes atlas series, and serially issued atlases."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Other work included does not have to be cartographic material."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "map series"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Globe."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of cartographic item described."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en .
-&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
 &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Separate supplement to another work"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "map series"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of cartographic item described."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "atlas"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bound as part of another work"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Single map."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Other work included does not have to be cartographic material."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/title&gt; "Maps: type of cartographic material"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Atlas."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for atlas series."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Globe."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes atlas series, and serially issued atlases."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Other work being supplemented does not have to be cartographic material."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "separate supplement to another work"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "single map"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for serially issued atlases."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bound as part of another work"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "map serial"@en .
+&lt;https://doi.org/10.6069/uwlswd.vw5v-gh79&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/25 values for maps expressed using RDF"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#c",
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."
+        "@value": "Single map."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1113,154 +1113,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "map serial"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for serially issued atlases."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "map series"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for atlas series."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Atlas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "atlas"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes atlas series, and serially issued atlases."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bound as part of another work"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bound as part of another work"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Other work included does not have to be cartographic material."
+        "@value": "single map"
       }
     ]
   },
@@ -1333,7 +1192,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1362,24 +1221,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#d",
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Globe."
+        "@value": "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1389,43 +1249,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "globe"
+        "@value": "map serial"
       }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Single map."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "single map"
+        "@value": "Not used for serially issued atlases."
       }
     ]
   },
@@ -1447,7 +1283,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -1455,6 +1290,40 @@
       {
         "@language": "en",
         "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Atlas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "atlas"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes atlas series, and serially issued atlases."
       }
     ]
   },
@@ -1476,7 +1345,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "f"
       }
     ],
@@ -1490,6 +1358,130 @@
       {
         "@language": "en",
         "@value": "Other work being supplemented does not have to be cartographic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bound as part of another work"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bound as part of another work"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Other work included does not have to be cartographic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "map series"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for atlas series."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Globe."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "globe"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
       }
     ]
   }

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#c",
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."
+        "@value": "Single map."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,154 +17,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "map serial"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for serially issued atlases."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "map series"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for atlas series."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Atlas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "atlas"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes atlas series, and serially issued atlases."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bound as part of another work"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bound as part of another work"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Other work included does not have to be cartographic material."
+        "@value": "single map"
       }
     ]
   },
@@ -237,7 +96,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -266,24 +125,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#d",
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Globe."
+        "@value": "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -293,43 +153,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "globe"
+        "@value": "map serial"
       }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
     ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Single map."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "single map"
+        "@value": "Not used for serially issued atlases."
       }
     ]
   },
@@ -351,7 +187,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -359,6 +194,40 @@
       {
         "@language": "en",
         "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Atlas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "atlas"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes atlas series, and serially issued atlases."
       }
     ]
   },
@@ -380,7 +249,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "f"
       }
     ],
@@ -394,6 +262,130 @@
       {
         "@language": "en",
         "@value": "Other work being supplemented does not have to be cartographic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bound as part of another work"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bound as part of another work"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Other work included does not have to be cartographic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "map series"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for atlas series."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Globe."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "globe"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.vw5v-gh79"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
       }
     ]
   }

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt
@@ -1,72 +1,72 @@
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serially issued atlases."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/title> "Maps: type of cartographic material"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "separate supplement to another work"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#definition> "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "map serial"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
 <https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "bound as part of another work"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for atlas series."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Other work being supplemented does not have to be cartographic material."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/alternative> "MARC21 008/25 values for maps expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#definition> "Bound as part of another work"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#definition> "Atlas."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#definition> "Single map."@en .
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "globe"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "atlas"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "single map"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes atlas series, and serially issued atlases."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "Other work included does not have to be cartographic material."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "map series"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#definition> "Globe."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/description> "Indicates the type of cartographic item described."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#definition> "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en .
-<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#definition> "Separate supplement to another work"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "map series"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/description> "Indicates the type of cartographic item described."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "atlas"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "bound as part of another work"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#definition> "Single map."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "Other work included does not have to be cartographic material."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/title> "Maps: type of cartographic material"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#definition> "Atlas."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for atlas series."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#definition> "Globe."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#definition> "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes atlas series, and serially issued atlases."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Other work being supplemented does not have to be cartographic material."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#b> <http://www.w3.org/2004/02/skos/core#definition> "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "separate supplement to another work"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "single map"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for serially issued atlases."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#definition> "Bound as part of another work"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown."@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.vw5v-gh79> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "map serial"@en .
+<https://doi.org/10.6069/uwlswd.vw5v-gh79> <http://purl.org/dc/terms/alternative> "MARC21 008/25 values for maps expressed using RDF"@en .

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Maps: type of cartographic material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of cartographic item described.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,7 +29,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">separate supplement to another work</skos:prefLabel>
     <skos:definition xml:lang="en">Separate supplement to another work</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Other work being supplemented does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g">
@@ -43,7 +37,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">bound as part of another work</skos:prefLabel>
     <skos:definition xml:lang="en">Bound as part of another work</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">Other work included does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#c">
@@ -51,7 +45,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map serial</skos:prefLabel>
     <skos:definition xml:lang="en">Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
@@ -59,14 +53,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">single map</skos:prefLabel>
     <skos:definition xml:lang="en">Single map.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">atlas</skos:prefLabel>
     <skos:definition xml:lang="en">Atlas.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes atlas series, and serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
@@ -74,7 +68,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map series</skos:prefLabel>
     <skos:definition xml:lang="en">Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for atlas series.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z">
@@ -82,20 +76,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">globe</skos:prefLabel>
     <skos:definition xml:lang="en">Globe.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld"/>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Maps: type of cartographic material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of cartographic item described.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld"/>
@@ -29,7 +35,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">separate supplement to another work</skos:prefLabel>
     <skos:definition xml:lang="en">Separate supplement to another work</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
     <skos:scopeNote xml:lang="en">Other work being supplemented does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g">
@@ -37,7 +43,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">bound as part of another work</skos:prefLabel>
     <skos:definition xml:lang="en">Bound as part of another work</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
     <skos:scopeNote xml:lang="en">Other work included does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#c">
@@ -45,7 +51,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map serial</skos:prefLabel>
     <skos:definition xml:lang="en">Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
@@ -53,14 +59,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">single map</skos:prefLabel>
     <skos:definition xml:lang="en">Single map.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">atlas</skos:prefLabel>
     <skos:definition xml:lang="en">Atlas.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes atlas series, and serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
@@ -68,7 +74,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map series</skos:prefLabel>
     <skos:definition xml:lang="en">Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for atlas series.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z">
@@ -76,20 +82,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">globe</skos:prefLabel>
     <skos:definition xml:lang="en">Globe.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,6 +30,13 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
+    <skos:prefLabel xml:lang="en">globe</skos:prefLabel>
+    <skos:definition xml:lang="en">Globe.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
@@ -31,6 +44,29 @@
     <skos:definition xml:lang="en">Separate supplement to another work</skos:definition>
     <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Other work being supplemented does not have to be cartographic material.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
+    <skos:prefLabel xml:lang="en">map series</skos:prefLabel>
+    <skos:definition xml:lang="en">Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.</skos:definition>
+    <skos:notation>b</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for atlas series.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
+    <skos:prefLabel xml:lang="en">single map</skos:prefLabel>
+    <skos:definition xml:lang="en">Single map.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
+    <skos:prefLabel xml:lang="en">atlas</skos:prefLabel>
+    <skos:definition xml:lang="en">Atlas.</skos:definition>
+    <skos:notation>e</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes atlas series, and serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -48,42 +84,12 @@
     <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serially issued atlases.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
-    <skos:prefLabel xml:lang="en">single map</skos:prefLabel>
-    <skos:definition xml:lang="en">Single map.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
-    <skos:prefLabel xml:lang="en">atlas</skos:prefLabel>
-    <skos:definition xml:lang="en">Atlas.</skos:definition>
-    <skos:notation>e</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes atlas series, and serially issued atlases.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
-    <skos:prefLabel xml:lang="en">map series</skos:prefLabel>
-    <skos:definition xml:lang="en">Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.</skos:definition>
-    <skos:notation>b</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for atlas series.</skos:scopeNote>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work.</skos:definition>
     <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
-    <skos:prefLabel xml:lang="en">globe</skos:prefLabel>
-    <skos:definition xml:lang="en">Globe.</skos:definition>
-    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Maps: type of cartographic material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/25 values for maps expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of cartographic item described.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.jsonld"/>
@@ -35,7 +29,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">separate supplement to another work</skos:prefLabel>
     <skos:definition xml:lang="en">Separate supplement to another work</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Other work being supplemented does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#g">
@@ -43,7 +37,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">bound as part of another work</skos:prefLabel>
     <skos:definition xml:lang="en">Bound as part of another work</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">Other work included does not have to be cartographic material.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#c">
@@ -51,7 +45,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map serial</skos:prefLabel>
     <skos:definition xml:lang="en">Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#a">
@@ -59,14 +53,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">single map</skos:prefLabel>
     <skos:definition xml:lang="en">Single map.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">atlas</skos:prefLabel>
     <skos:definition xml:lang="en">Atlas.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
     <skos:scopeNote xml:lang="en">Includes atlas series, and serially issued atlases.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#b">
@@ -74,7 +68,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">map series</skos:prefLabel>
     <skos:definition xml:lang="en">Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for atlas series.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#z">
@@ -82,20 +76,20 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">globe</skos:prefLabel>
     <skos:definition xml:lang="en">Globe.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.vw5v-gh79#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.vw5v-gh79"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl
+++ b/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.ttl
@@ -6,60 +6,60 @@
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#a> a skos:Concept ;
     skos:definition "Single map."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "single map"@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#b> a skos:Concept ;
     skos:definition "Number of related but physically separate and bibliographically distinct cartographic units intended by the producer(s) or issuing body(s) to form a single group."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "map series"@en ;
     skos:scopeNote "Not used for atlas series."@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#c> a skos:Concept ;
     skos:definition "Issued in successive parts bearing numerical or chronological designations and intended to be continued indefinitely."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "map serial"@en ;
     skos:scopeNote "Not used for serially issued atlases."@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#d> a skos:Concept ;
     skos:definition "Globe."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "globe"@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#e> a skos:Concept ;
     skos:definition "Atlas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "atlas"@en ;
     skos:scopeNote "Includes atlas series, and serially issued atlases."@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#f> a skos:Concept ;
     skos:definition "Separate supplement to another work"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "separate supplement to another work"@en ;
     skos:scopeNote "Other work being supplemented does not have to be cartographic material."@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#g> a skos:Concept ;
     skos:definition "Bound as part of another work"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "bound as part of another work"@en ;
     skos:scopeNote "Other work included does not have to be cartographic material."@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#u> a skos:Concept ;
     skos:definition "Unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79#z> a skos:Concept ;
     skos:definition "Type of cartographic material other than single map, map series, map serial, globe, atlas, separate map supplement to another work, or map bound as part of another work."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.vw5v-gh79> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.vw5v-gh79> a skos:ConceptScheme ;
@@ -76,12 +76,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/maps_type_of_cartographic_material/maps_type_of_cartographic_material.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Maps: type of cartographic material"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_accompanying_matter/music_accompanying_matter.html
+++ b/008/music_accompanying_matter/music_accompanying_matter.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
                         <td id="a">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
                         <td>
@@ -466,7 +466,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
                         <td>
@@ -516,7 +516,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#d">
                         <td>
@@ -565,7 +565,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
                         <td>
@@ -614,7 +614,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#f">
                         <td>
@@ -663,7 +663,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
                         <td>
@@ -712,7 +712,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
                         <td>
@@ -770,7 +770,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
                         <td>
@@ -810,7 +810,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#jx">
                         <td>
@@ -859,7 +859,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
                         <td>
@@ -899,7 +899,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
                         <td>
@@ -948,7 +948,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound">
                         <td>
@@ -997,7 +997,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
                         <td>
@@ -1046,7 +1046,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
                         <td>
@@ -1098,7 +1098,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.nt0v-d633#z">
                         <td>
@@ -1122,33 +1122,82 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;ethnological information&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant ethnological information that relates to the musical part of the item.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical and/or historical information on instruments&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant technical information, including instructions for performance.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;thematic index&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Thematic index.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical information on music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant technical information.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Including instructions for performance.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;historical information&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant historical information.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;ethnological information&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant ethnological information that relates to the musical part of the item.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;biography of performer or history of ensemble&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Significant biographical information on a performer or a history of an ensemble.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biography of composer or author&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Significant biographical information on a composer or author.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;discography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Discography or other bibliography of recorded sound.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;thematic index&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Thematic index.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;A score or other music format than that of the main item.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1156,106 +1205,57 @@
     &lt;dct:title xml:lang="en"&gt;Music: accompanying matter&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/24-29 values for music expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#jx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;historical information other than music [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical and/or historical information on instruments&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant technical information, including instructions for performance.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;historical information&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant historical information.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;no accompanying matter&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;No accompanying matter or no indication of accompanying matter appears on the item.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biography of composer or author&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant biographical information on a composer or author.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical information on music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Significant technical information.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Including instructions for performance.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bibliography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Bibliography.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;libretto or text&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;discography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Discography or other bibliography of recorded sound.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;A score or other music format than that of the main item.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;instructional materials&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Instructional materials.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;libretto or text&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bibliography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Bibliography.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#jx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;historical information other than music [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1270,96 +1270,96 @@
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; a skos:Concept ;
     skos:definition "Discography or other bibliography of recorded sound."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "discography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; a skos:Concept ;
     skos:definition "Bibliography."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bibliography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; a skos:Concept ;
     skos:definition "Thematic index."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "thematic index"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; a skos:Concept ;
     skos:definition "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "libretto or text"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; a skos:Concept ;
     skos:definition "Significant biographical information on a composer or author."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "biography of composer or author"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; a skos:Concept ;
     skos:definition "Significant biographical information on a performer or a history of an ensemble."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "biography of performer or history of ensemble"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; a skos:Concept ;
     skos:definition "Significant technical information, including instructions for performance."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "technical and/or historical information on instruments"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; a skos:Concept ;
     skos:definition "Significant technical information."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "technical information on music"@en ;
     skos:scopeNote "Including instructions for performance."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; a skos:Concept ;
     skos:definition "Significant historical information."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "historical information"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "historical information other than music [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; a skos:Concept ;
     skos:definition "Significant ethnological information that relates to the musical part of the item."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "ethnological information"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; a skos:Concept ;
     skos:definition "No accompanying matter or no indication of accompanying matter appears on the item."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no accompanying matter"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; a skos:Concept ;
     skos:definition "Instructional materials."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "instructional materials"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; a skos:Concept ;
     skos:definition "A score or other music format than that of the main item."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; a skos:Concept ;
     skos:definition "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; a skos:ConceptScheme ;
@@ -1376,134 +1376,134 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: accompanying matter"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant ethnological information that relates to the musical part of the item."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography of performer or history of ensemble"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant historical information."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant biographical information on a composer or author."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bibliography."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thematic index."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discography or other bibliography of recorded sound."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography of composer or author"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant technical information."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instructional materials."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No accompanying matter or no indication of accompanying matter appears on the item."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instructional materials"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "historical information"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A score or other music format than that of the main item."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discography"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "libretto or text"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: accompanying matter"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant technical information, including instructions for performance."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24-29 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliography"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical and/or historical information on instruments"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "thematic index"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "historical information other than music [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "music"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no accompanying matter"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant biographical information on a performer or a history of an ensemble."@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant technical information, including instructions for performance."@en .
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Including instructions for performance."@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "historical information"@en .
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ethnological information"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant historical information."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant biographical information on a composer or author."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical and/or historical information on instruments"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A score or other music format than that of the main item."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no accompanying matter"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instructional materials"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography of composer or author"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instructional materials."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Thematic index."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bibliography."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Discography or other bibliography of recorded sound."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld&gt; .
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical information on music"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "music"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography of performer or history of ensemble"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No accompanying matter or no indication of accompanying matter appears on the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "historical information other than music [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "libretto or text"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant ethnological information that relates to the musical part of the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bibliography"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/24-29 values for music expressed using RDF"@en .
 &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: accompanying matter"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "thematic index"@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant technical information."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Significant biographical information on a performer or a history of an ensemble."@en .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.nt0v-d633#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "discography"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#g",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#z",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Significant technical information, including instructions for performance."
+        "@value": "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1513,101 +1513,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "z"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "technical and/or historical information on instruments"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant historical information."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "historical information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant ethnological information that relates to the musical part of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ethnological information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant biographical information on a performer or a history of an ensemble."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography of performer or history of ensemble"
+        "@value": "other"
       }
     ]
   },
@@ -1629,7 +1541,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -1647,9 +1558,15 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#jx",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A score or other music format than that of the main item."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1658,21 +1575,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "historical information other than music [obsolete]"
+        "@value": "music"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#nx",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No accompanying matter or no indication of accompanying matter appears on the item."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -1681,14 +1603,125 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not applicable [obsolete]"
+        "@value": "no accompanying matter"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant biographical information on a composer or author."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography of composer or author"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discography or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thematic index."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "thematic index"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant historical information."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "historical information"
       }
     ]
   },
@@ -1761,7 +1794,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1790,186 +1823,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant biographical information on a composer or author."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography of composer or author"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bibliography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No accompanying matter or no indication of accompanying matter appears on the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no accompanying matter"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discography or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A score or other music format than that of the main item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "music"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1991,7 +1851,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -2003,14 +1862,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#c",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Thematic index."
+        "@value": "Significant biographical information on a performer or a history of an ensemble."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2020,14 +1879,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "thematic index"
+        "@value": "biography of performer or history of ensemble"
       }
     ]
   },
@@ -2049,7 +1907,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -2057,6 +1914,134 @@
       {
         "@language": "en",
         "@value": "libretto or text"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant ethnological information that relates to the musical part of the item."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ethnological information"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant technical information, including instructions for performance."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical and/or historical information on instruments"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "historical information other than music [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bibliography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliography"
       }
     ]
   }

--- a/008/music_accompanying_matter/music_accompanying_matter.jsonld
+++ b/008/music_accompanying_matter/music_accompanying_matter.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#g",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#z",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Significant technical information, including instructions for performance."
+        "@value": "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,101 +17,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "g"
+        "@value": "z"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "technical and/or historical information on instruments"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant historical information."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "historical information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant ethnological information that relates to the musical part of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ethnological information"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant biographical information on a performer or a history of an ensemble."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography of performer or history of ensemble"
+        "@value": "other"
       }
     ]
   },
@@ -133,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -151,9 +62,15 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#jx",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A score or other music format than that of the main item."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -162,21 +79,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "historical information other than music [obsolete]"
+        "@value": "music"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#nx",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#pound",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No accompanying matter or no indication of accompanying matter appears on the item."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -185,14 +107,125 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "#"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not applicable [obsolete]"
+        "@value": "no accompanying matter"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant biographical information on a composer or author."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography of composer or author"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Discography or other bibliography of recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "discography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Thematic index."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "thematic index"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant historical information."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "historical information"
       }
     ]
   },
@@ -265,7 +298,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -294,186 +327,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Significant biographical information on a composer or author."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography of composer or author"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bibliography."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bibliography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "No accompanying matter or no indication of accompanying matter appears on the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "no accompanying matter"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Discography or other bibliography of recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "discography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A score or other music format than that of the main item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "music"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -495,7 +355,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -507,14 +366,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#c",
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Thematic index."
+        "@value": "Significant biographical information on a performer or a history of an ensemble."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -524,14 +383,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "thematic index"
+        "@value": "biography of performer or history of ensemble"
       }
     ]
   },
@@ -553,7 +411,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "d"
       }
     ],
@@ -561,6 +418,134 @@
       {
         "@language": "en",
         "@value": "libretto or text"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant ethnological information that relates to the musical part of the item."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ethnological information"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Significant technical information, including instructions for performance."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "technical and/or historical information on instruments"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "historical information other than music [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bibliography."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.nt0v-d633"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bibliography"
       }
     ]
   }

--- a/008/music_accompanying_matter/music_accompanying_matter.nt
+++ b/008/music_accompanying_matter/music_accompanying_matter.nt
@@ -1,101 +1,101 @@
-<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant ethnological information that relates to the musical part of the item."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography of performer or history of ensemble"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#definition> "Significant historical information."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#definition> "Significant biographical information on a composer or author."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#definition> "Bibliography."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#definition> "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#definition> "Thematic index."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#definition> "Discography or other bibliography of recorded sound."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography of composer or author"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#definition> "Significant technical information."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#definition> "Instructional materials."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#definition> "No accompanying matter or no indication of accompanying matter appears on the item."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "instructional materials"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/description> "Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "historical information"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#definition> "A score or other music format than that of the main item."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "discography"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "libretto or text"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#definition> "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/title> "Music: accompanying matter"@en .
 <https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#definition> "Significant technical information, including instructions for performance."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/alternative> "MARC21 008/24-29 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliography"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical and/or historical information on instruments"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "thematic index"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "historical information other than music [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "music"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no accompanying matter"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#definition> "Significant biographical information on a performer or a history of an ensemble."@en .
 <https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#scopeNote> "Including instructions for performance."@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#definition> "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "historical information"@en .
 <https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "ethnological information"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#definition> "Significant historical information."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#definition> "Significant biographical information on a composer or author."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical and/or historical information on instruments"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#definition> "A score or other music format than that of the main item."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no accompanying matter"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "instructional materials"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography of composer or author"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#definition> "Instructional materials."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#definition> "Thematic index."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#definition> "Bibliography."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#definition> "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#definition> "Discography or other bibliography of recorded sound."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld> .
 <https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical information on music"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "music"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography of performer or history of ensemble"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/description> "Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#definition> "No accompanying matter or no indication of accompanying matter appears on the item."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "historical information other than music [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "libretto or text"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/2004/02/skos/core#definition> "Significant ethnological information that relates to the musical part of the item."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "bibliography"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/alternative> "MARC21 008/24-29 values for music expressed using RDF"@en .
 <https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl> .
-<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/title> "Music: accompanying matter"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "thematic index"@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#definition> "Significant technical information."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#f> <http://www.w3.org/2004/02/skos/core#definition> "Significant biographical information on a performer or a history of an ensemble."@en .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.nt0v-d633> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.nt0v-d633#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "discography"@en .

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -1,38 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">ethnological information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant ethnological information that relates to the musical part of the item.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">thematic index</skos:prefLabel>
     <skos:definition xml:lang="en">Thematic index.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of performer or history of ensemble</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a performer or a history of an ensemble.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -40,7 +34,7 @@
     <dct:title xml:lang="en">Music: accompanying matter</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-29 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -51,7 +45,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld"/>
@@ -62,48 +56,48 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information other than music [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical and/or historical information on instruments</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information, including instructions for performance.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant historical information.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">no accompanying matter</skos:prefLabel>
     <skos:definition xml:lang="en">No accompanying matter or no indication of accompanying matter appears on the item.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of composer or author</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a composer or author.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical information on music</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Including instructions for performance.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
@@ -111,34 +105,34 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">bibliography</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliography.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">libretto or text</skos:prefLabel>
     <skos:definition xml:lang="en">Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">discography</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">A score or other music format than that of the main item.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">instructional materials</skos:prefLabel>
     <skos:definition xml:lang="en">Instructional materials.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -1,18 +1,25 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">ethnological information</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant ethnological information that relates to the musical part of the item.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:prefLabel xml:lang="en">technical and/or historical information on instruments</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant technical information, including instructions for performance.</skos:definition>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">thematic index</skos:prefLabel>
-    <skos:definition xml:lang="en">Thematic index.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">technical information on music</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant technical information.</skos:definition>
+    <skos:notation>h</skos:notation>
+    <skos:scopeNote xml:lang="en">Including instructions for performance.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -21,12 +28,60 @@
     <skos:definition xml:lang="en">Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music.</skos:definition>
     <skos:notation>z</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">historical information</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant historical information.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">ethnological information</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant ethnological information that relates to the musical part of the item.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of performer or history of ensemble</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a performer or a history of an ensemble.</skos:definition>
     <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">biography of composer or author</skos:prefLabel>
+    <skos:definition xml:lang="en">Significant biographical information on a composer or author.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">discography</skos:prefLabel>
+    <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">thematic index</skos:prefLabel>
+    <skos:definition xml:lang="en">Thematic index.</skos:definition>
+    <skos:notation>c</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
+    <skos:notation>n</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
+    <skos:prefLabel xml:lang="en">music</skos:prefLabel>
+    <skos:definition xml:lang="en">A score or other music format than that of the main item.</skos:definition>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -52,26 +107,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#jx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">historical information other than music [obsolete]</skos:prefLabel>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">technical and/or historical information on instruments</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant technical information, including instructions for performance.</skos:definition>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">historical information</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant historical information.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
@@ -79,33 +114,12 @@
     <skos:definition xml:lang="en">No accompanying matter or no indication of accompanying matter appears on the item.</skos:definition>
     <skos:notation>#</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">biography of composer or author</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant biographical information on a composer or author.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">technical information on music</skos:prefLabel>
-    <skos:definition xml:lang="en">Significant technical information.</skos:definition>
-    <skos:notation>h</skos:notation>
-    <skos:scopeNote xml:lang="en">Including instructions for performance.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">bibliography</skos:prefLabel>
-    <skos:definition xml:lang="en">Bibliography.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:prefLabel xml:lang="en">instructional materials</skos:prefLabel>
+    <skos:definition xml:lang="en">Instructional materials.</skos:definition>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -114,25 +128,17 @@
     <skos:definition xml:lang="en">Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).</skos:definition>
     <skos:notation>d</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">discography</skos:prefLabel>
-    <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">bibliography</skos:prefLabel>
+    <skos:definition xml:lang="en">Bibliography.</skos:definition>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">music</skos:prefLabel>
-    <skos:definition xml:lang="en">A score or other music format than that of the main item.</skos:definition>
-    <skos:notation>s</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
-    <skos:prefLabel xml:lang="en">instructional materials</skos:prefLabel>
-    <skos:definition xml:lang="en">Instructional materials.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:prefLabel xml:lang="en">historical information other than music [obsolete]</skos:prefLabel>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -1,32 +1,38 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">ethnological information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant ethnological information that relates to the musical part of the item.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">thematic index</skos:prefLabel>
     <skos:definition xml:lang="en">Thematic index.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of performer or history of ensemble</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a performer or a history of an ensemble.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -34,7 +40,7 @@
     <dct:title xml:lang="en">Music: accompanying matter</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-29 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -45,7 +51,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld"/>
@@ -56,48 +62,48 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information other than music [obsolete]</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical and/or historical information on instruments</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information, including instructions for performance.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant historical information.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">no accompanying matter</skos:prefLabel>
     <skos:definition xml:lang="en">No accompanying matter or no indication of accompanying matter appears on the item.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of composer or author</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a composer or author.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical information on music</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
     <skos:scopeNote xml:lang="en">Including instructions for performance.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
@@ -105,34 +111,34 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">bibliography</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliography.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">libretto or text</skos:prefLabel>
     <skos:definition xml:lang="en">Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">discography</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">A score or other music format than that of the main item.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">instructional materials</skos:prefLabel>
     <skos:definition xml:lang="en">Instructional materials.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -45,7 +45,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.jsonld"/>

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -1,38 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">ethnological information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant ethnological information that relates to the musical part of the item.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">thematic index</skos:prefLabel>
     <skos:definition xml:lang="en">Thematic index.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of performer or history of ensemble</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a performer or a history of an ensemble.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -40,7 +34,7 @@
     <dct:title xml:lang="en">Music: accompanying matter</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/24-29 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the contents of program notes and other accompanying material for sound recording, music manuscripts, or notated music.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -62,48 +56,48 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information other than music [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical and/or historical information on instruments</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information, including instructions for performance.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">historical information</skos:prefLabel>
     <skos:definition xml:lang="en">Significant historical information.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">no accompanying matter</skos:prefLabel>
     <skos:definition xml:lang="en">No accompanying matter or no indication of accompanying matter appears on the item.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">biography of composer or author</skos:prefLabel>
     <skos:definition xml:lang="en">Significant biographical information on a composer or author.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">technical information on music</skos:prefLabel>
     <skos:definition xml:lang="en">Significant technical information.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
     <skos:scopeNote xml:lang="en">Including instructions for performance.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#b">
@@ -111,34 +105,34 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">bibliography</skos:prefLabel>
     <skos:definition xml:lang="en">Bibliography.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">libretto or text</skos:prefLabel>
     <skos:definition xml:lang="en">Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording).</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">discography</skos:prefLabel>
     <skos:definition xml:lang="en">Discography or other bibliography of recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">music</skos:prefLabel>
     <skos:definition xml:lang="en">A score or other music format than that of the main item.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.nt0v-d633#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.nt0v-d633"/>
     <skos:prefLabel xml:lang="en">instructional materials</skos:prefLabel>
     <skos:definition xml:lang="en">Instructional materials.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_accompanying_matter/music_accompanying_matter.rdf
+++ b/008/music_accompanying_matter/music_accompanying_matter.rdf
@@ -38,7 +38,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/music_accompanying_matter/music_accompanying_matter.ttl
+++ b/008/music_accompanying_matter/music_accompanying_matter.ttl
@@ -6,96 +6,96 @@
 <https://doi.org/10.6069/uwlswd.nt0v-d633#a> a skos:Concept ;
     skos:definition "Discography or other bibliography of recorded sound."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "discography"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#b> a skos:Concept ;
     skos:definition "Bibliography."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "bibliography"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#c> a skos:Concept ;
     skos:definition "Thematic index."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "thematic index"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#d> a skos:Concept ;
     skos:definition "Printed transcription of the libretto or other text (e.g., a transcript of verbal contents of a sound recording)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "libretto or text"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#e> a skos:Concept ;
     skos:definition "Significant biographical information on a composer or author."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "biography of composer or author"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#f> a skos:Concept ;
     skos:definition "Significant biographical information on a performer or a history of an ensemble."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "biography of performer or history of ensemble"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#g> a skos:Concept ;
     skos:definition "Significant technical information, including instructions for performance."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "technical and/or historical information on instruments"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#h> a skos:Concept ;
     skos:definition "Significant technical information."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "technical information on music"@en ;
     skos:scopeNote "Including instructions for performance."@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#i> a skos:Concept ;
     skos:definition "Significant historical information."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "historical information"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#jx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "historical information other than music [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#k> a skos:Concept ;
     skos:definition "Significant ethnological information that relates to the musical part of the item."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "ethnological information"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#nx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#pound> a skos:Concept ;
     skos:definition "No accompanying matter or no indication of accompanying matter appears on the item."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no accompanying matter"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#r> a skos:Concept ;
     skos:definition "Instructional materials."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "instructional materials"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#s> a skos:Concept ;
     skos:definition "A score or other music format than that of the main item."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "music"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633#z> a skos:Concept ;
     skos:definition "Accompanying matter other than discography, bibliography, thematic index, libretto or text, biography of composer or author, biography of performer or history of ensemble, technical and/or historical information on instruments, technical information on music, historical information, ethnological information, instructional materials, or music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.nt0v-d633> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.nt0v-d633> a skos:ConceptScheme ;
@@ -112,12 +112,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_accompanying_matter/music_accompanying_matter.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: accompanying matter"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_form_of_composition/music_form_of_composition.html
+++ b/008/music_form_of_composition/music_form_of_composition.html
@@ -52,7 +52,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -246,8 +246,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
@@ -321,7 +321,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
                         <td>
@@ -330,7 +330,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
                         <td>
@@ -380,7 +380,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">an</td>
+                        <td property="skos:notation">an</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
                         <td>
@@ -429,7 +429,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bd</td>
+                        <td property="skos:notation">bd</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
                         <td>
@@ -478,7 +478,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bg</td>
+                        <td property="skos:notation">bg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
                         <td>
@@ -527,7 +527,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bl</td>
+                        <td property="skos:notation">bl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bl">
                         <td>
@@ -576,7 +576,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">bt</td>
+                        <td property="skos:notation">bt</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
                         <td>
@@ -625,7 +625,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ca</td>
+                        <td property="skos:notation">ca</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
                         <td>
@@ -674,7 +674,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cb</td>
+                        <td property="skos:notation">cb</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
                         <td>
@@ -723,7 +723,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cc</td>
+                        <td property="skos:notation">cc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
                         <td>
@@ -772,7 +772,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cg</td>
+                        <td property="skos:notation">cg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
                         <td>
@@ -821,7 +821,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ch</td>
+                        <td property="skos:notation">ch</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
                         <td>
@@ -870,7 +870,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cl</td>
+                        <td property="skos:notation">cl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
                         <td>
@@ -920,7 +920,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cn</td>
+                        <td property="skos:notation">cn</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
                         <td>
@@ -969,7 +969,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">co</td>
+                        <td property="skos:notation">co</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
                         <td>
@@ -1018,7 +1018,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cp</td>
+                        <td property="skos:notation">cp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
                         <td>
@@ -1067,7 +1067,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cr</td>
+                        <td property="skos:notation">cr</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
                         <td>
@@ -1116,7 +1116,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cs</td>
+                        <td property="skos:notation">cs</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
                         <td>
@@ -1165,7 +1165,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ct</td>
+                        <td property="skos:notation">ct</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
                         <td>
@@ -1214,7 +1214,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cy</td>
+                        <td property="skos:notation">cy</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
                         <td>
@@ -1263,7 +1263,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">cz</td>
+                        <td property="skos:notation">cz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
                         <td>
@@ -1321,7 +1321,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">df</td>
+                        <td property="skos:notation">df</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df">
                         <td>
@@ -1381,7 +1381,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">dv</td>
+                        <td property="skos:notation">dv</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
                         <td>
@@ -1441,7 +1441,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">fg</td>
+                        <td property="skos:notation">fg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
                         <td>
@@ -1490,7 +1490,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">fl</td>
+                        <td property="skos:notation">fl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
                         <td>
@@ -1549,7 +1549,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">fm</td>
+                        <td property="skos:notation">fm</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm">
                         <td>
@@ -1607,7 +1607,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ft</td>
+                        <td property="skos:notation">ft</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
                         <td>
@@ -1666,7 +1666,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">gm</td>
+                        <td property="skos:notation">gm</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
                         <td>
@@ -1715,7 +1715,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">hy</td>
+                        <td property="skos:notation">hy</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
                         <td>
@@ -1764,7 +1764,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">jz</td>
+                        <td property="skos:notation">jz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
                         <td>
@@ -1813,7 +1813,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mc</td>
+                        <td property="skos:notation">mc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc">
                         <td>
@@ -1862,7 +1862,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">md</td>
+                        <td property="skos:notation">md</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
                         <td>
@@ -1911,7 +1911,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mi</td>
+                        <td property="skos:notation">mi</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
                         <td>
@@ -1960,7 +1960,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mo</td>
+                        <td property="skos:notation">mo</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
                         <td>
@@ -2009,7 +2009,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mp</td>
+                        <td property="skos:notation">mp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp">
                         <td>
@@ -2058,7 +2058,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mr</td>
+                        <td property="skos:notation">mr</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
                         <td>
@@ -2107,7 +2107,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ms</td>
+                        <td property="skos:notation">ms</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
                         <td>
@@ -2156,7 +2156,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mu</td>
+                        <td property="skos:notation">mu</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
                         <td>
@@ -2205,7 +2205,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">mz</td>
+                        <td property="skos:notation">mz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
                         <td>
@@ -2254,7 +2254,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">nc</td>
+                        <td property="skos:notation">nc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
                         <td>
@@ -2303,7 +2303,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">nn</td>
+                        <td property="skos:notation">nn</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
                         <td>
@@ -2361,7 +2361,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">op</td>
+                        <td property="skos:notation">op</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
                         <td>
@@ -2410,7 +2410,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">or</td>
+                        <td property="skos:notation">or</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
                         <td>
@@ -2459,7 +2459,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ov</td>
+                        <td property="skos:notation">ov</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
                         <td>
@@ -2508,7 +2508,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pg</td>
+                        <td property="skos:notation">pg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg">
                         <td>
@@ -2557,7 +2557,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pm</td>
+                        <td property="skos:notation">pm</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
                         <td>
@@ -2606,7 +2606,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">po</td>
+                        <td property="skos:notation">po</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
                         <td>
@@ -2655,7 +2655,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pp</td>
+                        <td property="skos:notation">pp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
                         <td>
@@ -2704,7 +2704,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pr</td>
+                        <td property="skos:notation">pr</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
                         <td>
@@ -2753,7 +2753,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ps</td>
+                        <td property="skos:notation">ps</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
                         <td>
@@ -2811,7 +2811,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pt</td>
+                        <td property="skos:notation">pt</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pt">
                         <td>
@@ -2860,7 +2860,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">pv</td>
+                        <td property="skos:notation">pv</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
                         <td>
@@ -2909,7 +2909,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">rc</td>
+                        <td property="skos:notation">rc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc">
                         <td>
@@ -2958,7 +2958,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">rd</td>
+                        <td property="skos:notation">rd</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
                         <td>
@@ -3007,7 +3007,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">rg</td>
+                        <td property="skos:notation">rg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rg">
                         <td>
@@ -3056,7 +3056,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ri</td>
+                        <td property="skos:notation">ri</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
                         <td>
@@ -3105,7 +3105,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">rp</td>
+                        <td property="skos:notation">rp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp">
                         <td>
@@ -3154,7 +3154,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">rq</td>
+                        <td property="skos:notation">rq</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq">
                         <td>
@@ -3203,7 +3203,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">sd</td>
+                        <td property="skos:notation">sd</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
                         <td>
@@ -3252,7 +3252,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">sg</td>
+                        <td property="skos:notation">sg</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
                         <td>
@@ -3301,7 +3301,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">sn</td>
+                        <td property="skos:notation">sn</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
                         <td>
@@ -3350,7 +3350,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">sp</td>
+                        <td property="skos:notation">sp</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
                         <td>
@@ -3399,7 +3399,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">st</td>
+                        <td property="skos:notation">st</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
                         <td>
@@ -3458,7 +3458,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">su</td>
+                        <td property="skos:notation">su</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
                         <td>
@@ -3507,7 +3507,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">sy</td>
+                        <td property="skos:notation">sy</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy">
                         <td>
@@ -3556,7 +3556,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">tc</td>
+                        <td property="skos:notation">tc</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
                         <td>
@@ -3605,7 +3605,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">tl</td>
+                        <td property="skos:notation">tl</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
                         <td>
@@ -3665,7 +3665,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">ts</td>
+                        <td property="skos:notation">ts</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
                         <td>
@@ -3714,7 +3714,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">uu</td>
+                        <td property="skos:notation">uu</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
                         <td>
@@ -3779,7 +3779,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">vi</td>
+                        <td property="skos:notation">vi</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
                         <td>
@@ -3828,7 +3828,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">vr</td>
+                        <td property="skos:notation">vr</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vr">
                         <td>
@@ -3877,7 +3877,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">wz</td>
+                        <td property="skos:notation">wz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
                         <td>
@@ -3937,7 +3937,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">za</td>
+                        <td property="skos:notation">za</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za">
                         <td>
@@ -3997,7 +3997,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">zz</td>
+                        <td property="skos:notation">zz</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
                         <td>
@@ -4021,40 +4021,422 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;suites&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Suites.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;su&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Not applicable&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;nn&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for any item that is a non-music sound recording.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;ballets&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Ballets.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bt&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;fantasias&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Fantasias.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes instrumental music designated as fantasia, fancies,
+            fantasies, etc.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;ft&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pt"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;hymns&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Hymns.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;hy&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;masses&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Masses.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ms&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;part-songs&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Part-songs.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pt&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;symphonies&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Symphonies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;sy&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;sy&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;musical revues and comedies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Musical revues and comedies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;preludes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Preludes.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pr&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;studies and exercises&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Studies and exercises.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used only when the work is intended for teaching purposes
+            (usually entitled Studies, Etudes, etc.).&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;st&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;requiems&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Requiems.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;rq&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;sonatas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Sonatas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;sn&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;suites&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Suites.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;su&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;ballads&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Ballads.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bd&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chant, Christian&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chant, Christian.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vr"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;variations&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Variations.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;vr&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;anthems&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Anthems.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;an&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;popular music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Popular music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pp&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;divertimentos, serenades, cassations, divertissements, and
+            notturni&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Divertimentos, serenades, cassations, divertissements, and
+            notturni.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for instrumental music designated as a divertimento,
+            serenade, cassation, divertissement, or a notturno.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;dv&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;marches&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Marches.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mr&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;flamenco&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Flamenco.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;fl&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;toccatas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Toccatas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;tc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;oratorios&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Oratorios.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;or&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rock music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Rock music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;rc&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;fugues&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Fugues.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;fg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;operas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Operas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;op&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bl"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;blues&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Blues.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bl&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;bluegrass music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Bluegrass music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;waltzes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Waltzes.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;wz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;madrigals&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Madrigals.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;md&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;canzonas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Canzonas.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for instrumental music that is designated as a canzona.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;cz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;villancicos&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Characteristic form of Spanish polyphony, religious or
+            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
+            important ceremonies (including Christmas, when these songs were sometimes called
+            "pastoradas").&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;vi&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chorale preludes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chorale preludes.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cl&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;carols&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Carols.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cr&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;motets&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Motets.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mo&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;country music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Country music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cy&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;concerti grossi&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Concerti grossi.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;minuets&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Minuets.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mi&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;polonaises&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Polonaises.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;po&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;songs&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Songs.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;sg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;program music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Program music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pg&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chorales&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chorales.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ch&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;symphonic poems&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Symphonic poems.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;sp&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;square dance music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Square dance music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;sd&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;cantatas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Cantatas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ct&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chansons, polyphonic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chansons, polyphonic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cp&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;multiple forms&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Multiple forms.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mu&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;ricercars&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Ricercars.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ri&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chance compositions&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chance compositions.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;cs&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;passacaglias&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Passacaglias.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ps&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes all types of ostinato basses.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;mazurkas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Mazurkas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Music: form of composition&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/18-19 values for music expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Indicates the form of composition.&lt;/dct:description&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music).&lt;/skos:scopeNote&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html"/&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Unknown.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;uu&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used when the only indication given is the number of
+            instruments and the medium of performance. No structure or genre is given, although they
+            may be implied or understood.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;trio-sonatas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Trio-sonatas.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ts&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;gospel music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Gospel music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;gm&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;zarzuelas&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Zarzuelas.&lt;/skos:definition&gt;
+    &lt;skos:definition xml:lang="en"&gt;Term applicable to all musical plays taking that name, from
+            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”
+            (“modern zarzuela”) from the mid 19th to the mid 20th-century.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;za&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rg"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;ragtime music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Ragtime music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;rg&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -4072,339 +4454,7 @@
             rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;zz&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;musical revues and comedies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Musical revues and comedies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;requiems&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Requiems.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;rq&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;concerti grossi&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Concerti grossi.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;jazz&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Jazz.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;jz&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rock music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Rock music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;rc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;program music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Program music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
-    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
-    &lt;dct:title xml:lang="en"&gt;Music: form of composition&lt;/dct:title&gt;
-    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/18-19 values for music expressed using RDF&lt;/dct:alternative&gt;
-    &lt;dct:description xml:lang="en"&gt;Indicates the form of composition.&lt;/dct:description&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music).&lt;/skos:scopeNote&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
-    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
-    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
-    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
-    &lt;dc:language&gt;en&lt;/dc:language&gt;
-    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html"/&gt;
-    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pt"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;part-songs&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Part-songs.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pt&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chorale preludes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chorale preludes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cl&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;operas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Operas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;op&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;villancicos&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Characteristic form of Spanish polyphony, religious or
-            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
-            important ceremonies (including Christmas, when these songs were sometimes called
-            "pastoradas").&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;vi&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;teatro lirico&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Spanish and Spanish American theatre music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;tl&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for a large number of more specific terms which describe
-            Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
-            "sainetes líricos", "entremeses cómico-lírico," etc.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;blues&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Blues.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bl&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chaconnes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chaconnes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ca&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;zarzuelas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Zarzuelas.&lt;/skos:definition&gt;
-    &lt;skos:definition xml:lang="en"&gt;Term applicable to all musical plays taking that name, from
-            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”
-            (“modern zarzuela”) from the mid 19th to the mid 20th-century.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;za&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;waltzes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Waltzes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;wz&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;divertimentos, serenades, cassations, divertissements, and
-            notturni&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Divertimentos, serenades, cassations, divertissements, and
-            notturni.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for instrumental music designated as a divertimento,
-            serenade, cassation, divertissement, or a notturno.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;dv&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;ricercars&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Ricercars.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ri&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;bluegrass music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Bluegrass music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;dance forms&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Dance forms.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;df&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes music for individual dances except for mazurkas,
-            minuets, pavans, polonaises, and waltzes.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;ragtime music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Ragtime music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;rg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;flamenco&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Flamenco.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;fl&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;ballads&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Ballads.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;bd&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;country music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Country music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cy&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;motets&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Motets.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mo&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;preludes&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Preludes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pr&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;carols&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Carols.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cr&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;marches&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Marches.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mr&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;passacaglias&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Passacaglias.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ps&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes all types of ostinato basses.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;concertos&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Concertos.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;co&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;studies and exercises&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Studies and exercises.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used only when the work is intended for teaching purposes
-            (usually entitled Studies, Etudes, etc.).&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;st&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;folk music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Folk music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;fm&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes folk songs, etc.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;popular music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Popular music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pp&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;overtures&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Overtures.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ov&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chant, Christian&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chant, Christian.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;toccatas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Toccatas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;tc&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rondos&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Rondos.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;rd&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;symphonic poems&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Symphonic poems.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;sp&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;fugues&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Fugues.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;fg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;square dance music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Square dance music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;sd&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;songs&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Songs.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;sg&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;motion picture music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Motion picture music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mp&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;zz&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -4412,182 +4462,132 @@
     &lt;skos:prefLabel xml:lang="en"&gt;canons and rounds&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Canons and rounds. Compositions employing strict imitation
             throughout.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cn&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;minuets&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Minuets.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mi&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rhapsodies&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Rhapsodies.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;rp&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;passion music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Passion music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pm&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Not applicable&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;nn&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for any item that is a non-music sound recording.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;sonatas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Sonatas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;sn&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;mazurkas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Mazurkas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mz&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;pavans&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Pavans.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;pv&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;cn&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;chants, other religions&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Chants, Other religions.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cb&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;anthems&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Anthems.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;an&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;uu&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used when the only indication given is the number of
-            instruments and the medium of performance. No structure or genre is given, although they
-            may be implied or understood.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vr"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;variations&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Variations.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;vr&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;gospel music&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Gospel music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;gm&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chorales&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chorales.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ch&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;cantatas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Cantatas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ct&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;madrigals&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Madrigals.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;md&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;canzonas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Canzonas.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for instrumental music that is designated as a canzona.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;cz&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;fantasias&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Fantasias.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes instrumental music designated as fantasia, fancies,
-            fantasies, etc.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;ft&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chance compositions&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chance compositions.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cs&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;polonaises&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Polonaises.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;po&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chansons, polyphonic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Chansons, polyphonic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;cp&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;oratorios&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Oratorios.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;or&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;trio-sonatas&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Trio-sonatas.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;ts&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;cb&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;nocturnes&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Nocturnes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;nc&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;nc&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;multiple forms&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Multiple forms.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;mu&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;teatro lirico&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Spanish and Spanish American theatre music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;tl&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for a large number of more specific terms which describe
+            Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
+            "sainetes líricos", "entremeses cómico-lírico," etc.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;passion music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Passion music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pm&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rondos&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Rondos.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;rd&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;hymns&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Hymns.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;hy&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;dance forms&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Dance forms.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;df&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes music for individual dances except for mazurkas,
+            minuets, pavans, polonaises, and waltzes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;ballets&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Ballets.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;bt&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;masses&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Masses.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ms&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;jazz&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Jazz.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;jz&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;overtures&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Overtures.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ov&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chaconnes&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Chaconnes.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;ca&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;pavans&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Pavans.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;pv&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;folk music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Folk music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;fm&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes folk songs, etc.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;concertos&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Concertos.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;co&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;motion picture music&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Motion picture music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;mp&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rhapsodies&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Rhapsodies.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;rp&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -4602,123 +4602,123 @@
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; a skos:Concept ;
     skos:definition "Anthems."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "an"@en ;
+    skos:notation "an" ;
     skos:prefLabel "anthems"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; a skos:Concept ;
     skos:definition "Ballads."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "bd"@en ;
+    skos:notation "bd" ;
     skos:prefLabel "ballads"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; a skos:Concept ;
     skos:definition "Bluegrass music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "bg"@en ;
+    skos:notation "bg" ;
     skos:prefLabel "bluegrass music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; a skos:Concept ;
     skos:definition "Blues."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "bl"@en ;
+    skos:notation "bl" ;
     skos:prefLabel "blues"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; a skos:Concept ;
     skos:definition "Ballets."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "bt"@en ;
+    skos:notation "bt" ;
     skos:prefLabel "ballets"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; a skos:Concept ;
     skos:definition "Chaconnes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ca"@en ;
+    skos:notation "ca" ;
     skos:prefLabel "chaconnes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; a skos:Concept ;
     skos:definition "Chants, Other religions."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cb"@en ;
+    skos:notation "cb" ;
     skos:prefLabel "chants, other religions"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; a skos:Concept ;
     skos:definition "Chant, Christian."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cc"@en ;
+    skos:notation "cc" ;
     skos:prefLabel "chant, Christian"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; a skos:Concept ;
     skos:definition "Concerti grossi."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cg"@en ;
+    skos:notation "cg" ;
     skos:prefLabel "concerti grossi"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; a skos:Concept ;
     skos:definition "Chorales."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ch"@en ;
+    skos:notation "ch" ;
     skos:prefLabel "chorales"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; a skos:Concept ;
     skos:definition "Chorale preludes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cl"@en ;
+    skos:notation "cl" ;
     skos:prefLabel "chorale preludes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; a skos:Concept ;
     skos:definition """Canons and rounds. Compositions employing strict imitation
             throughout."""@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cn"@en ;
+    skos:notation "cn" ;
     skos:prefLabel "canons and rounds"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; a skos:Concept ;
     skos:definition "Concertos."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "co"@en ;
+    skos:notation "co" ;
     skos:prefLabel "concertos"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; a skos:Concept ;
     skos:definition "Chansons, polyphonic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cp"@en ;
+    skos:notation "cp" ;
     skos:prefLabel "chansons, polyphonic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; a skos:Concept ;
     skos:definition "Carols."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cr"@en ;
+    skos:notation "cr" ;
     skos:prefLabel "carols"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; a skos:Concept ;
     skos:definition "Chance compositions."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cs"@en ;
+    skos:notation "cs" ;
     skos:prefLabel "chance compositions"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; a skos:Concept ;
     skos:definition "Cantatas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ct"@en ;
+    skos:notation "ct" ;
     skos:prefLabel "cantatas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; a skos:Concept ;
     skos:definition "Country music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cy"@en ;
+    skos:notation "cy" ;
     skos:prefLabel "country music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; a skos:Concept ;
     skos:definition "Canzonas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "cz"@en ;
+    skos:notation "cz" ;
     skos:prefLabel "canzonas"@en ;
     skos:scopeNote "Used for instrumental music that is designated as a canzona."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; a skos:Concept ;
     skos:definition "Dance forms."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "df"@en ;
+    skos:notation "df" ;
     skos:prefLabel "dance forms"@en ;
     skos:scopeNote """Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes."""@en .
@@ -4727,7 +4727,7 @@
     skos:definition """Divertimentos, serenades, cassations, divertissements, and
             notturni."""@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "dv"@en ;
+    skos:notation "dv" ;
     skos:prefLabel """divertimentos, serenades, cassations, divertissements, and
             notturni"""@en ;
     skos:scopeNote """Used for instrumental music designated as a divertimento,
@@ -4736,27 +4736,27 @@
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; a skos:Concept ;
     skos:definition "Fugues."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "fg"@en ;
+    skos:notation "fg" ;
     skos:prefLabel "fugues"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; a skos:Concept ;
     skos:definition "Flamenco."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "fl"@en ;
+    skos:notation "fl" ;
     skos:prefLabel "flamenco"@en ;
     skos:scopeNote "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; a skos:Concept ;
     skos:definition "Folk music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "fm"@en ;
+    skos:notation "fm" ;
     skos:prefLabel "folk music"@en ;
     skos:scopeNote "Includes folk songs, etc."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; a skos:Concept ;
     skos:definition "Fantasias."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ft"@en ;
+    skos:notation "ft" ;
     skos:prefLabel "fantasias"@en ;
     skos:scopeNote """Includes instrumental music designated as fantasia, fancies,
             fantasies, etc."""@en .
@@ -4764,219 +4764,219 @@
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; a skos:Concept ;
     skos:definition "Gospel music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "gm"@en ;
+    skos:notation "gm" ;
     skos:prefLabel "gospel music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; a skos:Concept ;
     skos:definition "Hymns."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "hy"@en ;
+    skos:notation "hy" ;
     skos:prefLabel "hymns"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; a skos:Concept ;
     skos:definition "Jazz."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "jz"@en ;
+    skos:notation "jz" ;
     skos:prefLabel "jazz"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; a skos:Concept ;
     skos:definition "Musical revues and comedies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mc"@en ;
+    skos:notation "mc" ;
     skos:prefLabel "musical revues and comedies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; a skos:Concept ;
     skos:definition "Madrigals."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "md"@en ;
+    skos:notation "md" ;
     skos:prefLabel "madrigals"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; a skos:Concept ;
     skos:definition "Minuets."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mi"@en ;
+    skos:notation "mi" ;
     skos:prefLabel "minuets"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; a skos:Concept ;
     skos:definition "Motets."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mo"@en ;
+    skos:notation "mo" ;
     skos:prefLabel "motets"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; a skos:Concept ;
     skos:definition "Motion picture music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mp"@en ;
+    skos:notation "mp" ;
     skos:prefLabel "motion picture music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; a skos:Concept ;
     skos:definition "Marches."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mr"@en ;
+    skos:notation "mr" ;
     skos:prefLabel "marches"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; a skos:Concept ;
     skos:definition "Masses."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ms"@en ;
+    skos:notation "ms" ;
     skos:prefLabel "masses"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; a skos:Concept ;
     skos:definition "Multiple forms."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mu"@en ;
+    skos:notation "mu" ;
     skos:prefLabel "multiple forms"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; a skos:Concept ;
     skos:definition "Mazurkas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "mz"@en ;
+    skos:notation "mz" ;
     skos:prefLabel "mazurkas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; a skos:Concept ;
     skos:definition "Nocturnes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "nc"@en ;
+    skos:notation "nc" ;
     skos:prefLabel "nocturnes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; a skos:Concept ;
     skos:definition "Not applicable"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "nn"@en ;
+    skos:notation "nn" ;
     skos:prefLabel "not applicable"@en ;
     skos:scopeNote "Used for any item that is a non-music sound recording."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; a skos:Concept ;
     skos:definition "Operas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "op"@en ;
+    skos:notation "op" ;
     skos:prefLabel "operas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; a skos:Concept ;
     skos:definition "Oratorios."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "or"@en ;
+    skos:notation "or" ;
     skos:prefLabel "oratorios"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; a skos:Concept ;
     skos:definition "Overtures."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ov"@en ;
+    skos:notation "ov" ;
     skos:prefLabel "overtures"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; a skos:Concept ;
     skos:definition "Program music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pg"@en ;
+    skos:notation "pg" ;
     skos:prefLabel "program music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; a skos:Concept ;
     skos:definition "Passion music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pm"@en ;
+    skos:notation "pm" ;
     skos:prefLabel "passion music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; a skos:Concept ;
     skos:definition "Polonaises."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "po"@en ;
+    skos:notation "po" ;
     skos:prefLabel "polonaises"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; a skos:Concept ;
     skos:definition "Popular music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pp"@en ;
+    skos:notation "pp" ;
     skos:prefLabel "popular music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; a skos:Concept ;
     skos:definition "Preludes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pr"@en ;
+    skos:notation "pr" ;
     skos:prefLabel "preludes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; a skos:Concept ;
     skos:definition "Passacaglias."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ps"@en ;
+    skos:notation "ps" ;
     skos:prefLabel "passacaglias"@en ;
     skos:scopeNote "Includes all types of ostinato basses."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; a skos:Concept ;
     skos:definition "Part-songs."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pt"@en ;
+    skos:notation "pt" ;
     skos:prefLabel "part-songs"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; a skos:Concept ;
     skos:definition "Pavans."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "pv"@en ;
+    skos:notation "pv" ;
     skos:prefLabel "pavans"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; a skos:Concept ;
     skos:definition "Rock music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "rc"@en ;
+    skos:notation "rc" ;
     skos:prefLabel "rock music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; a skos:Concept ;
     skos:definition "Rondos."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "rd"@en ;
+    skos:notation "rd" ;
     skos:prefLabel "rondos"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; a skos:Concept ;
     skos:definition "Ragtime music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "rg"@en ;
+    skos:notation "rg" ;
     skos:prefLabel "ragtime music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; a skos:Concept ;
     skos:definition "Ricercars."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ri"@en ;
+    skos:notation "ri" ;
     skos:prefLabel "ricercars"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; a skos:Concept ;
     skos:definition "Rhapsodies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "rp"@en ;
+    skos:notation "rp" ;
     skos:prefLabel "rhapsodies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; a skos:Concept ;
     skos:definition "Requiems."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "rq"@en ;
+    skos:notation "rq" ;
     skos:prefLabel "requiems"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; a skos:Concept ;
     skos:definition "Square dance music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "sd"@en ;
+    skos:notation "sd" ;
     skos:prefLabel "square dance music"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; a skos:Concept ;
     skos:definition "Songs."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "sg"@en ;
+    skos:notation "sg" ;
     skos:prefLabel "songs"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; a skos:Concept ;
     skos:definition "Sonatas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "sn"@en ;
+    skos:notation "sn" ;
     skos:prefLabel "sonatas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; a skos:Concept ;
     skos:definition "Symphonic poems."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "sp"@en ;
+    skos:notation "sp" ;
     skos:prefLabel "symphonic poems"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; a skos:Concept ;
     skos:definition "Studies and exercises."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "st"@en ;
+    skos:notation "st" ;
     skos:prefLabel "studies and exercises"@en ;
     skos:scopeNote """Used only when the work is intended for teaching purposes
             (usually entitled Studies, Etudes, etc.)."""@en .
@@ -4984,25 +4984,25 @@
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; a skos:Concept ;
     skos:definition "Suites."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "su"@en ;
+    skos:notation "su" ;
     skos:prefLabel "suites"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; a skos:Concept ;
     skos:definition "Symphonies."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "sy"@en ;
+    skos:notation "sy" ;
     skos:prefLabel "symphonies"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; a skos:Concept ;
     skos:definition "Toccatas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "tc"@en ;
+    skos:notation "tc" ;
     skos:prefLabel "toccatas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; a skos:Concept ;
     skos:definition "Spanish and Spanish American theatre music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "tl"@en ;
+    skos:notation "tl" ;
     skos:prefLabel "teatro lirico"@en ;
     skos:scopeNote """Used for a large number of more specific terms which describe
             Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
@@ -5011,13 +5011,13 @@
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; a skos:Concept ;
     skos:definition "Trio-sonatas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "ts"@en ;
+    skos:notation "ts" ;
     skos:prefLabel "trio-sonatas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; a skos:Concept ;
     skos:definition "Unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "uu"@en ;
+    skos:notation "uu" ;
     skos:prefLabel "unknown"@en ;
     skos:scopeNote """Used when the only indication given is the number of
             instruments and the medium of performance. No structure or genre is given, although they
@@ -5029,19 +5029,19 @@
             important ceremonies (including Christmas, when these songs were sometimes called
             "pastoradas")."""@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "vi"@en ;
+    skos:notation "vi" ;
     skos:prefLabel "villancicos"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; a skos:Concept ;
     skos:definition "Variations."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "vr"@en ;
+    skos:notation "vr" ;
     skos:prefLabel "variations"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; a skos:Concept ;
     skos:definition "Waltzes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "wz"@en ;
+    skos:notation "wz" ;
     skos:prefLabel "waltzes"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; a skos:Concept ;
@@ -5050,7 +5050,7 @@
             (“modern zarzuela”) from the mid 19th to the mid 20th-century."""@en,
         "Zarzuelas."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "za"@en ;
+    skos:notation "za" ;
     skos:prefLabel "zarzuelas"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; a skos:Concept ;
@@ -5067,7 +5067,7 @@
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."""@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; ;
-    skos:notation "zz"@en ;
+    skos:notation "zz" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; a skos:ConceptScheme ;
@@ -5084,429 +5084,429 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: form of composition"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
     skos:scopeNote "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Hymns."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "symphonies"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Musical revues and comedies."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rq"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Concerti grossi."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "jazz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: form of composition"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for any item that is a non-music sound recording."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cl"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rc"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Operas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Spanish and Spanish American theatre music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "suites"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chaconnes"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "za"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "waltzes"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Divertimentos, serenades, cassations, divertissements, and\n            notturni."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "df"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "flamenco"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pr"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mo"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "divertimentos, serenades, cassations, divertissements, and\n            notturni"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "marches"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes all types of ostinato basses."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "co"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ricercars"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Folk music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "popular music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "overtures"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dance forms"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "zz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Toccatas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Zarzuelas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "country music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rondos."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pp"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Symphonic poems."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Square dance music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rock music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "songs"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ragtime music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Blues."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Canons and rounds. Compositions employing strict imitation\n            throughout."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mr"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rp"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "vi"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chorale preludes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Requiems."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ov"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "minuets"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ballets"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sonatas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "zarzuelas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pt"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cy"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mc"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ri"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "requiems"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "concertos"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rhapsodies"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mazurkas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-19 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pavans"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fl"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bluegrass music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Symphonies."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sonatas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pr" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Suites."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ballads"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chant, Christian"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "st" .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Anthems."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chaconnes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "toccatas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Preludes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rhapsodies."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ca"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pm"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Studies and exercises."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "part-songs"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dv"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorale preludes"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "an"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "canons and rounds"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motion picture music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Flamenco."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Madrigals."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "op"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rd"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pp" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Marches."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Motets."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Flamenco."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "toccatas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Oratorios."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "oratorios"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Operas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "blues"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Toccatas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "wz" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "madrigals"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for instrumental music that is designated as a canzona."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "dv" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "vi" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fantasias."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "operas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cr" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "country music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Musical revues and comedies."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mi" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polonaises"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cc" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Program music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorales"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motets"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "symphonies"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Symphonic poems."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ballads."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Requiems."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "square dance music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Bluegrass music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cantatas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Minuets."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple forms"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ricercars"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Passacaglias."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mazurkas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "po" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: form of composition"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bl" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cantatas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Songs."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Trio-sonatas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gospel music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cz" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ragtime music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Canzonas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cn" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chorales."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "md" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sd" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "tl" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "passion music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Multiple forms."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Term applicable to all musical plays taking that name, from\n            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”\n            (“modern zarzuela”) from the mid 19th to the mid 20th-century."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rondos"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hymns"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "dance forms"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chants, other religions"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mz" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rock music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bt" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mo" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cl" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "masses"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "jazz"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "zarzuelas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Concerti grossi."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for instrumental music designated as a divertimento,\n            serenade, cassation, divertissement, or a notturno."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ca" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ballets"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "anthems"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "suites"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "folk music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "concertos"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "studies and exercises"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chansons, polyphonic."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Motion picture music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "preludes"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Masses."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chaconnes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pm" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "co" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ov" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes folk songs, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Passion music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Part-songs."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Carols."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "overtures"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rhapsodies."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chansons, polyphonic"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes all types of ostinato basses."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cy" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chant, Christian."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Concertos."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "variations"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fm" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "flamenco"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "op" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chance compositions"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ricercars."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ri" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mazurkas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pavans"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "concerti grossi"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chants, Other religions."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bluegrass music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nocturnes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rock music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Blues."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a large number of more specific terms which describe\n            Spanish and Spanish American theatre music: \"tonadilla escénica\", \"fiestas de música\",\n            \"sainetes líricos\", \"entremeses cómico-lírico,\" etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rhapsodies"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "su" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pt" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fantasias"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "symphonic poems"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ragtime music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mr" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polonaises."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Waltzes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Pavans."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cp" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "trio-sonatas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "zz" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rp" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Preludes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dance forms."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "gospel music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ct" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mc" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Variations."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Country music."@en .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "md"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "canzonas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "symphonic poems"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Songs."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "su"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "gospel music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "bluegrass music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ballets."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Minuets."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "carols"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bl"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "po"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chant, Christian"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cp"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "studies and exercises"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sp"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "teatro lirico"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Dance forms."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rock music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "folk music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "oratorios"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fugues."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Canzonas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Jazz."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Trio-sonatas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "gm"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "ballads"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fg"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "jz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "vr"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motets"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chants, Other religions."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cn"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "passion music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "nocturnes"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#op&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "operas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fm"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cc"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ch"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for instrumental music designated as a divertimento,\n            serenade, cassation, divertissement, or a notturno."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bt"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for a large number of more specific terms which describe\n            Spanish and Spanish American theatre music: \"tonadilla escénica\", \"fiestas de música\",\n            \"sainetes líricos\", \"entremeses cómico-lírico,\" etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ft"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "minuets"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motion picture music"@en .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Masses."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Term applicable to all musical plays taking that name, from\n            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”\n            (“modern zarzuela”) from the mid 19th to the mid 20th-century."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sonatas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "or"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chansons, polyphonic"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chance compositions"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rondos"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ragtime music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cb"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cr"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "nn"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "trio-sonatas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Multiple forms."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sy"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "madrigals"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fantasias."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pv"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Variations."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chansons, polyphonic."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cantatas."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fugues"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "nc"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Suites."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ms"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chant, Christian."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "variations"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "uu"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "teatro lirico"@en .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "musical revues and comedies"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Carols."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "hymns"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorales"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "square dance music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "masses"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "concerti grossi"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ts"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for any item that is a non-music sound recording."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cs"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Passacaglias."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mu"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fantasias"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Overtures."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Motion picture music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sd"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "tc"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sn"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ct"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Oratorios."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Concertos."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "blues"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "hy"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chants, other religions"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the form of composition."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "st"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Gospel music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Symphonies."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "passacaglias"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Program music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mp"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bd"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chorales."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "cantatas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chance compositions."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Passion music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "tl"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Zarzuelas."@en .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "villancicos"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "anthems"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Popular music."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "wz"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "program music"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes folk songs, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Nocturnes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ps"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for instrumental music that is designated as a canzona."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "preludes"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mi&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mi"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Part-songs."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Waltzes."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Pavans."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "polonaises"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ricercars."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#po&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Polonaises."@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "mazurkas"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple forms"@en .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ballads."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "carols"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the form of composition."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rc" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sy" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ms&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ms" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "fl" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ps" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bd" .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sn" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chance compositions."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "or" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#za&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "za" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Spanish and Spanish American theatre music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mp" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ts" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "divertimentos, serenades, cassations, divertissements, and\n            notturni"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rd" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Canons and rounds. Compositions employing strict imitation\n            throughout."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#st&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Studies and exercises."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "bg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ct&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#an&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "an" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#df&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "df" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#co&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cy&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sonatas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sp&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "sp" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fm&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Folk music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "hy" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#or&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sy&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Ballets."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Chorale preludes."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cl&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorale preludes"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rg&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rg" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#md&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Madrigals."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cc&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mz&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bt&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vi&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "songs"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ps&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "passacaglias"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "nocturnes"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "mu" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pr&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "canzonas"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ts&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mr&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "marches"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fugues."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bl&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#wz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "waltzes"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#tc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "tc" .
 &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fl&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "jz" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#su&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "gm" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#jz&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Jazz."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "popular music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nc&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "nc" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#hy&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Hymns."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ov&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Overtures."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#uu&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "uu" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "program music"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Square dance music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pp&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Popular music."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#dv&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Divertimentos, serenades, cassations, divertissements, and\n            notturni."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pv&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "pv" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ft" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cn&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "canons and rounds"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sn&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cb&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cb" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ft&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rp&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "requiems"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#nn&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "nn" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#fg&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fugues"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#zz&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#vr&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "vr" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "rq" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rd&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Rondos."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cs&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "cs" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/18-19 values for music expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#pt&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "part-songs"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#sg&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ca&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chaconnes"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ri&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#gm&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#ch&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "ch" .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#cp&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#rq&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mo&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Motets."@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#mc&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "musical revues and comedies"@en .
+&lt;https://doi.org/10.6069/uwlswd.8rpj-ek77#bg&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.8rpj-ek77&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pv",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Pavans."
+        "@value": "Mazurkas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -5516,26 +5516,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "pv"
+        "@value": "mz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "pavans"
+        "@value": "mazurkas"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#uu",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ms",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Unknown."
+        "@value": "Masses."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -5545,20 +5544,911 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "uu"
+        "@value": "ms"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown"
+        "@value": "masses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ri",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ricercars."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ri"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ricercars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cr",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Carols."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cr"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "carols"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#or",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Oratorios."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "or"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "oratorios"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ft",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Fantasias."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ft"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "fantasias"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."
+        "@value": "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Country music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "country music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cn",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Canons and rounds. Compositions employing strict imitation\n            throughout."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "canons and rounds"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ct",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cantatas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ct"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cantatas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#an",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Anthems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "an"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "anthems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mr",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Marches."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mr"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "marches"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#gm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gospel music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "gm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "gospel music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#df",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dance forms."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "df"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dance forms"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Passion music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "passion music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Blues."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "blues"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Concerti grossi."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "concerti grossi"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rq",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Requiems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rq"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "requiems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#op",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Operas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "op"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "operas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#zz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "zz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rondos."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rondos"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Folk music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "fm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "folk music"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes folk songs, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#co",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Concertos."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "co"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "concertos"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Motion picture music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motion picture music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#wz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Waltzes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "wz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "waltzes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Symphonies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "symphonies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mo",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Motets."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motets"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chants, Other religions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chants, other religions"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#su",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Suites."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "su"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "suites"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Songs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "songs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Musical revues and comedies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "musical revues and comedies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Canzonas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "canzonas"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for instrumental music that is designated as a canzona."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ps",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Passacaglias."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ps"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "passacaglias"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes all types of ostinato basses."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#hy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Hymns."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "hy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "hymns"
       }
     ]
   },
@@ -5631,7 +6521,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -5666,24 +6556,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vi",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rp",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."
+        "@value": "Rhapsodies."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -5693,130 +6584,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "vi"
+        "@value": "rp"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "villancicos"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#md",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Madrigals."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "md"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "madrigals"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ca",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chaconnes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chaconnes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mazurkas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "mazurkas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chant, Christian."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chant, Christian"
+        "@value": "rhapsodies"
       }
     ]
   },
@@ -5838,7 +6612,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "fg"
       }
     ],
@@ -5850,14 +6623,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#or",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pv",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Oratorios."
+        "@value": "Pavans."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -5867,600 +6640,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "or"
+        "@value": "pv"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "oratorios"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#jz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Jazz."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "jz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "jazz"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#zz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "zz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ct",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cantatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ct"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cantatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nocturnes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "nc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "nocturnes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chants, Other religions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chants, other religions"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Marches."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "marches"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#su",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Suites."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "su"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "suites"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Passion music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "passion music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#gm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gospel music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "gm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "gospel music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rondos."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rondos"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ri",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ricercars."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ri"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ricercars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Variations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "vr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "variations"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bluegrass music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bluegrass music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rq",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Requiems."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rq"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "requiems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ragtime music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ragtime music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Folk music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "fm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "folk music"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes folk songs, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#hy",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Hymns."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "hy"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "hymns"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#wz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Waltzes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "wz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "waltzes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#op",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Operas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "op"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "operas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Musical revues and comedies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "musical revues and comedies"
+        "@value": "pavans"
       }
     ]
   },
@@ -6482,7 +6668,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "tl"
       }
     ],
@@ -6500,14 +6685,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bd",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sn",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Ballads."
+        "@value": "Sonatas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6517,136 +6702,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bd"
+        "@value": "sn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "ballads"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Canons and rounds. Compositions employing strict imitation\n            throughout."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "canons and rounds"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ft",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Fantasias."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ft"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fantasias"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ms",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Masses."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ms"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "masses"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#po",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Polonaises."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "po"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "polonaises"
+        "@value": "sonatas"
       }
     ]
   },
@@ -6668,7 +6730,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "st"
       }
     ],
@@ -6682,163 +6743,6 @@
       {
         "@language": "en",
         "@value": "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ov",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Overtures."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ov"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "overtures"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Flamenco."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "fl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "flamenco"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Canzonas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "canzonas"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for instrumental music that is designated as a canzona."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cs",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chance compositions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chance compositions"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Blues."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "blues"
       }
     ]
   },
@@ -6860,7 +6764,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ch"
       }
     ],
@@ -6872,14 +6775,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pr",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vr",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Preludes."
+        "@value": "Variations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6889,26 +6792,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "pr"
+        "@value": "vr"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "preludes"
+        "@value": "variations"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#co",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#jz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Concertos."
+        "@value": "Jazz."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6918,14 +6820,327 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "co"
+        "@value": "jz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "concertos"
+        "@value": "jazz"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nocturnes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "nc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "nocturnes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nn",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not applicable"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "nn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for any item that is a non-music sound recording."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ballads."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ballads"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bluegrass music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bluegrass music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cs",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chance compositions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chance compositions"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Symphonic poems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "symphonic poems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chant, Christian."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chant, Christian"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rock music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rock music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ragtime music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ragtime music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ca",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chaconnes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ca"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chaconnes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vi",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "vi"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "villancicos"
       }
     ]
   },
@@ -6947,7 +7162,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "cp"
       }
     ],
@@ -6959,14 +7173,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ps",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ov",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Passacaglias."
+        "@value": "Overtures."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -6976,32 +7190,143 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "ps"
+        "@value": "ov"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "passacaglias"
+        "@value": "overtures"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#po",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Polonaises."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "po"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "polonaises"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chorale preludes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chorale preludes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pt",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Part-songs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pt"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "part-songs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#uu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "uu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Includes all types of ostinato basses."
+        "@value": "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sy",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#md",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Symphonies."
+        "@value": "Madrigals."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -7011,14 +7336,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "sy"
+        "@value": "md"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "symphonies"
+        "@value": "madrigals"
       }
     ]
   },
@@ -7040,7 +7364,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "mi"
       }
     ],
@@ -7048,93 +7371,6 @@
       {
         "@language": "en",
         "@value": "minuets"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Concerti grossi."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "concerti grossi"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Square dance music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "square dance music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Motion picture music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motion picture music"
       }
     ]
   },
@@ -7156,7 +7392,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "pp"
       }
     ],
@@ -7168,14 +7403,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cy",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#tc",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Country music."
+        "@value": "Toccatas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -7185,14 +7420,103 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "cy"
+        "@value": "tc"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "country music"
+        "@value": "toccatas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Program music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "program music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Square dance music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "square dance music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Flamenco."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "fl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "flamenco"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."
       }
     ]
   },
@@ -7218,7 +7542,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "za"
       }
     ],
@@ -7230,14 +7553,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cl",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mu",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Chorale preludes."
+        "@value": "Multiple forms."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -7247,26 +7570,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "cl"
+        "@value": "mu"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "chorale preludes"
+        "@value": "multiple forms"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sp",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pr",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Symphonic poems."
+        "@value": "Preludes."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -7276,281 +7598,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "sp"
+        "@value": "pr"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "symphonic poems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#tc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Toccatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "tc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "toccatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mo",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Motets."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motets"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rhapsodies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rhapsodies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Carols."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "carols"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not applicable"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "nn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for any item that is a non-music sound recording."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#an",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Anthems."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "an"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "anthems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Songs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "songs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sonatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sonatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Program music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "program music"
+        "@value": "preludes"
       }
     ]
   },
@@ -7572,7 +7626,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dv"
       }
     ],
@@ -7607,7 +7660,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "bt"
       }
     ],
@@ -7636,7 +7688,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ts"
       }
     ],
@@ -7644,128 +7695,6 @@
       {
         "@language": "en",
         "@value": "trio-sonatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rock music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rock music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pt",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Part-songs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pt"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "part-songs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#df",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dance forms."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "df"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dance forms"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Multiple forms."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "multiple forms"
       }
     ]
   }

--- a/008/music_form_of_composition/music_form_of_composition.jsonld
+++ b/008/music_form_of_composition/music_form_of_composition.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pv",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Pavans."
+        "@value": "Mazurkas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,26 +17,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "pv"
+        "@value": "mz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "pavans"
+        "@value": "mazurkas"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#uu",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ms",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Unknown."
+        "@value": "Masses."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -46,20 +45,911 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "uu"
+        "@value": "ms"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown"
+        "@value": "masses"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ri",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ricercars."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ri"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ricercars"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cr",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Carols."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cr"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "carols"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#or",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Oratorios."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "or"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "oratorios"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ft",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Fantasias."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ft"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "fantasias"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."
+        "@value": "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Country music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "country music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cn",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Canons and rounds. Compositions employing strict imitation\n            throughout."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "canons and rounds"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ct",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Cantatas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ct"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "cantatas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#an",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Anthems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "an"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "anthems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mr",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Marches."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mr"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "marches"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#gm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Gospel music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "gm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "gospel music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#df",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Dance forms."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "df"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "dance forms"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Passion music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "passion music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Blues."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "blues"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Concerti grossi."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "concerti grossi"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rq",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Requiems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rq"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "requiems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#op",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Operas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "op"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "operas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#zz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "zz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rondos."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rondos"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fm",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Folk music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "fm"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "folk music"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes folk songs, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#co",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Concertos."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "co"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "concertos"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Motion picture music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motion picture music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#wz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Waltzes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "wz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "waltzes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Symphonies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "symphonies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mo",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Motets."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mo"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motets"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cb",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chants, Other religions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cb"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chants, other religions"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#su",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Suites."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "su"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "suites"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Songs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "songs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Musical revues and comedies."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "mc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "musical revues and comedies"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cz",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Canzonas."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cz"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "canzonas"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for instrumental music that is designated as a canzona."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ps",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Passacaglias."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ps"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "passacaglias"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes all types of ostinato basses."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#hy",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Hymns."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "hy"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "hymns"
       }
     ]
   },
@@ -132,7 +1022,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -167,24 +1057,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vi",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rp",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."
+        "@value": "Rhapsodies."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -194,130 +1085,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "vi"
+        "@value": "rp"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "villancicos"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#md",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Madrigals."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "md"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "madrigals"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ca",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chaconnes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ca"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chaconnes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mazurkas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "mazurkas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chant, Christian."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chant, Christian"
+        "@value": "rhapsodies"
       }
     ]
   },
@@ -339,7 +1113,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "fg"
       }
     ],
@@ -351,14 +1124,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#or",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pv",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Oratorios."
+        "@value": "Pavans."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -368,600 +1141,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "or"
+        "@value": "pv"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "oratorios"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#jz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Jazz."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "jz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "jazz"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#zz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "zz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ct",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Cantatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ct"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "cantatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Nocturnes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "nc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "nocturnes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cb",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chants, Other religions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cb"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chants, other religions"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Marches."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "marches"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#su",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Suites."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "su"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "suites"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Passion music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "passion music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#gm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Gospel music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "gm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "gospel music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rondos."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rondos"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ri",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ricercars."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ri"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ricercars"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Variations."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "vr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "variations"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Bluegrass music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "bluegrass music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rq",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Requiems."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rq"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "requiems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Ragtime music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "ragtime music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fm",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Folk music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "fm"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "folk music"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes folk songs, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#hy",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Hymns."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "hy"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "hymns"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#wz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Waltzes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "wz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "waltzes"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#op",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Operas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "op"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "operas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Musical revues and comedies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "musical revues and comedies"
+        "@value": "pavans"
       }
     ]
   },
@@ -983,7 +1169,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "tl"
       }
     ],
@@ -1001,14 +1186,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bd",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sn",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Ballads."
+        "@value": "Sonatas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1018,136 +1203,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "bd"
+        "@value": "sn"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "ballads"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Canons and rounds. Compositions employing strict imitation\n            throughout."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "canons and rounds"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ft",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Fantasias."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ft"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fantasias"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ms",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Masses."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ms"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "masses"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#po",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Polonaises."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "po"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "polonaises"
+        "@value": "sonatas"
       }
     ]
   },
@@ -1169,7 +1231,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "st"
       }
     ],
@@ -1183,163 +1244,6 @@
       {
         "@language": "en",
         "@value": "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ov",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Overtures."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "ov"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "overtures"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Flamenco."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "fl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "flamenco"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cz",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Canzonas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cz"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "canzonas"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for instrumental music that is designated as a canzona."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cs",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Chance compositions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cs"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chance compositions"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bl",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Blues."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "bl"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "blues"
       }
     ]
   },
@@ -1361,7 +1265,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ch"
       }
     ],
@@ -1373,14 +1276,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pr",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vr",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Preludes."
+        "@value": "Variations."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1390,26 +1293,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "pr"
+        "@value": "vr"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "preludes"
+        "@value": "variations"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#co",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#jz",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Concertos."
+        "@value": "Jazz."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1419,14 +1321,327 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "co"
+        "@value": "jz"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "concertos"
+        "@value": "jazz"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Nocturnes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "nc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "nocturnes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nn",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not applicable"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "nn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for any item that is a non-music sound recording."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ballads."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ballads"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#bg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Bluegrass music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "bg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "bluegrass music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cs",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chance compositions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cs"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chance compositions"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sp",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Symphonic poems."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sp"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "symphonic poems"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chant, Christian."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chant, Christian"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rc",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Rock music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rc"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rock music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Ragtime music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "rg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "ragtime music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ca",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chaconnes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "ca"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chaconnes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#vi",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "vi"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "villancicos"
       }
     ]
   },
@@ -1448,7 +1663,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "cp"
       }
     ],
@@ -1460,14 +1674,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ps",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#ov",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Passacaglias."
+        "@value": "Overtures."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1477,32 +1691,143 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "ps"
+        "@value": "ov"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "passacaglias"
+        "@value": "overtures"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#po",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Polonaises."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "po"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "polonaises"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Chorale preludes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "cl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chorale preludes"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pt",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Part-songs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pt"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "part-songs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#uu",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "uu"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#scopeNote": [
       {
         "@language": "en",
-        "@value": "Includes all types of ostinato basses."
+        "@value": "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sy",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#md",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Symphonies."
+        "@value": "Madrigals."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1512,14 +1837,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "sy"
+        "@value": "md"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "symphonies"
+        "@value": "madrigals"
       }
     ]
   },
@@ -1541,7 +1865,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "mi"
       }
     ],
@@ -1549,93 +1872,6 @@
       {
         "@language": "en",
         "@value": "minuets"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Concerti grossi."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "concerti grossi"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sd",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Square dance music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sd"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "square dance music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Motion picture music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motion picture music"
       }
     ]
   },
@@ -1657,7 +1893,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "pp"
       }
     ],
@@ -1669,14 +1904,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cy",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#tc",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Country music."
+        "@value": "Toccatas."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1686,14 +1921,103 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "cy"
+        "@value": "tc"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "country music"
+        "@value": "toccatas"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pg",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Program music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "pg"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "program music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sd",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Square dance music."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "sd"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "square dance music"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#fl",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Flamenco."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "fl"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "flamenco"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."
       }
     ]
   },
@@ -1719,7 +2043,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "za"
       }
     ],
@@ -1731,14 +2054,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cl",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mu",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Chorale preludes."
+        "@value": "Multiple forms."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1748,26 +2071,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "cl"
+        "@value": "mu"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "chorale preludes"
+        "@value": "multiple forms"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sp",
+    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pr",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Symphonic poems."
+        "@value": "Preludes."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1777,281 +2099,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "sp"
+        "@value": "pr"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "symphonic poems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#tc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Toccatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "tc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "toccatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mo",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Motets."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mo"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motets"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rp",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rhapsodies."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rp"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rhapsodies"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#cr",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Carols."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "cr"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "carols"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#nn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not applicable"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "nn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for any item that is a non-music sound recording."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#an",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Anthems."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "an"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "anthems"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Songs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "songs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#sn",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sonatas."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "sn"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sonatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pg",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Program music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pg"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "program music"
+        "@value": "preludes"
       }
     ]
   },
@@ -2073,7 +2127,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "dv"
       }
     ],
@@ -2108,7 +2161,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "bt"
       }
     ],
@@ -2137,7 +2189,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "ts"
       }
     ],
@@ -2145,128 +2196,6 @@
       {
         "@language": "en",
         "@value": "trio-sonatas"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#rc",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Rock music."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "rc"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rock music"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#pt",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Part-songs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "pt"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "part-songs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#df",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Dance forms."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "df"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "dance forms"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77#mu",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Multiple forms."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.8rpj-ek77"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "mu"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "multiple forms"
       }
     ]
   }

--- a/008/music_form_of_composition/music_form_of_composition.nt
+++ b/008/music_form_of_composition/music_form_of_composition.nt
@@ -1,395 +1,395 @@
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#definition> "Hymns."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#prefLabel> "symphonies"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#definition> "Musical revues and comedies."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#notation> "rq"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#definition> "Concerti grossi."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#prefLabel> "jazz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/title> "Music: form of composition"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for any item that is a non-music sound recording."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#notation> "cl"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#notation> "rc"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#notation> "pg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#definition> "Operas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#definition> "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#definition> "Spanish and Spanish American theatre music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#prefLabel> "suites"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#prefLabel> "chaconnes"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#notation> "za"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#prefLabel> "waltzes"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#definition> "Divertimentos, serenades, cassations, divertissements, and\n            notturni."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#notation> "bg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#notation> "df"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#notation> "rg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#prefLabel> "flamenco"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#notation> "pr"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#notation> "mo"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#prefLabel> "divertimentos, serenades, cassations, divertissements, and\n            notturni"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#prefLabel> "marches"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes all types of ostinato basses."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#notation> "co"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#prefLabel> "ricercars"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#definition> "Folk music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#prefLabel> "popular music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#prefLabel> "overtures"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#prefLabel> "dance forms"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#notation> "zz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#definition> "Toccatas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#definition> "Zarzuelas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#prefLabel> "country music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#definition> "Rondos."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#notation> "pp"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#definition> "Symphonic poems."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#definition> "Square dance music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#definition> "Rock music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#prefLabel> "songs"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#prefLabel> "ragtime music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#definition> "Blues."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#definition> "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#definition> "Canons and rounds. Compositions employing strict imitation\n            throughout."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#notation> "mr"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#notation> "rp"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#notation> "vi"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#definition> "Chorale preludes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#definition> "Requiems."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#notation> "cg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#notation> "ov"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#prefLabel> "minuets"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#prefLabel> "ballets"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#prefLabel> "sonatas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#prefLabel> "zarzuelas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#notation> "pt"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#notation> "cy"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#notation> "mc"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#notation> "ri"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#prefLabel> "requiems"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#prefLabel> "concertos"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#prefLabel> "rhapsodies"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#definition> "Mazurkas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/alternative> "MARC21 008/18-19 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#prefLabel> "pavans"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#notation> "fl"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#definition> "Bluegrass music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#definition> "Symphonies."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#definition> "Sonatas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#notation> "pr" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#definition> "Suites."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#prefLabel> "ballads"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#prefLabel> "chant, Christian"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#notation> "st" .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#definition> "Anthems."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#definition> "Chaconnes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#prefLabel> "toccatas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#definition> "Preludes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#definition> "Rhapsodies."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#notation> "ca"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#notation> "pm"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#definition> "Studies and exercises."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#prefLabel> "part-songs"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#notation> "dv"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorale preludes"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#definition> "Unknown."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#notation> "an"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#prefLabel> "canons and rounds"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#prefLabel> "motion picture music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#definition> "Flamenco."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#definition> "Madrigals."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#notation> "op"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#notation> "sg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#notation> "rd"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#notation> "pp" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#definition> "Marches."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#definition> "Motets."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#definition> "Flamenco."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#prefLabel> "toccatas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#definition> "Oratorios."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#prefLabel> "oratorios"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#definition> "Operas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#prefLabel> "blues"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#definition> "Toccatas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#notation> "wz" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#prefLabel> "madrigals"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for instrumental music that is designated as a canzona."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#notation> "dv" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#notation> "vi" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#definition> "Fantasias."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#prefLabel> "operas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#notation> "cr" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#prefLabel> "country music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#definition> "Musical revues and comedies."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#notation> "mi" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#prefLabel> "polonaises"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#notation> "sg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#notation> "cc" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#definition> "Program music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorales"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#prefLabel> "motets"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#prefLabel> "symphonies"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#definition> "Symphonic poems."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#notation> "cg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#definition> "Ballads."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#definition> "Requiems."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#prefLabel> "square dance music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#definition> "Bluegrass music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#prefLabel> "cantatas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#definition> "Minuets."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple forms"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#prefLabel> "ricercars"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#definition> "Passacaglias."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#definition> "Mazurkas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#notation> "po" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/title> "Music: form of composition"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#notation> "bl" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#definition> "Unknown."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#definition> "Cantatas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#definition> "Songs."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#definition> "Trio-sonatas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#definition> "Characteristic form of Spanish polyphony, religious or\n            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in\n            important ceremonies (including Christmas, when these songs were sometimes called\n            \"pastoradas\")."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#definition> "Gospel music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#notation> "cz" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#definition> "Ragtime music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#definition> "Canzonas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#notation> "cn" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#definition> "Chorales."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#notation> "md" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#notation> "sd" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#notation> "tl" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#prefLabel> "passion music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#definition> "Multiple forms."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#notation> "fg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#definition> "Term applicable to all musical plays taking that name, from\n            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”\n            (“modern zarzuela”) from the mid 19th to the mid 20th-century."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#prefLabel> "rondos"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#prefLabel> "hymns"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#prefLabel> "dance forms"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#prefLabel> "chants, other religions"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#notation> "mz" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#definition> "Rock music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#notation> "bt" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#notation> "mo" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#scopeNote> "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#notation> "cl" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#prefLabel> "masses"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#prefLabel> "jazz"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#prefLabel> "zarzuelas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#definition> "Concerti grossi."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for instrumental music designated as a divertimento,\n            serenade, cassation, divertissement, or a notturno."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#notation> "ca" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#prefLabel> "ballets"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#prefLabel> "anthems"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#prefLabel> "suites"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#prefLabel> "folk music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#prefLabel> "concertos"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#prefLabel> "studies and exercises"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#definition> "Chansons, polyphonic."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#definition> "Motion picture music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#prefLabel> "preludes"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#definition> "Masses."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#definition> "Chaconnes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#notation> "pm" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#notation> "co" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#notation> "ov" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes folk songs, etc."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#definition> "Passion music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#definition> "Part-songs."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#definition> "Carols."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#prefLabel> "overtures"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#definition> "Rhapsodies."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#prefLabel> "chansons, polyphonic"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes all types of ostinato basses."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#notation> "cy" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#definition> "Chant, Christian."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#definition> "Concertos."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#prefLabel> "variations"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#notation> "fm" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#prefLabel> "flamenco"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#notation> "op" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#prefLabel> "chance compositions"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#definition> "Ricercars."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#notation> "ri" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#prefLabel> "mazurkas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#prefLabel> "pavans"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#prefLabel> "concerti grossi"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#definition> "Chants, Other religions."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#prefLabel> "bluegrass music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#definition> "Nocturnes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#prefLabel> "rock music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#definition> "Blues."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a large number of more specific terms which describe\n            Spanish and Spanish American theatre music: \"tonadilla escénica\", \"fiestas de música\",\n            \"sainetes líricos\", \"entremeses cómico-lírico,\" etc."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#prefLabel> "rhapsodies"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#notation> "su" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#notation> "pt" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#prefLabel> "fantasias"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#prefLabel> "symphonic poems"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used when the only indication given is the number of\n            instruments and the medium of performance. No structure or genre is given, although they\n            may be implied or understood."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#prefLabel> "ragtime music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#notation> "mr" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#definition> "Polonaises."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#definition> "Waltzes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#definition> "Pavans."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#notation> "cp" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#prefLabel> "trio-sonatas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#notation> "zz" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#notation> "rp" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#definition> "Preludes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#definition> "Dance forms."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#prefLabel> "gospel music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#definition> "Not applicable"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#notation> "ct" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#notation> "mc" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#definition> "Variations."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/2004/02/skos/core#definition> "Country music."@en .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#notation> "md"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#prefLabel> "canzonas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#prefLabel> "symphonic poems"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#definition> "Songs."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#notation> "su"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#prefLabel> "gospel music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#prefLabel> "bluegrass music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#definition> "Ballets."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#definition> "Minuets."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#prefLabel> "carols"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#notation> "bl"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#notation> "po"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#prefLabel> "chant, Christian"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#notation> "cp"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#prefLabel> "studies and exercises"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#notation> "sp"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#prefLabel> "teatro lirico"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#definition> "Dance forms."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#prefLabel> "rock music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#notation> "mz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#prefLabel> "folk music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#prefLabel> "oratorios"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#definition> "Fugues."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#definition> "Canzonas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used only when the work is intended for teaching purposes\n            (usually entitled Studies, Etudes, etc.)."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#definition> "Jazz."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#definition> "Trio-sonatas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#notation> "gm"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#prefLabel> "ballads"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#notation> "fg"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#notation> "jz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#notation> "vr"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://www.w3.org/2004/02/skos/core#scopeNote> "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#prefLabel> "motets"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#definition> "Chants, Other religions."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#notation> "cn"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#prefLabel> "passion music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#prefLabel> "nocturnes"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#op> <http://www.w3.org/2004/02/skos/core#prefLabel> "operas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#notation> "fm"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#notation> "cc"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#notation> "ch"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for instrumental music designated as a divertimento,\n            serenade, cassation, divertissement, or a notturno."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#notation> "bt"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for a large number of more specific terms which describe\n            Spanish and Spanish American theatre music: \"tonadilla escénica\", \"fiestas de música\",\n            \"sainetes líricos\", \"entremeses cómico-lírico,\" etc."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#notation> "ft"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#prefLabel> "minuets"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#prefLabel> "motion picture music"@en .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#definition> "Masses."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#definition> "Term applicable to all musical plays taking that name, from\n            the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”\n            (“modern zarzuela”) from the mid 19th to the mid 20th-century."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#definition> "Sonatas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#notation> "or"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#prefLabel> "chansons, polyphonic"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#prefLabel> "chance compositions"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#prefLabel> "rondos"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#definition> "Ragtime music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#notation> "cb"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#notation> "cr"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#notation> "nn"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#prefLabel> "trio-sonatas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#definition> "Multiple forms."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#notation> "sy"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#prefLabel> "madrigals"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes music for individual dances except for mazurkas,\n            minuets, pavans, polonaises, and waltzes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#definition> "Fantasias."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#notation> "pv"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#definition> "Variations."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#definition> "Chansons, polyphonic."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#definition> "Cantatas."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#notation> "cz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#prefLabel> "fugues"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#notation> "nc"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#definition> "Suites."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#notation> "ms"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#definition> "Chant, Christian."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#prefLabel> "variations"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#notation> "uu"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#prefLabel> "teatro lirico"@en .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#prefLabel> "musical revues and comedies"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#definition> "Carols."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#scopeNote> "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#prefLabel> "hymns"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorales"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#prefLabel> "square dance music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#prefLabel> "masses"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> <http://www.w3.org/2004/02/skos/core#prefLabel> "concerti grossi"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#notation> "ts"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for any item that is a non-music sound recording."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#notation> "cs"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#definition> "Not applicable"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#definition> "Passacaglias."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#notation> "mu"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#prefLabel> "fantasias"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#definition> "Overtures."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#definition> "Motion picture music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#notation> "sd"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#notation> "tc"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#notation> "sn"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#notation> "ct"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#definition> "Oratorios."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#definition> "Concertos."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#prefLabel> "blues"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#notation> "hy"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#prefLabel> "chants, other religions"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/description> "Indicates the form of composition."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#notation> "st"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#definition> "Gospel music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#definition> "Symphonies."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#prefLabel> "passacaglias"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#definition> "Program music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#notation> "mp"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#notation> "bd"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#definition> "Chorales."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/2004/02/skos/core#prefLabel> "cantatas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#definition> "Chance compositions."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/2004/02/skos/core#definition> "Passion music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#notation> "tl"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#definition> "Zarzuelas."@en .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/2004/02/skos/core#prefLabel> "villancicos"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#prefLabel> "anthems"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#definition> "Popular music."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#notation> "wz"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#prefLabel> "program music"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes folk songs, etc."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#definition> "Nocturnes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#notation> "ps"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for instrumental music that is designated as a canzona."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#prefLabel> "preludes"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> <http://www.w3.org/2004/02/skos/core#notation> "mi"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#definition> "Part-songs."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#definition> "Waltzes."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#definition> "Pavans."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#prefLabel> "polonaises"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#definition> "Ricercars."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#po> <http://www.w3.org/2004/02/skos/core#definition> "Polonaises."@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/2004/02/skos/core#prefLabel> "mazurkas"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple forms"@en .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#definition> "Ballads."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> <http://www.w3.org/2004/02/skos/core#prefLabel> "carols"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/description> "Indicates the form of composition."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> <http://www.w3.org/2004/02/skos/core#notation> "rc" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#notation> "sy" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> <http://www.w3.org/2004/02/skos/core#notation> "ms" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/2004/02/skos/core#notation> "fl" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#notation> "ps" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> <http://www.w3.org/2004/02/skos/core#notation> "bd" .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#notation> "sn" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#definition> "Chance compositions."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/2004/02/skos/core#notation> "or" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#za> <http://www.w3.org/2004/02/skos/core#notation> "za" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#notation> "pg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> <http://www.w3.org/2004/02/skos/core#definition> "Spanish and Spanish American theatre music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> <http://www.w3.org/2004/02/skos/core#notation> "mp" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/2004/02/skos/core#notation> "ts" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#prefLabel> "divertimentos, serenades, cassations, divertissements, and\n            notturni"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#notation> "rd" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#definition> "Canons and rounds. Compositions employing strict imitation\n            throughout."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#st> <http://www.w3.org/2004/02/skos/core#definition> "Studies and exercises."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#notation> "bg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#an> <http://www.w3.org/2004/02/skos/core#notation> "an" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#df> <http://www.w3.org/2004/02/skos/core#notation> "df" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#co> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#prefLabel> "sonatas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> <http://www.w3.org/2004/02/skos/core#notation> "sp" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> <http://www.w3.org/2004/02/skos/core#definition> "Folk music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#notation> "hy" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#or> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#definition> "Ballets."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#definition> "Chorale preludes."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorale preludes"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> <http://www.w3.org/2004/02/skos/core#notation> "rg" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#md> <http://www.w3.org/2004/02/skos/core#definition> "Madrigals."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#definition> "Form of composition other than anthems; ballads; bluegrass\n            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti\n            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;\n            carols; chance compositions; cantatas; country music; canzonas; dance forms;\n            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;\n            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;\n            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;\n            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;\n            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;\n            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;\n            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro\n            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes instrumental music designated as fantasia, fancies,\n            fantasies, etc."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#prefLabel> "songs"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> <http://www.w3.org/2004/02/skos/core#prefLabel> "passacaglias"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#prefLabel> "nocturnes"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> <http://www.w3.org/2004/02/skos/core#notation> "mu" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> <http://www.w3.org/2004/02/skos/core#prefLabel> "canzonas"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> <http://www.w3.org/2004/02/skos/core#prefLabel> "marches"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#definition> "Fugues."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> <http://www.w3.org/2004/02/skos/core#prefLabel> "waltzes"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> <http://www.w3.org/2004/02/skos/core#notation> "tc" .
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#notation> "jz" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#su> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/2004/02/skos/core#notation> "gm" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> <http://www.w3.org/2004/02/skos/core#definition> "Jazz."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#prefLabel> "popular music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> <http://www.w3.org/2004/02/skos/core#notation> "nc" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> <http://www.w3.org/2004/02/skos/core#definition> "Hymns."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> <http://www.w3.org/2004/02/skos/core#definition> "Overtures."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> <http://www.w3.org/2004/02/skos/core#notation> "uu" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> <http://www.w3.org/2004/02/skos/core#prefLabel> "program music"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> <http://www.w3.org/2004/02/skos/core#definition> "Square dance music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> <http://www.w3.org/2004/02/skos/core#definition> "Popular music."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#dv> <http://www.w3.org/2004/02/skos/core#definition> "Divertimentos, serenades, cassations, divertissements, and\n            notturni."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> <http://www.w3.org/2004/02/skos/core#notation> "pv" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://www.w3.org/2004/02/skos/core#scopeNote> "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#notation> "ft" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> <http://www.w3.org/2004/02/skos/core#prefLabel> "canons and rounds"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> <http://www.w3.org/2004/02/skos/core#notation> "cb" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#prefLabel> "requiems"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> <http://www.w3.org/2004/02/skos/core#notation> "nn" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> <http://www.w3.org/2004/02/skos/core#prefLabel> "fugues"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> <http://www.w3.org/2004/02/skos/core#notation> "vr" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/2004/02/skos/core#notation> "rq" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> <http://www.w3.org/2004/02/skos/core#definition> "Rondos."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> <http://www.w3.org/2004/02/skos/core#notation> "cs" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77> <http://purl.org/dc/terms/alternative> "MARC21 008/18-19 values for music expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> <http://www.w3.org/2004/02/skos/core#prefLabel> "part-songs"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> <http://www.w3.org/2004/02/skos/core#prefLabel> "chaconnes"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> <http://www.w3.org/2004/02/skos/core#notation> "ch" .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> <http://www.w3.org/2004/02/skos/core#definition> "Motets."@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> <http://www.w3.org/2004/02/skos/core#prefLabel> "musical revues and comedies"@en .
+<https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.8rpj-ek77> .

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -1,45 +1,39 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">suites</skos:prefLabel>
     <skos:definition xml:lang="en">Suites.</skos:definition>
-    <skos:notation xml:lang="en">su</skos:notation>
+    <skos:notation>su</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballets</skos:prefLabel>
     <skos:definition xml:lang="en">Ballets.</skos:definition>
-    <skos:notation xml:lang="en">bt</skos:notation>
+    <skos:notation>bt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">hymns</skos:prefLabel>
     <skos:definition xml:lang="en">Hymns.</skos:definition>
-    <skos:notation xml:lang="en">hy</skos:notation>
+    <skos:notation>hy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">masses</skos:prefLabel>
     <skos:definition xml:lang="en">Masses.</skos:definition>
-    <skos:notation xml:lang="en">ms</skos:notation>
+    <skos:notation>ms</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonies</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonies.</skos:definition>
-    <skos:notation xml:lang="en">sy</skos:notation>
+    <skos:notation>sy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -57,49 +51,49 @@
             rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.</skos:definition>
-    <skos:notation xml:lang="en">zz</skos:notation>
+    <skos:notation>zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">musical revues and comedies</skos:prefLabel>
     <skos:definition xml:lang="en">Musical revues and comedies.</skos:definition>
-    <skos:notation xml:lang="en">mc</skos:notation>
+    <skos:notation>mc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">requiems</skos:prefLabel>
     <skos:definition xml:lang="en">Requiems.</skos:definition>
-    <skos:notation xml:lang="en">rq</skos:notation>
+    <skos:notation>rq</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concerti grossi</skos:prefLabel>
     <skos:definition xml:lang="en">Concerti grossi.</skos:definition>
-    <skos:notation xml:lang="en">cg</skos:notation>
+    <skos:notation>cg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">jazz</skos:prefLabel>
     <skos:definition xml:lang="en">Jazz.</skos:definition>
-    <skos:notation xml:lang="en">jz</skos:notation>
+    <skos:notation>jz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rock music</skos:prefLabel>
     <skos:definition xml:lang="en">Rock music.</skos:definition>
-    <skos:notation xml:lang="en">rc</skos:notation>
+    <skos:notation>rc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">program music</skos:prefLabel>
     <skos:definition xml:lang="en">Program music.</skos:definition>
-    <skos:notation xml:lang="en">pg</skos:notation>
+    <skos:notation>pg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -108,7 +102,7 @@
     <dct:alternative xml:lang="en">MARC21 008/18-19 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of composition.</dct:description>
     <skos:scopeNote xml:lang="en">Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music).</skos:scopeNote>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -131,21 +125,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">part-songs</skos:prefLabel>
     <skos:definition xml:lang="en">Part-songs.</skos:definition>
-    <skos:notation xml:lang="en">pt</skos:notation>
+    <skos:notation>pt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorale preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Chorale preludes.</skos:definition>
-    <skos:notation xml:lang="en">cl</skos:notation>
+    <skos:notation>cl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">operas</skos:prefLabel>
     <skos:definition xml:lang="en">Operas.</skos:definition>
-    <skos:notation xml:lang="en">op</skos:notation>
+    <skos:notation>op</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -155,14 +149,14 @@
             secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
             important ceremonies (including Christmas, when these songs were sometimes called
             "pastoradas").</skos:definition>
-    <skos:notation xml:lang="en">vi</skos:notation>
+    <skos:notation>vi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">teatro lirico</skos:prefLabel>
     <skos:definition xml:lang="en">Spanish and Spanish American theatre music.</skos:definition>
-    <skos:notation xml:lang="en">tl</skos:notation>
+    <skos:notation>tl</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a large number of more specific terms which describe
             Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
             "sainetes líricos", "entremeses cómico-lírico," etc.</skos:scopeNote>
@@ -172,14 +166,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">blues</skos:prefLabel>
     <skos:definition xml:lang="en">Blues.</skos:definition>
-    <skos:notation xml:lang="en">bl</skos:notation>
+    <skos:notation>bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chaconnes</skos:prefLabel>
     <skos:definition xml:lang="en">Chaconnes.</skos:definition>
-    <skos:notation xml:lang="en">ca</skos:notation>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -189,14 +183,14 @@
     <skos:definition xml:lang="en">Term applicable to all musical plays taking that name, from
             the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”
             (“modern zarzuela”) from the mid 19th to the mid 20th-century.</skos:definition>
-    <skos:notation xml:lang="en">za</skos:notation>
+    <skos:notation>za</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">waltzes</skos:prefLabel>
     <skos:definition xml:lang="en">Waltzes.</skos:definition>
-    <skos:notation xml:lang="en">wz</skos:notation>
+    <skos:notation>wz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -207,28 +201,28 @@
             notturni.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music designated as a divertimento,
             serenade, cassation, divertissement, or a notturno.</skos:scopeNote>
-    <skos:notation xml:lang="en">dv</skos:notation>
+    <skos:notation>dv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ricercars</skos:prefLabel>
     <skos:definition xml:lang="en">Ricercars.</skos:definition>
-    <skos:notation xml:lang="en">ri</skos:notation>
+    <skos:notation>ri</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">bluegrass music</skos:prefLabel>
     <skos:definition xml:lang="en">Bluegrass music.</skos:definition>
-    <skos:notation xml:lang="en">bg</skos:notation>
+    <skos:notation>bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">dance forms</skos:prefLabel>
     <skos:definition xml:lang="en">Dance forms.</skos:definition>
-    <skos:notation xml:lang="en">df</skos:notation>
+    <skos:notation>df</skos:notation>
     <skos:scopeNote xml:lang="en">Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes.</skos:scopeNote>
   </rdf:Description>
@@ -237,14 +231,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ragtime music</skos:prefLabel>
     <skos:definition xml:lang="en">Ragtime music.</skos:definition>
-    <skos:notation xml:lang="en">rg</skos:notation>
+    <skos:notation>rg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">flamenco</skos:prefLabel>
     <skos:definition xml:lang="en">Flamenco.</skos:definition>
-    <skos:notation xml:lang="en">fl</skos:notation>
+    <skos:notation>fl</skos:notation>
     <skos:scopeNote xml:lang="en">All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
@@ -252,49 +246,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballads</skos:prefLabel>
     <skos:definition xml:lang="en">Ballads.</skos:definition>
-    <skos:notation xml:lang="en">bd</skos:notation>
+    <skos:notation>bd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">country music</skos:prefLabel>
     <skos:definition xml:lang="en">Country music.</skos:definition>
-    <skos:notation xml:lang="en">cy</skos:notation>
+    <skos:notation>cy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motets</skos:prefLabel>
     <skos:definition xml:lang="en">Motets.</skos:definition>
-    <skos:notation xml:lang="en">mo</skos:notation>
+    <skos:notation>mo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Preludes.</skos:definition>
-    <skos:notation xml:lang="en">pr</skos:notation>
+    <skos:notation>pr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">carols</skos:prefLabel>
     <skos:definition xml:lang="en">Carols.</skos:definition>
-    <skos:notation xml:lang="en">cr</skos:notation>
+    <skos:notation>cr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">marches</skos:prefLabel>
     <skos:definition xml:lang="en">Marches.</skos:definition>
-    <skos:notation xml:lang="en">mr</skos:notation>
+    <skos:notation>mr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passacaglias</skos:prefLabel>
     <skos:definition xml:lang="en">Passacaglias.</skos:definition>
-    <skos:notation xml:lang="en">ps</skos:notation>
+    <skos:notation>ps</skos:notation>
     <skos:scopeNote xml:lang="en">Includes all types of ostinato basses.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
@@ -302,7 +296,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concertos</skos:prefLabel>
     <skos:definition xml:lang="en">Concertos.</skos:definition>
-    <skos:notation xml:lang="en">co</skos:notation>
+    <skos:notation>co</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -311,14 +305,14 @@
     <skos:definition xml:lang="en">Studies and exercises.</skos:definition>
     <skos:scopeNote xml:lang="en">Used only when the work is intended for teaching purposes
             (usually entitled Studies, Etudes, etc.).</skos:scopeNote>
-    <skos:notation xml:lang="en">st</skos:notation>
+    <skos:notation>st</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">folk music</skos:prefLabel>
     <skos:definition xml:lang="en">Folk music.</skos:definition>
-    <skos:notation xml:lang="en">fm</skos:notation>
+    <skos:notation>fm</skos:notation>
     <skos:scopeNote xml:lang="en">Includes folk songs, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
@@ -326,70 +320,70 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">popular music</skos:prefLabel>
     <skos:definition xml:lang="en">Popular music.</skos:definition>
-    <skos:notation xml:lang="en">pp</skos:notation>
+    <skos:notation>pp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">overtures</skos:prefLabel>
     <skos:definition xml:lang="en">Overtures.</skos:definition>
-    <skos:notation xml:lang="en">ov</skos:notation>
+    <skos:notation>ov</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chant, Christian</skos:prefLabel>
     <skos:definition xml:lang="en">Chant, Christian.</skos:definition>
-    <skos:notation xml:lang="en">cc</skos:notation>
+    <skos:notation>cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">toccatas</skos:prefLabel>
     <skos:definition xml:lang="en">Toccatas.</skos:definition>
-    <skos:notation xml:lang="en">tc</skos:notation>
+    <skos:notation>tc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rondos</skos:prefLabel>
     <skos:definition xml:lang="en">Rondos.</skos:definition>
-    <skos:notation xml:lang="en">rd</skos:notation>
+    <skos:notation>rd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonic poems</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonic poems.</skos:definition>
-    <skos:notation xml:lang="en">sp</skos:notation>
+    <skos:notation>sp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">fugues</skos:prefLabel>
     <skos:definition xml:lang="en">Fugues.</skos:definition>
-    <skos:notation xml:lang="en">fg</skos:notation>
+    <skos:notation>fg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">square dance music</skos:prefLabel>
     <skos:definition xml:lang="en">Square dance music.</skos:definition>
-    <skos:notation xml:lang="en">sd</skos:notation>
+    <skos:notation>sd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">songs</skos:prefLabel>
     <skos:definition xml:lang="en">Songs.</skos:definition>
-    <skos:notation xml:lang="en">sg</skos:notation>
+    <skos:notation>sg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motion picture music</skos:prefLabel>
     <skos:definition xml:lang="en">Motion picture music.</skos:definition>
-    <skos:notation xml:lang="en">mp</skos:notation>
+    <skos:notation>mp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -397,35 +391,35 @@
     <skos:prefLabel xml:lang="en">canons and rounds</skos:prefLabel>
     <skos:definition xml:lang="en">Canons and rounds. Compositions employing strict imitation
             throughout.</skos:definition>
-    <skos:notation xml:lang="en">cn</skos:notation>
+    <skos:notation>cn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">minuets</skos:prefLabel>
     <skos:definition xml:lang="en">Minuets.</skos:definition>
-    <skos:notation xml:lang="en">mi</skos:notation>
+    <skos:notation>mi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rhapsodies</skos:prefLabel>
     <skos:definition xml:lang="en">Rhapsodies.</skos:definition>
-    <skos:notation xml:lang="en">rp</skos:notation>
+    <skos:notation>rp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passion music</skos:prefLabel>
     <skos:definition xml:lang="en">Passion music.</skos:definition>
-    <skos:notation xml:lang="en">pm</skos:notation>
+    <skos:notation>pm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not applicable</skos:definition>
-    <skos:notation xml:lang="en">nn</skos:notation>
+    <skos:notation>nn</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any item that is a non-music sound recording.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
@@ -433,42 +427,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Sonatas.</skos:definition>
-    <skos:notation xml:lang="en">sn</skos:notation>
+    <skos:notation>sn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">mazurkas</skos:prefLabel>
     <skos:definition xml:lang="en">Mazurkas.</skos:definition>
-    <skos:notation xml:lang="en">mz</skos:notation>
+    <skos:notation>mz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">pavans</skos:prefLabel>
     <skos:definition xml:lang="en">Pavans.</skos:definition>
-    <skos:notation xml:lang="en">pv</skos:notation>
+    <skos:notation>pv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chants, other religions</skos:prefLabel>
     <skos:definition xml:lang="en">Chants, Other religions.</skos:definition>
-    <skos:notation xml:lang="en">cb</skos:notation>
+    <skos:notation>cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">anthems</skos:prefLabel>
     <skos:definition xml:lang="en">Anthems.</skos:definition>
-    <skos:notation xml:lang="en">an</skos:notation>
+    <skos:notation>an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation xml:lang="en">uu</skos:notation>
+    <skos:notation>uu</skos:notation>
     <skos:scopeNote xml:lang="en">Used when the only indication given is the number of
             instruments and the medium of performance. No structure or genre is given, although they
             may be implied or understood.</skos:scopeNote>
@@ -478,35 +472,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">variations</skos:prefLabel>
     <skos:definition xml:lang="en">Variations.</skos:definition>
-    <skos:notation xml:lang="en">vr</skos:notation>
+    <skos:notation>vr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">gospel music</skos:prefLabel>
     <skos:definition xml:lang="en">Gospel music.</skos:definition>
-    <skos:notation xml:lang="en">gm</skos:notation>
+    <skos:notation>gm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorales</skos:prefLabel>
     <skos:definition xml:lang="en">Chorales.</skos:definition>
-    <skos:notation xml:lang="en">ch</skos:notation>
+    <skos:notation>ch</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">cantatas</skos:prefLabel>
     <skos:definition xml:lang="en">Cantatas.</skos:definition>
-    <skos:notation xml:lang="en">ct</skos:notation>
+    <skos:notation>ct</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">madrigals</skos:prefLabel>
     <skos:definition xml:lang="en">Madrigals.</skos:definition>
-    <skos:notation xml:lang="en">md</skos:notation>
+    <skos:notation>md</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -514,7 +508,7 @@
     <skos:prefLabel xml:lang="en">canzonas</skos:prefLabel>
     <skos:definition xml:lang="en">Canzonas.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music that is designated as a canzona.</skos:scopeNote>
-    <skos:notation xml:lang="en">cz</skos:notation>
+    <skos:notation>cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -523,55 +517,55 @@
     <skos:definition xml:lang="en">Fantasias.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes instrumental music designated as fantasia, fancies,
             fantasies, etc.</skos:scopeNote>
-    <skos:notation xml:lang="en">ft</skos:notation>
+    <skos:notation>ft</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chance compositions</skos:prefLabel>
     <skos:definition xml:lang="en">Chance compositions.</skos:definition>
-    <skos:notation xml:lang="en">cs</skos:notation>
+    <skos:notation>cs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">polonaises</skos:prefLabel>
     <skos:definition xml:lang="en">Polonaises.</skos:definition>
-    <skos:notation xml:lang="en">po</skos:notation>
+    <skos:notation>po</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chansons, polyphonic</skos:prefLabel>
     <skos:definition xml:lang="en">Chansons, polyphonic.</skos:definition>
-    <skos:notation xml:lang="en">cp</skos:notation>
+    <skos:notation>cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">oratorios</skos:prefLabel>
     <skos:definition xml:lang="en">Oratorios.</skos:definition>
-    <skos:notation xml:lang="en">or</skos:notation>
+    <skos:notation>or</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">trio-sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Trio-sonatas.</skos:definition>
-    <skos:notation xml:lang="en">ts</skos:notation>
+    <skos:notation>ts</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">nocturnes</skos:prefLabel>
     <skos:definition xml:lang="en">Nocturnes.</skos:definition>
-    <skos:notation xml:lang="en">nc</skos:notation>
+    <skos:notation>nc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">multiple forms</skos:prefLabel>
     <skos:definition xml:lang="en">Multiple forms.</skos:definition>
-    <skos:notation xml:lang="en">mu</skos:notation>
+    <skos:notation>mu</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -106,7 +106,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -113,7 +113,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld"/>

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -1,45 +1,39 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">suites</skos:prefLabel>
     <skos:definition xml:lang="en">Suites.</skos:definition>
-    <skos:notation xml:lang="en">su</skos:notation>
+    <skos:notation>su</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballets</skos:prefLabel>
     <skos:definition xml:lang="en">Ballets.</skos:definition>
-    <skos:notation xml:lang="en">bt</skos:notation>
+    <skos:notation>bt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">hymns</skos:prefLabel>
     <skos:definition xml:lang="en">Hymns.</skos:definition>
-    <skos:notation xml:lang="en">hy</skos:notation>
+    <skos:notation>hy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">masses</skos:prefLabel>
     <skos:definition xml:lang="en">Masses.</skos:definition>
-    <skos:notation xml:lang="en">ms</skos:notation>
+    <skos:notation>ms</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonies</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonies.</skos:definition>
-    <skos:notation xml:lang="en">sy</skos:notation>
+    <skos:notation>sy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -57,49 +51,49 @@
             rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.</skos:definition>
-    <skos:notation xml:lang="en">zz</skos:notation>
+    <skos:notation>zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">musical revues and comedies</skos:prefLabel>
     <skos:definition xml:lang="en">Musical revues and comedies.</skos:definition>
-    <skos:notation xml:lang="en">mc</skos:notation>
+    <skos:notation>mc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">requiems</skos:prefLabel>
     <skos:definition xml:lang="en">Requiems.</skos:definition>
-    <skos:notation xml:lang="en">rq</skos:notation>
+    <skos:notation>rq</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concerti grossi</skos:prefLabel>
     <skos:definition xml:lang="en">Concerti grossi.</skos:definition>
-    <skos:notation xml:lang="en">cg</skos:notation>
+    <skos:notation>cg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">jazz</skos:prefLabel>
     <skos:definition xml:lang="en">Jazz.</skos:definition>
-    <skos:notation xml:lang="en">jz</skos:notation>
+    <skos:notation>jz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rock music</skos:prefLabel>
     <skos:definition xml:lang="en">Rock music.</skos:definition>
-    <skos:notation xml:lang="en">rc</skos:notation>
+    <skos:notation>rc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">program music</skos:prefLabel>
     <skos:definition xml:lang="en">Program music.</skos:definition>
-    <skos:notation xml:lang="en">pg</skos:notation>
+    <skos:notation>pg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -108,7 +102,7 @@
     <dct:alternative xml:lang="en">MARC21 008/18-19 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of composition.</dct:description>
     <skos:scopeNote xml:lang="en">Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music).</skos:scopeNote>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -119,7 +113,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld"/>
@@ -131,21 +125,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">part-songs</skos:prefLabel>
     <skos:definition xml:lang="en">Part-songs.</skos:definition>
-    <skos:notation xml:lang="en">pt</skos:notation>
+    <skos:notation>pt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorale preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Chorale preludes.</skos:definition>
-    <skos:notation xml:lang="en">cl</skos:notation>
+    <skos:notation>cl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">operas</skos:prefLabel>
     <skos:definition xml:lang="en">Operas.</skos:definition>
-    <skos:notation xml:lang="en">op</skos:notation>
+    <skos:notation>op</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -155,14 +149,14 @@
             secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
             important ceremonies (including Christmas, when these songs were sometimes called
             "pastoradas").</skos:definition>
-    <skos:notation xml:lang="en">vi</skos:notation>
+    <skos:notation>vi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">teatro lirico</skos:prefLabel>
     <skos:definition xml:lang="en">Spanish and Spanish American theatre music.</skos:definition>
-    <skos:notation xml:lang="en">tl</skos:notation>
+    <skos:notation>tl</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a large number of more specific terms which describe
             Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
             "sainetes líricos", "entremeses cómico-lírico," etc.</skos:scopeNote>
@@ -172,14 +166,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">blues</skos:prefLabel>
     <skos:definition xml:lang="en">Blues.</skos:definition>
-    <skos:notation xml:lang="en">bl</skos:notation>
+    <skos:notation>bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chaconnes</skos:prefLabel>
     <skos:definition xml:lang="en">Chaconnes.</skos:definition>
-    <skos:notation xml:lang="en">ca</skos:notation>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -189,14 +183,14 @@
     <skos:definition xml:lang="en">Term applicable to all musical plays taking that name, from
             the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”
             (“modern zarzuela”) from the mid 19th to the mid 20th-century.</skos:definition>
-    <skos:notation xml:lang="en">za</skos:notation>
+    <skos:notation>za</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">waltzes</skos:prefLabel>
     <skos:definition xml:lang="en">Waltzes.</skos:definition>
-    <skos:notation xml:lang="en">wz</skos:notation>
+    <skos:notation>wz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -207,28 +201,28 @@
             notturni.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music designated as a divertimento,
             serenade, cassation, divertissement, or a notturno.</skos:scopeNote>
-    <skos:notation xml:lang="en">dv</skos:notation>
+    <skos:notation>dv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ricercars</skos:prefLabel>
     <skos:definition xml:lang="en">Ricercars.</skos:definition>
-    <skos:notation xml:lang="en">ri</skos:notation>
+    <skos:notation>ri</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">bluegrass music</skos:prefLabel>
     <skos:definition xml:lang="en">Bluegrass music.</skos:definition>
-    <skos:notation xml:lang="en">bg</skos:notation>
+    <skos:notation>bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">dance forms</skos:prefLabel>
     <skos:definition xml:lang="en">Dance forms.</skos:definition>
-    <skos:notation xml:lang="en">df</skos:notation>
+    <skos:notation>df</skos:notation>
     <skos:scopeNote xml:lang="en">Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes.</skos:scopeNote>
   </rdf:Description>
@@ -237,14 +231,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ragtime music</skos:prefLabel>
     <skos:definition xml:lang="en">Ragtime music.</skos:definition>
-    <skos:notation xml:lang="en">rg</skos:notation>
+    <skos:notation>rg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">flamenco</skos:prefLabel>
     <skos:definition xml:lang="en">Flamenco.</skos:definition>
-    <skos:notation xml:lang="en">fl</skos:notation>
+    <skos:notation>fl</skos:notation>
     <skos:scopeNote xml:lang="en">All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
@@ -252,49 +246,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballads</skos:prefLabel>
     <skos:definition xml:lang="en">Ballads.</skos:definition>
-    <skos:notation xml:lang="en">bd</skos:notation>
+    <skos:notation>bd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">country music</skos:prefLabel>
     <skos:definition xml:lang="en">Country music.</skos:definition>
-    <skos:notation xml:lang="en">cy</skos:notation>
+    <skos:notation>cy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motets</skos:prefLabel>
     <skos:definition xml:lang="en">Motets.</skos:definition>
-    <skos:notation xml:lang="en">mo</skos:notation>
+    <skos:notation>mo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Preludes.</skos:definition>
-    <skos:notation xml:lang="en">pr</skos:notation>
+    <skos:notation>pr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">carols</skos:prefLabel>
     <skos:definition xml:lang="en">Carols.</skos:definition>
-    <skos:notation xml:lang="en">cr</skos:notation>
+    <skos:notation>cr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">marches</skos:prefLabel>
     <skos:definition xml:lang="en">Marches.</skos:definition>
-    <skos:notation xml:lang="en">mr</skos:notation>
+    <skos:notation>mr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passacaglias</skos:prefLabel>
     <skos:definition xml:lang="en">Passacaglias.</skos:definition>
-    <skos:notation xml:lang="en">ps</skos:notation>
+    <skos:notation>ps</skos:notation>
     <skos:scopeNote xml:lang="en">Includes all types of ostinato basses.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
@@ -302,7 +296,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concertos</skos:prefLabel>
     <skos:definition xml:lang="en">Concertos.</skos:definition>
-    <skos:notation xml:lang="en">co</skos:notation>
+    <skos:notation>co</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -311,14 +305,14 @@
     <skos:definition xml:lang="en">Studies and exercises.</skos:definition>
     <skos:scopeNote xml:lang="en">Used only when the work is intended for teaching purposes
             (usually entitled Studies, Etudes, etc.).</skos:scopeNote>
-    <skos:notation xml:lang="en">st</skos:notation>
+    <skos:notation>st</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">folk music</skos:prefLabel>
     <skos:definition xml:lang="en">Folk music.</skos:definition>
-    <skos:notation xml:lang="en">fm</skos:notation>
+    <skos:notation>fm</skos:notation>
     <skos:scopeNote xml:lang="en">Includes folk songs, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
@@ -326,70 +320,70 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">popular music</skos:prefLabel>
     <skos:definition xml:lang="en">Popular music.</skos:definition>
-    <skos:notation xml:lang="en">pp</skos:notation>
+    <skos:notation>pp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">overtures</skos:prefLabel>
     <skos:definition xml:lang="en">Overtures.</skos:definition>
-    <skos:notation xml:lang="en">ov</skos:notation>
+    <skos:notation>ov</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chant, Christian</skos:prefLabel>
     <skos:definition xml:lang="en">Chant, Christian.</skos:definition>
-    <skos:notation xml:lang="en">cc</skos:notation>
+    <skos:notation>cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">toccatas</skos:prefLabel>
     <skos:definition xml:lang="en">Toccatas.</skos:definition>
-    <skos:notation xml:lang="en">tc</skos:notation>
+    <skos:notation>tc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rondos</skos:prefLabel>
     <skos:definition xml:lang="en">Rondos.</skos:definition>
-    <skos:notation xml:lang="en">rd</skos:notation>
+    <skos:notation>rd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonic poems</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonic poems.</skos:definition>
-    <skos:notation xml:lang="en">sp</skos:notation>
+    <skos:notation>sp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">fugues</skos:prefLabel>
     <skos:definition xml:lang="en">Fugues.</skos:definition>
-    <skos:notation xml:lang="en">fg</skos:notation>
+    <skos:notation>fg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">square dance music</skos:prefLabel>
     <skos:definition xml:lang="en">Square dance music.</skos:definition>
-    <skos:notation xml:lang="en">sd</skos:notation>
+    <skos:notation>sd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">songs</skos:prefLabel>
     <skos:definition xml:lang="en">Songs.</skos:definition>
-    <skos:notation xml:lang="en">sg</skos:notation>
+    <skos:notation>sg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motion picture music</skos:prefLabel>
     <skos:definition xml:lang="en">Motion picture music.</skos:definition>
-    <skos:notation xml:lang="en">mp</skos:notation>
+    <skos:notation>mp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -397,35 +391,35 @@
     <skos:prefLabel xml:lang="en">canons and rounds</skos:prefLabel>
     <skos:definition xml:lang="en">Canons and rounds. Compositions employing strict imitation
             throughout.</skos:definition>
-    <skos:notation xml:lang="en">cn</skos:notation>
+    <skos:notation>cn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">minuets</skos:prefLabel>
     <skos:definition xml:lang="en">Minuets.</skos:definition>
-    <skos:notation xml:lang="en">mi</skos:notation>
+    <skos:notation>mi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rhapsodies</skos:prefLabel>
     <skos:definition xml:lang="en">Rhapsodies.</skos:definition>
-    <skos:notation xml:lang="en">rp</skos:notation>
+    <skos:notation>rp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passion music</skos:prefLabel>
     <skos:definition xml:lang="en">Passion music.</skos:definition>
-    <skos:notation xml:lang="en">pm</skos:notation>
+    <skos:notation>pm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not applicable</skos:definition>
-    <skos:notation xml:lang="en">nn</skos:notation>
+    <skos:notation>nn</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any item that is a non-music sound recording.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
@@ -433,42 +427,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Sonatas.</skos:definition>
-    <skos:notation xml:lang="en">sn</skos:notation>
+    <skos:notation>sn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">mazurkas</skos:prefLabel>
     <skos:definition xml:lang="en">Mazurkas.</skos:definition>
-    <skos:notation xml:lang="en">mz</skos:notation>
+    <skos:notation>mz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">pavans</skos:prefLabel>
     <skos:definition xml:lang="en">Pavans.</skos:definition>
-    <skos:notation xml:lang="en">pv</skos:notation>
+    <skos:notation>pv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chants, other religions</skos:prefLabel>
     <skos:definition xml:lang="en">Chants, Other religions.</skos:definition>
-    <skos:notation xml:lang="en">cb</skos:notation>
+    <skos:notation>cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">anthems</skos:prefLabel>
     <skos:definition xml:lang="en">Anthems.</skos:definition>
-    <skos:notation xml:lang="en">an</skos:notation>
+    <skos:notation>an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation xml:lang="en">uu</skos:notation>
+    <skos:notation>uu</skos:notation>
     <skos:scopeNote xml:lang="en">Used when the only indication given is the number of
             instruments and the medium of performance. No structure or genre is given, although they
             may be implied or understood.</skos:scopeNote>
@@ -478,35 +472,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">variations</skos:prefLabel>
     <skos:definition xml:lang="en">Variations.</skos:definition>
-    <skos:notation xml:lang="en">vr</skos:notation>
+    <skos:notation>vr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">gospel music</skos:prefLabel>
     <skos:definition xml:lang="en">Gospel music.</skos:definition>
-    <skos:notation xml:lang="en">gm</skos:notation>
+    <skos:notation>gm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorales</skos:prefLabel>
     <skos:definition xml:lang="en">Chorales.</skos:definition>
-    <skos:notation xml:lang="en">ch</skos:notation>
+    <skos:notation>ch</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">cantatas</skos:prefLabel>
     <skos:definition xml:lang="en">Cantatas.</skos:definition>
-    <skos:notation xml:lang="en">ct</skos:notation>
+    <skos:notation>ct</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">madrigals</skos:prefLabel>
     <skos:definition xml:lang="en">Madrigals.</skos:definition>
-    <skos:notation xml:lang="en">md</skos:notation>
+    <skos:notation>md</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -514,7 +508,7 @@
     <skos:prefLabel xml:lang="en">canzonas</skos:prefLabel>
     <skos:definition xml:lang="en">Canzonas.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music that is designated as a canzona.</skos:scopeNote>
-    <skos:notation xml:lang="en">cz</skos:notation>
+    <skos:notation>cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -523,55 +517,55 @@
     <skos:definition xml:lang="en">Fantasias.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes instrumental music designated as fantasia, fancies,
             fantasies, etc.</skos:scopeNote>
-    <skos:notation xml:lang="en">ft</skos:notation>
+    <skos:notation>ft</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chance compositions</skos:prefLabel>
     <skos:definition xml:lang="en">Chance compositions.</skos:definition>
-    <skos:notation xml:lang="en">cs</skos:notation>
+    <skos:notation>cs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">polonaises</skos:prefLabel>
     <skos:definition xml:lang="en">Polonaises.</skos:definition>
-    <skos:notation xml:lang="en">po</skos:notation>
+    <skos:notation>po</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chansons, polyphonic</skos:prefLabel>
     <skos:definition xml:lang="en">Chansons, polyphonic.</skos:definition>
-    <skos:notation xml:lang="en">cp</skos:notation>
+    <skos:notation>cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">oratorios</skos:prefLabel>
     <skos:definition xml:lang="en">Oratorios.</skos:definition>
-    <skos:notation xml:lang="en">or</skos:notation>
+    <skos:notation>or</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">trio-sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Trio-sonatas.</skos:definition>
-    <skos:notation xml:lang="en">ts</skos:notation>
+    <skos:notation>ts</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">nocturnes</skos:prefLabel>
     <skos:definition xml:lang="en">Nocturnes.</skos:definition>
-    <skos:notation xml:lang="en">nc</skos:notation>
+    <skos:notation>nc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">multiple forms</skos:prefLabel>
     <skos:definition xml:lang="en">Multiple forms.</skos:definition>
-    <skos:notation xml:lang="en">mu</skos:notation>
+    <skos:notation>mu</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -1,32 +1,34 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">suites</skos:prefLabel>
-    <skos:definition xml:lang="en">Suites.</skos:definition>
-    <skos:notation>su</skos:notation>
+    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
+    <skos:definition xml:lang="en">Not applicable</skos:definition>
+    <skos:notation>nn</skos:notation>
+    <skos:scopeNote xml:lang="en">Used for any item that is a non-music sound recording.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">ballets</skos:prefLabel>
-    <skos:definition xml:lang="en">Ballets.</skos:definition>
-    <skos:notation>bt</skos:notation>
+    <skos:prefLabel xml:lang="en">fantasias</skos:prefLabel>
+    <skos:definition xml:lang="en">Fantasias.</skos:definition>
+    <skos:scopeNote xml:lang="en">Includes instrumental music designated as fantasia, fancies,
+            fantasies, etc.</skos:scopeNote>
+    <skos:notation>ft</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pt">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">hymns</skos:prefLabel>
-    <skos:definition xml:lang="en">Hymns.</skos:definition>
-    <skos:notation>hy</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">masses</skos:prefLabel>
-    <skos:definition xml:lang="en">Masses.</skos:definition>
-    <skos:notation>ms</skos:notation>
+    <skos:prefLabel xml:lang="en">part-songs</skos:prefLabel>
+    <skos:definition xml:lang="en">Part-songs.</skos:definition>
+    <skos:notation>pt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -35,30 +37,28 @@
     <skos:definition xml:lang="en">Symphonies.</skos:definition>
     <skos:notation>sy</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of composition other than anthems; ballads; bluegrass
-            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti
-            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;
-            carols; chance compositions; cantatas; country music; canzonas; dance forms;
-            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;
-            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;
-            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;
-            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;
-            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;
-            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
-            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
-            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.</skos:definition>
-    <skos:notation>zz</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">musical revues and comedies</skos:prefLabel>
     <skos:definition xml:lang="en">Musical revues and comedies.</skos:definition>
     <skos:notation>mc</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">preludes</skos:prefLabel>
+    <skos:definition xml:lang="en">Preludes.</skos:definition>
+    <skos:notation>pr</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">studies and exercises</skos:prefLabel>
+    <skos:definition xml:lang="en">Studies and exercises.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used only when the work is intended for teaching purposes
+            (usually entitled Studies, Etudes, etc.).</skos:scopeNote>
+    <skos:notation>st</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -67,19 +67,94 @@
     <skos:definition xml:lang="en">Requiems.</skos:definition>
     <skos:notation>rq</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">concerti grossi</skos:prefLabel>
-    <skos:definition xml:lang="en">Concerti grossi.</skos:definition>
-    <skos:notation>cg</skos:notation>
+    <skos:prefLabel xml:lang="en">sonatas</skos:prefLabel>
+    <skos:definition xml:lang="en">Sonatas.</skos:definition>
+    <skos:notation>sn</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">jazz</skos:prefLabel>
-    <skos:definition xml:lang="en">Jazz.</skos:definition>
-    <skos:notation>jz</skos:notation>
+    <skos:prefLabel xml:lang="en">suites</skos:prefLabel>
+    <skos:definition xml:lang="en">Suites.</skos:definition>
+    <skos:notation>su</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">ballads</skos:prefLabel>
+    <skos:definition xml:lang="en">Ballads.</skos:definition>
+    <skos:notation>bd</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">chant, Christian</skos:prefLabel>
+    <skos:definition xml:lang="en">Chant, Christian.</skos:definition>
+    <skos:notation>cc</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vr">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">variations</skos:prefLabel>
+    <skos:definition xml:lang="en">Variations.</skos:definition>
+    <skos:notation>vr</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">anthems</skos:prefLabel>
+    <skos:definition xml:lang="en">Anthems.</skos:definition>
+    <skos:notation>an</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">popular music</skos:prefLabel>
+    <skos:definition xml:lang="en">Popular music.</skos:definition>
+    <skos:notation>pp</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">divertimentos, serenades, cassations, divertissements, and
+            notturni</skos:prefLabel>
+    <skos:definition xml:lang="en">Divertimentos, serenades, cassations, divertissements, and
+            notturni.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used for instrumental music designated as a divertimento,
+            serenade, cassation, divertissement, or a notturno.</skos:scopeNote>
+    <skos:notation>dv</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">marches</skos:prefLabel>
+    <skos:definition xml:lang="en">Marches.</skos:definition>
+    <skos:notation>mr</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">flamenco</skos:prefLabel>
+    <skos:definition xml:lang="en">Flamenco.</skos:definition>
+    <skos:notation>fl</skos:notation>
+    <skos:scopeNote xml:lang="en">All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">toccatas</skos:prefLabel>
+    <skos:definition xml:lang="en">Toccatas.</skos:definition>
+    <skos:notation>tc</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">oratorios</skos:prefLabel>
+    <skos:definition xml:lang="en">Oratorios.</skos:definition>
+    <skos:notation>or</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -88,12 +163,199 @@
     <skos:definition xml:lang="en">Rock music.</skos:definition>
     <skos:notation>rc</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">fugues</skos:prefLabel>
+    <skos:definition xml:lang="en">Fugues.</skos:definition>
+    <skos:notation>fg</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">operas</skos:prefLabel>
+    <skos:definition xml:lang="en">Operas.</skos:definition>
+    <skos:notation>op</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bl">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">blues</skos:prefLabel>
+    <skos:definition xml:lang="en">Blues.</skos:definition>
+    <skos:notation>bl</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">bluegrass music</skos:prefLabel>
+    <skos:definition xml:lang="en">Bluegrass music.</skos:definition>
+    <skos:notation>bg</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">waltzes</skos:prefLabel>
+    <skos:definition xml:lang="en">Waltzes.</skos:definition>
+    <skos:notation>wz</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">madrigals</skos:prefLabel>
+    <skos:definition xml:lang="en">Madrigals.</skos:definition>
+    <skos:notation>md</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">canzonas</skos:prefLabel>
+    <skos:definition xml:lang="en">Canzonas.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used for instrumental music that is designated as a canzona.</skos:scopeNote>
+    <skos:notation>cz</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">villancicos</skos:prefLabel>
+    <skos:definition xml:lang="en">Characteristic form of Spanish polyphony, religious or
+            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
+            important ceremonies (including Christmas, when these songs were sometimes called
+            "pastoradas").</skos:definition>
+    <skos:notation>vi</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">chorale preludes</skos:prefLabel>
+    <skos:definition xml:lang="en">Chorale preludes.</skos:definition>
+    <skos:notation>cl</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">carols</skos:prefLabel>
+    <skos:definition xml:lang="en">Carols.</skos:definition>
+    <skos:notation>cr</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">motets</skos:prefLabel>
+    <skos:definition xml:lang="en">Motets.</skos:definition>
+    <skos:notation>mo</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">country music</skos:prefLabel>
+    <skos:definition xml:lang="en">Country music.</skos:definition>
+    <skos:notation>cy</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">concerti grossi</skos:prefLabel>
+    <skos:definition xml:lang="en">Concerti grossi.</skos:definition>
+    <skos:notation>cg</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">minuets</skos:prefLabel>
+    <skos:definition xml:lang="en">Minuets.</skos:definition>
+    <skos:notation>mi</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">polonaises</skos:prefLabel>
+    <skos:definition xml:lang="en">Polonaises.</skos:definition>
+    <skos:notation>po</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">songs</skos:prefLabel>
+    <skos:definition xml:lang="en">Songs.</skos:definition>
+    <skos:notation>sg</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">program music</skos:prefLabel>
     <skos:definition xml:lang="en">Program music.</skos:definition>
     <skos:notation>pg</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">chorales</skos:prefLabel>
+    <skos:definition xml:lang="en">Chorales.</skos:definition>
+    <skos:notation>ch</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">symphonic poems</skos:prefLabel>
+    <skos:definition xml:lang="en">Symphonic poems.</skos:definition>
+    <skos:notation>sp</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">square dance music</skos:prefLabel>
+    <skos:definition xml:lang="en">Square dance music.</skos:definition>
+    <skos:notation>sd</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">cantatas</skos:prefLabel>
+    <skos:definition xml:lang="en">Cantatas.</skos:definition>
+    <skos:notation>ct</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">chansons, polyphonic</skos:prefLabel>
+    <skos:definition xml:lang="en">Chansons, polyphonic.</skos:definition>
+    <skos:notation>cp</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">multiple forms</skos:prefLabel>
+    <skos:definition xml:lang="en">Multiple forms.</skos:definition>
+    <skos:notation>mu</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">ricercars</skos:prefLabel>
+    <skos:definition xml:lang="en">Ricercars.</skos:definition>
+    <skos:notation>ri</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">chance compositions</skos:prefLabel>
+    <skos:definition xml:lang="en">Chance compositions.</skos:definition>
+    <skos:notation>cs</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">passacaglias</skos:prefLabel>
+    <skos:definition xml:lang="en">Passacaglias.</skos:definition>
+    <skos:notation>ps</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes all types of ostinato basses.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">mazurkas</skos:prefLabel>
+    <skos:definition xml:lang="en">Mazurkas.</skos:definition>
+    <skos:notation>mz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -120,60 +382,29 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pt">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">part-songs</skos:prefLabel>
-    <skos:definition xml:lang="en">Part-songs.</skos:definition>
-    <skos:notation>pt</skos:notation>
+    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Unknown.</skos:definition>
+    <skos:notation>uu</skos:notation>
+    <skos:scopeNote xml:lang="en">Used when the only indication given is the number of
+            instruments and the medium of performance. No structure or genre is given, although they
+            may be implied or understood.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chorale preludes</skos:prefLabel>
-    <skos:definition xml:lang="en">Chorale preludes.</skos:definition>
-    <skos:notation>cl</skos:notation>
+    <skos:prefLabel xml:lang="en">trio-sonatas</skos:prefLabel>
+    <skos:definition xml:lang="en">Trio-sonatas.</skos:definition>
+    <skos:notation>ts</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">operas</skos:prefLabel>
-    <skos:definition xml:lang="en">Operas.</skos:definition>
-    <skos:notation>op</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">villancicos</skos:prefLabel>
-    <skos:definition xml:lang="en">Characteristic form of Spanish polyphony, religious or
-            secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
-            important ceremonies (including Christmas, when these songs were sometimes called
-            "pastoradas").</skos:definition>
-    <skos:notation>vi</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">teatro lirico</skos:prefLabel>
-    <skos:definition xml:lang="en">Spanish and Spanish American theatre music.</skos:definition>
-    <skos:notation>tl</skos:notation>
-    <skos:scopeNote xml:lang="en">Used for a large number of more specific terms which describe
-            Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
-            "sainetes líricos", "entremeses cómico-lírico," etc.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bl">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">blues</skos:prefLabel>
-    <skos:definition xml:lang="en">Blues.</skos:definition>
-    <skos:notation>bl</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chaconnes</skos:prefLabel>
-    <skos:definition xml:lang="en">Chaconnes.</skos:definition>
-    <skos:notation>ca</skos:notation>
+    <skos:prefLabel xml:lang="en">gospel music</skos:prefLabel>
+    <skos:definition xml:lang="en">Gospel music.</skos:definition>
+    <skos:notation>gm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -185,37 +416,83 @@
             (“modern zarzuela”) from the mid 19th to the mid 20th-century.</skos:definition>
     <skos:notation>za</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">waltzes</skos:prefLabel>
-    <skos:definition xml:lang="en">Waltzes.</skos:definition>
-    <skos:notation>wz</skos:notation>
+    <skos:prefLabel xml:lang="en">ragtime music</skos:prefLabel>
+    <skos:definition xml:lang="en">Ragtime music.</skos:definition>
+    <skos:notation>rg</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">divertimentos, serenades, cassations, divertissements, and
-            notturni</skos:prefLabel>
-    <skos:definition xml:lang="en">Divertimentos, serenades, cassations, divertissements, and
-            notturni.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used for instrumental music designated as a divertimento,
-            serenade, cassation, divertissement, or a notturno.</skos:scopeNote>
-    <skos:notation>dv</skos:notation>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of composition other than anthems; ballads; bluegrass
+            music; blues; ballets; chaconnes; chants, other religions; chant, Christian; concerti
+            grossi; chorales; chorale preludes; canons and rounds; concertos; chansons, polyphonic;
+            carols; chance compositions; cantatas; country music; canzonas; dance forms;
+            divertimentos, serenades, cassations, divertissements, and notturni; fugues; flamenco;
+            folk music; fantasias; gospel music; hymns; jazz; musical revues and comedies;
+            madrigals; minuets; motets; motion picture music; marches; masses; multiple forms;
+            mazurkas; nocturnes; operas; oratorios; overtures; program music; passion music;
+            polonaises; popular music; preludes; passacaglias; part-songs; pavans; rock music;
+            rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
+            sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
+            lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.</skos:definition>
+    <skos:notation>zz</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">ricercars</skos:prefLabel>
-    <skos:definition xml:lang="en">Ricercars.</skos:definition>
-    <skos:notation>ri</skos:notation>
+    <skos:prefLabel xml:lang="en">canons and rounds</skos:prefLabel>
+    <skos:definition xml:lang="en">Canons and rounds. Compositions employing strict imitation
+            throughout.</skos:definition>
+    <skos:notation>cn</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">bluegrass music</skos:prefLabel>
-    <skos:definition xml:lang="en">Bluegrass music.</skos:definition>
-    <skos:notation>bg</skos:notation>
+    <skos:prefLabel xml:lang="en">chants, other religions</skos:prefLabel>
+    <skos:definition xml:lang="en">Chants, Other religions.</skos:definition>
+    <skos:notation>cb</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">nocturnes</skos:prefLabel>
+    <skos:definition xml:lang="en">Nocturnes.</skos:definition>
+    <skos:notation>nc</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">teatro lirico</skos:prefLabel>
+    <skos:definition xml:lang="en">Spanish and Spanish American theatre music.</skos:definition>
+    <skos:notation>tl</skos:notation>
+    <skos:scopeNote xml:lang="en">Used for a large number of more specific terms which describe
+            Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
+            "sainetes líricos", "entremeses cómico-lírico," etc.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">passion music</skos:prefLabel>
+    <skos:definition xml:lang="en">Passion music.</skos:definition>
+    <skos:notation>pm</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">rondos</skos:prefLabel>
+    <skos:definition xml:lang="en">Rondos.</skos:definition>
+    <skos:notation>rd</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
+    <skos:prefLabel xml:lang="en">hymns</skos:prefLabel>
+    <skos:definition xml:lang="en">Hymns.</skos:definition>
+    <skos:notation>hy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -226,86 +503,47 @@
     <skos:scopeNote xml:lang="en">Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rg">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">ragtime music</skos:prefLabel>
-    <skos:definition xml:lang="en">Ragtime music.</skos:definition>
-    <skos:notation>rg</skos:notation>
+    <skos:prefLabel xml:lang="en">ballets</skos:prefLabel>
+    <skos:definition xml:lang="en">Ballets.</skos:definition>
+    <skos:notation>bt</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">flamenco</skos:prefLabel>
-    <skos:definition xml:lang="en">Flamenco.</skos:definition>
-    <skos:notation>fl</skos:notation>
-    <skos:scopeNote xml:lang="en">All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">masses</skos:prefLabel>
+    <skos:definition xml:lang="en">Masses.</skos:definition>
+    <skos:notation>ms</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">ballads</skos:prefLabel>
-    <skos:definition xml:lang="en">Ballads.</skos:definition>
-    <skos:notation>bd</skos:notation>
+    <skos:prefLabel xml:lang="en">jazz</skos:prefLabel>
+    <skos:definition xml:lang="en">Jazz.</skos:definition>
+    <skos:notation>jz</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">country music</skos:prefLabel>
-    <skos:definition xml:lang="en">Country music.</skos:definition>
-    <skos:notation>cy</skos:notation>
+    <skos:prefLabel xml:lang="en">overtures</skos:prefLabel>
+    <skos:definition xml:lang="en">Overtures.</skos:definition>
+    <skos:notation>ov</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">motets</skos:prefLabel>
-    <skos:definition xml:lang="en">Motets.</skos:definition>
-    <skos:notation>mo</skos:notation>
+    <skos:prefLabel xml:lang="en">chaconnes</skos:prefLabel>
+    <skos:definition xml:lang="en">Chaconnes.</skos:definition>
+    <skos:notation>ca</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">preludes</skos:prefLabel>
-    <skos:definition xml:lang="en">Preludes.</skos:definition>
-    <skos:notation>pr</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">carols</skos:prefLabel>
-    <skos:definition xml:lang="en">Carols.</skos:definition>
-    <skos:notation>cr</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">marches</skos:prefLabel>
-    <skos:definition xml:lang="en">Marches.</skos:definition>
-    <skos:notation>mr</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">passacaglias</skos:prefLabel>
-    <skos:definition xml:lang="en">Passacaglias.</skos:definition>
-    <skos:notation>ps</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes all types of ostinato basses.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">concertos</skos:prefLabel>
-    <skos:definition xml:lang="en">Concertos.</skos:definition>
-    <skos:notation>co</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">studies and exercises</skos:prefLabel>
-    <skos:definition xml:lang="en">Studies and exercises.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used only when the work is intended for teaching purposes
-            (usually entitled Studies, Etudes, etc.).</skos:scopeNote>
-    <skos:notation>st</skos:notation>
+    <skos:prefLabel xml:lang="en">pavans</skos:prefLabel>
+    <skos:definition xml:lang="en">Pavans.</skos:definition>
+    <skos:notation>pv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -315,68 +553,12 @@
     <skos:notation>fm</skos:notation>
     <skos:scopeNote xml:lang="en">Includes folk songs, etc.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">popular music</skos:prefLabel>
-    <skos:definition xml:lang="en">Popular music.</skos:definition>
-    <skos:notation>pp</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">overtures</skos:prefLabel>
-    <skos:definition xml:lang="en">Overtures.</skos:definition>
-    <skos:notation>ov</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chant, Christian</skos:prefLabel>
-    <skos:definition xml:lang="en">Chant, Christian.</skos:definition>
-    <skos:notation>cc</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">toccatas</skos:prefLabel>
-    <skos:definition xml:lang="en">Toccatas.</skos:definition>
-    <skos:notation>tc</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">rondos</skos:prefLabel>
-    <skos:definition xml:lang="en">Rondos.</skos:definition>
-    <skos:notation>rd</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">symphonic poems</skos:prefLabel>
-    <skos:definition xml:lang="en">Symphonic poems.</skos:definition>
-    <skos:notation>sp</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">fugues</skos:prefLabel>
-    <skos:definition xml:lang="en">Fugues.</skos:definition>
-    <skos:notation>fg</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">square dance music</skos:prefLabel>
-    <skos:definition xml:lang="en">Square dance music.</skos:definition>
-    <skos:notation>sd</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">songs</skos:prefLabel>
-    <skos:definition xml:lang="en">Songs.</skos:definition>
-    <skos:notation>sg</skos:notation>
+    <skos:prefLabel xml:lang="en">concertos</skos:prefLabel>
+    <skos:definition xml:lang="en">Concertos.</skos:definition>
+    <skos:notation>co</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -385,187 +567,11 @@
     <skos:definition xml:lang="en">Motion picture music.</skos:definition>
     <skos:notation>mp</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">canons and rounds</skos:prefLabel>
-    <skos:definition xml:lang="en">Canons and rounds. Compositions employing strict imitation
-            throughout.</skos:definition>
-    <skos:notation>cn</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">minuets</skos:prefLabel>
-    <skos:definition xml:lang="en">Minuets.</skos:definition>
-    <skos:notation>mi</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rhapsodies</skos:prefLabel>
     <skos:definition xml:lang="en">Rhapsodies.</skos:definition>
     <skos:notation>rp</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">passion music</skos:prefLabel>
-    <skos:definition xml:lang="en">Passion music.</skos:definition>
-    <skos:notation>pm</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
-    <skos:definition xml:lang="en">Not applicable</skos:definition>
-    <skos:notation>nn</skos:notation>
-    <skos:scopeNote xml:lang="en">Used for any item that is a non-music sound recording.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">sonatas</skos:prefLabel>
-    <skos:definition xml:lang="en">Sonatas.</skos:definition>
-    <skos:notation>sn</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">mazurkas</skos:prefLabel>
-    <skos:definition xml:lang="en">Mazurkas.</skos:definition>
-    <skos:notation>mz</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">pavans</skos:prefLabel>
-    <skos:definition xml:lang="en">Pavans.</skos:definition>
-    <skos:notation>pv</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chants, other religions</skos:prefLabel>
-    <skos:definition xml:lang="en">Chants, Other religions.</skos:definition>
-    <skos:notation>cb</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">anthems</skos:prefLabel>
-    <skos:definition xml:lang="en">Anthems.</skos:definition>
-    <skos:notation>an</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation>uu</skos:notation>
-    <skos:scopeNote xml:lang="en">Used when the only indication given is the number of
-            instruments and the medium of performance. No structure or genre is given, although they
-            may be implied or understood.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vr">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">variations</skos:prefLabel>
-    <skos:definition xml:lang="en">Variations.</skos:definition>
-    <skos:notation>vr</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">gospel music</skos:prefLabel>
-    <skos:definition xml:lang="en">Gospel music.</skos:definition>
-    <skos:notation>gm</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chorales</skos:prefLabel>
-    <skos:definition xml:lang="en">Chorales.</skos:definition>
-    <skos:notation>ch</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">cantatas</skos:prefLabel>
-    <skos:definition xml:lang="en">Cantatas.</skos:definition>
-    <skos:notation>ct</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">madrigals</skos:prefLabel>
-    <skos:definition xml:lang="en">Madrigals.</skos:definition>
-    <skos:notation>md</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">canzonas</skos:prefLabel>
-    <skos:definition xml:lang="en">Canzonas.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used for instrumental music that is designated as a canzona.</skos:scopeNote>
-    <skos:notation>cz</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">fantasias</skos:prefLabel>
-    <skos:definition xml:lang="en">Fantasias.</skos:definition>
-    <skos:scopeNote xml:lang="en">Includes instrumental music designated as fantasia, fancies,
-            fantasies, etc.</skos:scopeNote>
-    <skos:notation>ft</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chance compositions</skos:prefLabel>
-    <skos:definition xml:lang="en">Chance compositions.</skos:definition>
-    <skos:notation>cs</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">polonaises</skos:prefLabel>
-    <skos:definition xml:lang="en">Polonaises.</skos:definition>
-    <skos:notation>po</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">chansons, polyphonic</skos:prefLabel>
-    <skos:definition xml:lang="en">Chansons, polyphonic.</skos:definition>
-    <skos:notation>cp</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">oratorios</skos:prefLabel>
-    <skos:definition xml:lang="en">Oratorios.</skos:definition>
-    <skos:notation>or</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">trio-sonatas</skos:prefLabel>
-    <skos:definition xml:lang="en">Trio-sonatas.</skos:definition>
-    <skos:notation>ts</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">nocturnes</skos:prefLabel>
-    <skos:definition xml:lang="en">Nocturnes.</skos:definition>
-    <skos:notation>nc</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
-    <skos:prefLabel xml:lang="en">multiple forms</skos:prefLabel>
-    <skos:definition xml:lang="en">Multiple forms.</skos:definition>
-    <skos:notation>mu</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_form_of_composition/music_form_of_composition.rdf
+++ b/008/music_form_of_composition/music_form_of_composition.rdf
@@ -1,39 +1,45 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#su">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">suites</skos:prefLabel>
     <skos:definition xml:lang="en">Suites.</skos:definition>
-    <skos:notation>su</skos:notation>
+    <skos:notation xml:lang="en">su</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bt">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballets</skos:prefLabel>
     <skos:definition xml:lang="en">Ballets.</skos:definition>
-    <skos:notation>bt</skos:notation>
+    <skos:notation xml:lang="en">bt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#hy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">hymns</skos:prefLabel>
     <skos:definition xml:lang="en">Hymns.</skos:definition>
-    <skos:notation>hy</skos:notation>
+    <skos:notation xml:lang="en">hy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ms">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">masses</skos:prefLabel>
     <skos:definition xml:lang="en">Masses.</skos:definition>
-    <skos:notation>ms</skos:notation>
+    <skos:notation xml:lang="en">ms</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonies</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonies.</skos:definition>
-    <skos:notation>sy</skos:notation>
+    <skos:notation xml:lang="en">sy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#zz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -51,49 +57,49 @@
             rondos; ragtime music; ricercars; rhapsodies; requiems; square dance music; songs;
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas.</skos:definition>
-    <skos:notation>zz</skos:notation>
+    <skos:notation xml:lang="en">zz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">musical revues and comedies</skos:prefLabel>
     <skos:definition xml:lang="en">Musical revues and comedies.</skos:definition>
-    <skos:notation>mc</skos:notation>
+    <skos:notation xml:lang="en">mc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rq">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">requiems</skos:prefLabel>
     <skos:definition xml:lang="en">Requiems.</skos:definition>
-    <skos:notation>rq</skos:notation>
+    <skos:notation xml:lang="en">rq</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concerti grossi</skos:prefLabel>
     <skos:definition xml:lang="en">Concerti grossi.</skos:definition>
-    <skos:notation>cg</skos:notation>
+    <skos:notation xml:lang="en">cg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#jz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">jazz</skos:prefLabel>
     <skos:definition xml:lang="en">Jazz.</skos:definition>
-    <skos:notation>jz</skos:notation>
+    <skos:notation xml:lang="en">jz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rock music</skos:prefLabel>
     <skos:definition xml:lang="en">Rock music.</skos:definition>
-    <skos:notation>rc</skos:notation>
+    <skos:notation xml:lang="en">rc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">program music</skos:prefLabel>
     <skos:definition xml:lang="en">Program music.</skos:definition>
-    <skos:notation>pg</skos:notation>
+    <skos:notation xml:lang="en">pg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -102,7 +108,7 @@
     <dct:alternative xml:lang="en">MARC21 008/18-19 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the form of composition.</dct:description>
     <skos:scopeNote xml:lang="en">Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music).</skos:scopeNote>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -113,7 +119,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.jsonld"/>
@@ -125,21 +131,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">part-songs</skos:prefLabel>
     <skos:definition xml:lang="en">Part-songs.</skos:definition>
-    <skos:notation>pt</skos:notation>
+    <skos:notation xml:lang="en">pt</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorale preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Chorale preludes.</skos:definition>
-    <skos:notation>cl</skos:notation>
+    <skos:notation xml:lang="en">cl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#op">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">operas</skos:prefLabel>
     <skos:definition xml:lang="en">Operas.</skos:definition>
-    <skos:notation>op</skos:notation>
+    <skos:notation xml:lang="en">op</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#vi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -149,14 +155,14 @@
             secular, from the 16th to 18th centuries. Religious villancicos were usually sung in
             important ceremonies (including Christmas, when these songs were sometimes called
             "pastoradas").</skos:definition>
-    <skos:notation>vi</skos:notation>
+    <skos:notation xml:lang="en">vi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">teatro lirico</skos:prefLabel>
     <skos:definition xml:lang="en">Spanish and Spanish American theatre music.</skos:definition>
-    <skos:notation>tl</skos:notation>
+    <skos:notation xml:lang="en">tl</skos:notation>
     <skos:scopeNote xml:lang="en">Used for a large number of more specific terms which describe
             Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
             "sainetes líricos", "entremeses cómico-lírico," etc.</skos:scopeNote>
@@ -166,14 +172,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">blues</skos:prefLabel>
     <skos:definition xml:lang="en">Blues.</skos:definition>
-    <skos:notation>bl</skos:notation>
+    <skos:notation xml:lang="en">bl</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ca">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chaconnes</skos:prefLabel>
     <skos:definition xml:lang="en">Chaconnes.</skos:definition>
-    <skos:notation>ca</skos:notation>
+    <skos:notation xml:lang="en">ca</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#za">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -183,14 +189,14 @@
     <skos:definition xml:lang="en">Term applicable to all musical plays taking that name, from
             the “fiestas de zarzuela” of the 17th/18th-centuries to the so-called “zarzuela moderna”
             (“modern zarzuela”) from the mid 19th to the mid 20th-century.</skos:definition>
-    <skos:notation>za</skos:notation>
+    <skos:notation xml:lang="en">za</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#wz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">waltzes</skos:prefLabel>
     <skos:definition xml:lang="en">Waltzes.</skos:definition>
-    <skos:notation>wz</skos:notation>
+    <skos:notation xml:lang="en">wz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#dv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -201,28 +207,28 @@
             notturni.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music designated as a divertimento,
             serenade, cassation, divertissement, or a notturno.</skos:scopeNote>
-    <skos:notation>dv</skos:notation>
+    <skos:notation xml:lang="en">dv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ri">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ricercars</skos:prefLabel>
     <skos:definition xml:lang="en">Ricercars.</skos:definition>
-    <skos:notation>ri</skos:notation>
+    <skos:notation xml:lang="en">ri</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">bluegrass music</skos:prefLabel>
     <skos:definition xml:lang="en">Bluegrass music.</skos:definition>
-    <skos:notation>bg</skos:notation>
+    <skos:notation xml:lang="en">bg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#df">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">dance forms</skos:prefLabel>
     <skos:definition xml:lang="en">Dance forms.</skos:definition>
-    <skos:notation>df</skos:notation>
+    <skos:notation xml:lang="en">df</skos:notation>
     <skos:scopeNote xml:lang="en">Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes.</skos:scopeNote>
   </rdf:Description>
@@ -231,14 +237,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ragtime music</skos:prefLabel>
     <skos:definition xml:lang="en">Ragtime music.</skos:definition>
-    <skos:notation>rg</skos:notation>
+    <skos:notation xml:lang="en">rg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fl">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">flamenco</skos:prefLabel>
     <skos:definition xml:lang="en">Flamenco.</skos:definition>
-    <skos:notation>fl</skos:notation>
+    <skos:notation xml:lang="en">fl</skos:notation>
     <skos:scopeNote xml:lang="en">All the Flamenco styles, or "palos", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#bd">
@@ -246,49 +252,49 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">ballads</skos:prefLabel>
     <skos:definition xml:lang="en">Ballads.</skos:definition>
-    <skos:notation>bd</skos:notation>
+    <skos:notation xml:lang="en">bd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cy">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">country music</skos:prefLabel>
     <skos:definition xml:lang="en">Country music.</skos:definition>
-    <skos:notation>cy</skos:notation>
+    <skos:notation xml:lang="en">cy</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mo">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motets</skos:prefLabel>
     <skos:definition xml:lang="en">Motets.</skos:definition>
-    <skos:notation>mo</skos:notation>
+    <skos:notation xml:lang="en">mo</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">preludes</skos:prefLabel>
     <skos:definition xml:lang="en">Preludes.</skos:definition>
-    <skos:notation>pr</skos:notation>
+    <skos:notation xml:lang="en">pr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">carols</skos:prefLabel>
     <skos:definition xml:lang="en">Carols.</skos:definition>
-    <skos:notation>cr</skos:notation>
+    <skos:notation xml:lang="en">cr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mr">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">marches</skos:prefLabel>
     <skos:definition xml:lang="en">Marches.</skos:definition>
-    <skos:notation>mr</skos:notation>
+    <skos:notation xml:lang="en">mr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ps">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passacaglias</skos:prefLabel>
     <skos:definition xml:lang="en">Passacaglias.</skos:definition>
-    <skos:notation>ps</skos:notation>
+    <skos:notation xml:lang="en">ps</skos:notation>
     <skos:scopeNote xml:lang="en">Includes all types of ostinato basses.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#co">
@@ -296,7 +302,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">concertos</skos:prefLabel>
     <skos:definition xml:lang="en">Concertos.</skos:definition>
-    <skos:notation>co</skos:notation>
+    <skos:notation xml:lang="en">co</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#st">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -305,14 +311,14 @@
     <skos:definition xml:lang="en">Studies and exercises.</skos:definition>
     <skos:scopeNote xml:lang="en">Used only when the work is intended for teaching purposes
             (usually entitled Studies, Etudes, etc.).</skos:scopeNote>
-    <skos:notation>st</skos:notation>
+    <skos:notation xml:lang="en">st</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">folk music</skos:prefLabel>
     <skos:definition xml:lang="en">Folk music.</skos:definition>
-    <skos:notation>fm</skos:notation>
+    <skos:notation xml:lang="en">fm</skos:notation>
     <skos:scopeNote xml:lang="en">Includes folk songs, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pp">
@@ -320,70 +326,70 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">popular music</skos:prefLabel>
     <skos:definition xml:lang="en">Popular music.</skos:definition>
-    <skos:notation>pp</skos:notation>
+    <skos:notation xml:lang="en">pp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ov">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">overtures</skos:prefLabel>
     <skos:definition xml:lang="en">Overtures.</skos:definition>
-    <skos:notation>ov</skos:notation>
+    <skos:notation xml:lang="en">ov</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chant, Christian</skos:prefLabel>
     <skos:definition xml:lang="en">Chant, Christian.</skos:definition>
-    <skos:notation>cc</skos:notation>
+    <skos:notation xml:lang="en">cc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#tc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">toccatas</skos:prefLabel>
     <skos:definition xml:lang="en">Toccatas.</skos:definition>
-    <skos:notation>tc</skos:notation>
+    <skos:notation xml:lang="en">tc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rondos</skos:prefLabel>
     <skos:definition xml:lang="en">Rondos.</skos:definition>
-    <skos:notation>rd</skos:notation>
+    <skos:notation xml:lang="en">rd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">symphonic poems</skos:prefLabel>
     <skos:definition xml:lang="en">Symphonic poems.</skos:definition>
-    <skos:notation>sp</skos:notation>
+    <skos:notation xml:lang="en">sp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#fg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">fugues</skos:prefLabel>
     <skos:definition xml:lang="en">Fugues.</skos:definition>
-    <skos:notation>fg</skos:notation>
+    <skos:notation xml:lang="en">fg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sd">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">square dance music</skos:prefLabel>
     <skos:definition xml:lang="en">Square dance music.</skos:definition>
-    <skos:notation>sd</skos:notation>
+    <skos:notation xml:lang="en">sd</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sg">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">songs</skos:prefLabel>
     <skos:definition xml:lang="en">Songs.</skos:definition>
-    <skos:notation>sg</skos:notation>
+    <skos:notation xml:lang="en">sg</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">motion picture music</skos:prefLabel>
     <skos:definition xml:lang="en">Motion picture music.</skos:definition>
-    <skos:notation>mp</skos:notation>
+    <skos:notation xml:lang="en">mp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -391,35 +397,35 @@
     <skos:prefLabel xml:lang="en">canons and rounds</skos:prefLabel>
     <skos:definition xml:lang="en">Canons and rounds. Compositions employing strict imitation
             throughout.</skos:definition>
-    <skos:notation>cn</skos:notation>
+    <skos:notation xml:lang="en">cn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mi">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">minuets</skos:prefLabel>
     <skos:definition xml:lang="en">Minuets.</skos:definition>
-    <skos:notation>mi</skos:notation>
+    <skos:notation xml:lang="en">mi</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#rp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">rhapsodies</skos:prefLabel>
     <skos:definition xml:lang="en">Rhapsodies.</skos:definition>
-    <skos:notation>rp</skos:notation>
+    <skos:notation xml:lang="en">rp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">passion music</skos:prefLabel>
     <skos:definition xml:lang="en">Passion music.</skos:definition>
-    <skos:notation>pm</skos:notation>
+    <skos:notation xml:lang="en">pm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nn">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not applicable</skos:definition>
-    <skos:notation>nn</skos:notation>
+    <skos:notation xml:lang="en">nn</skos:notation>
     <skos:scopeNote xml:lang="en">Used for any item that is a non-music sound recording.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#sn">
@@ -427,42 +433,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Sonatas.</skos:definition>
-    <skos:notation>sn</skos:notation>
+    <skos:notation xml:lang="en">sn</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">mazurkas</skos:prefLabel>
     <skos:definition xml:lang="en">Mazurkas.</skos:definition>
-    <skos:notation>mz</skos:notation>
+    <skos:notation xml:lang="en">mz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#pv">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">pavans</skos:prefLabel>
     <skos:definition xml:lang="en">Pavans.</skos:definition>
-    <skos:notation>pv</skos:notation>
+    <skos:notation xml:lang="en">pv</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cb">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chants, other religions</skos:prefLabel>
     <skos:definition xml:lang="en">Chants, Other religions.</skos:definition>
-    <skos:notation>cb</skos:notation>
+    <skos:notation xml:lang="en">cb</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#an">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">anthems</skos:prefLabel>
     <skos:definition xml:lang="en">Anthems.</skos:definition>
-    <skos:notation>an</skos:notation>
+    <skos:notation xml:lang="en">an</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#uu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown.</skos:definition>
-    <skos:notation>uu</skos:notation>
+    <skos:notation xml:lang="en">uu</skos:notation>
     <skos:scopeNote xml:lang="en">Used when the only indication given is the number of
             instruments and the medium of performance. No structure or genre is given, although they
             may be implied or understood.</skos:scopeNote>
@@ -472,35 +478,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">variations</skos:prefLabel>
     <skos:definition xml:lang="en">Variations.</skos:definition>
-    <skos:notation>vr</skos:notation>
+    <skos:notation xml:lang="en">vr</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#gm">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">gospel music</skos:prefLabel>
     <skos:definition xml:lang="en">Gospel music.</skos:definition>
-    <skos:notation>gm</skos:notation>
+    <skos:notation xml:lang="en">gm</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ch">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chorales</skos:prefLabel>
     <skos:definition xml:lang="en">Chorales.</skos:definition>
-    <skos:notation>ch</skos:notation>
+    <skos:notation xml:lang="en">ch</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ct">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">cantatas</skos:prefLabel>
     <skos:definition xml:lang="en">Cantatas.</skos:definition>
-    <skos:notation>ct</skos:notation>
+    <skos:notation xml:lang="en">ct</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#md">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">madrigals</skos:prefLabel>
     <skos:definition xml:lang="en">Madrigals.</skos:definition>
-    <skos:notation>md</skos:notation>
+    <skos:notation xml:lang="en">md</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cz">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -508,7 +514,7 @@
     <skos:prefLabel xml:lang="en">canzonas</skos:prefLabel>
     <skos:definition xml:lang="en">Canzonas.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for instrumental music that is designated as a canzona.</skos:scopeNote>
-    <skos:notation>cz</skos:notation>
+    <skos:notation xml:lang="en">cz</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ft">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -517,55 +523,55 @@
     <skos:definition xml:lang="en">Fantasias.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes instrumental music designated as fantasia, fancies,
             fantasies, etc.</skos:scopeNote>
-    <skos:notation>ft</skos:notation>
+    <skos:notation xml:lang="en">ft</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cs">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chance compositions</skos:prefLabel>
     <skos:definition xml:lang="en">Chance compositions.</skos:definition>
-    <skos:notation>cs</skos:notation>
+    <skos:notation xml:lang="en">cs</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#po">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">polonaises</skos:prefLabel>
     <skos:definition xml:lang="en">Polonaises.</skos:definition>
-    <skos:notation>po</skos:notation>
+    <skos:notation xml:lang="en">po</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#cp">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">chansons, polyphonic</skos:prefLabel>
     <skos:definition xml:lang="en">Chansons, polyphonic.</skos:definition>
-    <skos:notation>cp</skos:notation>
+    <skos:notation xml:lang="en">cp</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#or">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">oratorios</skos:prefLabel>
     <skos:definition xml:lang="en">Oratorios.</skos:definition>
-    <skos:notation>or</skos:notation>
+    <skos:notation xml:lang="en">or</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#ts">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">trio-sonatas</skos:prefLabel>
     <skos:definition xml:lang="en">Trio-sonatas.</skos:definition>
-    <skos:notation>ts</skos:notation>
+    <skos:notation xml:lang="en">ts</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#nc">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">nocturnes</skos:prefLabel>
     <skos:definition xml:lang="en">Nocturnes.</skos:definition>
-    <skos:notation>nc</skos:notation>
+    <skos:notation xml:lang="en">nc</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.8rpj-ek77#mu">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.8rpj-ek77"/>
     <skos:prefLabel xml:lang="en">multiple forms</skos:prefLabel>
     <skos:definition xml:lang="en">Multiple forms.</skos:definition>
-    <skos:notation>mu</skos:notation>
+    <skos:notation xml:lang="en">mu</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_form_of_composition/music_form_of_composition.ttl
+++ b/008/music_form_of_composition/music_form_of_composition.ttl
@@ -6,123 +6,123 @@
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#an> a skos:Concept ;
     skos:definition "Anthems."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "an"@en ;
+    skos:notation "an" ;
     skos:prefLabel "anthems"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#bd> a skos:Concept ;
     skos:definition "Ballads."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "bd"@en ;
+    skos:notation "bd" ;
     skos:prefLabel "ballads"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#bg> a skos:Concept ;
     skos:definition "Bluegrass music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "bg"@en ;
+    skos:notation "bg" ;
     skos:prefLabel "bluegrass music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#bl> a skos:Concept ;
     skos:definition "Blues."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "bl"@en ;
+    skos:notation "bl" ;
     skos:prefLabel "blues"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#bt> a skos:Concept ;
     skos:definition "Ballets."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "bt"@en ;
+    skos:notation "bt" ;
     skos:prefLabel "ballets"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ca> a skos:Concept ;
     skos:definition "Chaconnes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ca"@en ;
+    skos:notation "ca" ;
     skos:prefLabel "chaconnes"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cb> a skos:Concept ;
     skos:definition "Chants, Other religions."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cb"@en ;
+    skos:notation "cb" ;
     skos:prefLabel "chants, other religions"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cc> a skos:Concept ;
     skos:definition "Chant, Christian."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cc"@en ;
+    skos:notation "cc" ;
     skos:prefLabel "chant, Christian"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cg> a skos:Concept ;
     skos:definition "Concerti grossi."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cg"@en ;
+    skos:notation "cg" ;
     skos:prefLabel "concerti grossi"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ch> a skos:Concept ;
     skos:definition "Chorales."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ch"@en ;
+    skos:notation "ch" ;
     skos:prefLabel "chorales"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cl> a skos:Concept ;
     skos:definition "Chorale preludes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cl"@en ;
+    skos:notation "cl" ;
     skos:prefLabel "chorale preludes"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cn> a skos:Concept ;
     skos:definition """Canons and rounds. Compositions employing strict imitation
             throughout."""@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cn"@en ;
+    skos:notation "cn" ;
     skos:prefLabel "canons and rounds"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#co> a skos:Concept ;
     skos:definition "Concertos."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "co"@en ;
+    skos:notation "co" ;
     skos:prefLabel "concertos"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cp> a skos:Concept ;
     skos:definition "Chansons, polyphonic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cp"@en ;
+    skos:notation "cp" ;
     skos:prefLabel "chansons, polyphonic"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cr> a skos:Concept ;
     skos:definition "Carols."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cr"@en ;
+    skos:notation "cr" ;
     skos:prefLabel "carols"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cs> a skos:Concept ;
     skos:definition "Chance compositions."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cs"@en ;
+    skos:notation "cs" ;
     skos:prefLabel "chance compositions"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ct> a skos:Concept ;
     skos:definition "Cantatas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ct"@en ;
+    skos:notation "ct" ;
     skos:prefLabel "cantatas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cy> a skos:Concept ;
     skos:definition "Country music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cy"@en ;
+    skos:notation "cy" ;
     skos:prefLabel "country music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#cz> a skos:Concept ;
     skos:definition "Canzonas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "cz"@en ;
+    skos:notation "cz" ;
     skos:prefLabel "canzonas"@en ;
     skos:scopeNote "Used for instrumental music that is designated as a canzona."@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#df> a skos:Concept ;
     skos:definition "Dance forms."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "df"@en ;
+    skos:notation "df" ;
     skos:prefLabel "dance forms"@en ;
     skos:scopeNote """Includes music for individual dances except for mazurkas,
             minuets, pavans, polonaises, and waltzes."""@en .
@@ -131,7 +131,7 @@
     skos:definition """Divertimentos, serenades, cassations, divertissements, and
             notturni."""@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "dv"@en ;
+    skos:notation "dv" ;
     skos:prefLabel """divertimentos, serenades, cassations, divertissements, and
             notturni"""@en ;
     skos:scopeNote """Used for instrumental music designated as a divertimento,
@@ -140,27 +140,27 @@
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#fg> a skos:Concept ;
     skos:definition "Fugues."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "fg"@en ;
+    skos:notation "fg" ;
     skos:prefLabel "fugues"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#fl> a skos:Concept ;
     skos:definition "Flamenco."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "fl"@en ;
+    skos:notation "fl" ;
     skos:prefLabel "flamenco"@en ;
     skos:scopeNote "All the Flamenco styles, or \"palos\", and other forms of song and dance coming from the folkloric tradition of Spanish gypsies."@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#fm> a skos:Concept ;
     skos:definition "Folk music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "fm"@en ;
+    skos:notation "fm" ;
     skos:prefLabel "folk music"@en ;
     skos:scopeNote "Includes folk songs, etc."@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ft> a skos:Concept ;
     skos:definition "Fantasias."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ft"@en ;
+    skos:notation "ft" ;
     skos:prefLabel "fantasias"@en ;
     skos:scopeNote """Includes instrumental music designated as fantasia, fancies,
             fantasies, etc."""@en .
@@ -168,219 +168,219 @@
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#gm> a skos:Concept ;
     skos:definition "Gospel music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "gm"@en ;
+    skos:notation "gm" ;
     skos:prefLabel "gospel music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#hy> a skos:Concept ;
     skos:definition "Hymns."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "hy"@en ;
+    skos:notation "hy" ;
     skos:prefLabel "hymns"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#jz> a skos:Concept ;
     skos:definition "Jazz."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "jz"@en ;
+    skos:notation "jz" ;
     skos:prefLabel "jazz"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mc> a skos:Concept ;
     skos:definition "Musical revues and comedies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mc"@en ;
+    skos:notation "mc" ;
     skos:prefLabel "musical revues and comedies"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#md> a skos:Concept ;
     skos:definition "Madrigals."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "md"@en ;
+    skos:notation "md" ;
     skos:prefLabel "madrigals"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mi> a skos:Concept ;
     skos:definition "Minuets."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mi"@en ;
+    skos:notation "mi" ;
     skos:prefLabel "minuets"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mo> a skos:Concept ;
     skos:definition "Motets."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mo"@en ;
+    skos:notation "mo" ;
     skos:prefLabel "motets"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mp> a skos:Concept ;
     skos:definition "Motion picture music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mp"@en ;
+    skos:notation "mp" ;
     skos:prefLabel "motion picture music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mr> a skos:Concept ;
     skos:definition "Marches."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mr"@en ;
+    skos:notation "mr" ;
     skos:prefLabel "marches"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ms> a skos:Concept ;
     skos:definition "Masses."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ms"@en ;
+    skos:notation "ms" ;
     skos:prefLabel "masses"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mu> a skos:Concept ;
     skos:definition "Multiple forms."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mu"@en ;
+    skos:notation "mu" ;
     skos:prefLabel "multiple forms"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#mz> a skos:Concept ;
     skos:definition "Mazurkas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "mz"@en ;
+    skos:notation "mz" ;
     skos:prefLabel "mazurkas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#nc> a skos:Concept ;
     skos:definition "Nocturnes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "nc"@en ;
+    skos:notation "nc" ;
     skos:prefLabel "nocturnes"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#nn> a skos:Concept ;
     skos:definition "Not applicable"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "nn"@en ;
+    skos:notation "nn" ;
     skos:prefLabel "not applicable"@en ;
     skos:scopeNote "Used for any item that is a non-music sound recording."@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#op> a skos:Concept ;
     skos:definition "Operas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "op"@en ;
+    skos:notation "op" ;
     skos:prefLabel "operas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#or> a skos:Concept ;
     skos:definition "Oratorios."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "or"@en ;
+    skos:notation "or" ;
     skos:prefLabel "oratorios"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ov> a skos:Concept ;
     skos:definition "Overtures."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ov"@en ;
+    skos:notation "ov" ;
     skos:prefLabel "overtures"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pg> a skos:Concept ;
     skos:definition "Program music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pg"@en ;
+    skos:notation "pg" ;
     skos:prefLabel "program music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pm> a skos:Concept ;
     skos:definition "Passion music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pm"@en ;
+    skos:notation "pm" ;
     skos:prefLabel "passion music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#po> a skos:Concept ;
     skos:definition "Polonaises."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "po"@en ;
+    skos:notation "po" ;
     skos:prefLabel "polonaises"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pp> a skos:Concept ;
     skos:definition "Popular music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pp"@en ;
+    skos:notation "pp" ;
     skos:prefLabel "popular music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pr> a skos:Concept ;
     skos:definition "Preludes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pr"@en ;
+    skos:notation "pr" ;
     skos:prefLabel "preludes"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ps> a skos:Concept ;
     skos:definition "Passacaglias."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ps"@en ;
+    skos:notation "ps" ;
     skos:prefLabel "passacaglias"@en ;
     skos:scopeNote "Includes all types of ostinato basses."@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pt> a skos:Concept ;
     skos:definition "Part-songs."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pt"@en ;
+    skos:notation "pt" ;
     skos:prefLabel "part-songs"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#pv> a skos:Concept ;
     skos:definition "Pavans."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "pv"@en ;
+    skos:notation "pv" ;
     skos:prefLabel "pavans"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#rc> a skos:Concept ;
     skos:definition "Rock music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "rc"@en ;
+    skos:notation "rc" ;
     skos:prefLabel "rock music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#rd> a skos:Concept ;
     skos:definition "Rondos."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "rd"@en ;
+    skos:notation "rd" ;
     skos:prefLabel "rondos"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#rg> a skos:Concept ;
     skos:definition "Ragtime music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "rg"@en ;
+    skos:notation "rg" ;
     skos:prefLabel "ragtime music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ri> a skos:Concept ;
     skos:definition "Ricercars."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ri"@en ;
+    skos:notation "ri" ;
     skos:prefLabel "ricercars"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#rp> a skos:Concept ;
     skos:definition "Rhapsodies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "rp"@en ;
+    skos:notation "rp" ;
     skos:prefLabel "rhapsodies"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#rq> a skos:Concept ;
     skos:definition "Requiems."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "rq"@en ;
+    skos:notation "rq" ;
     skos:prefLabel "requiems"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#sd> a skos:Concept ;
     skos:definition "Square dance music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "sd"@en ;
+    skos:notation "sd" ;
     skos:prefLabel "square dance music"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#sg> a skos:Concept ;
     skos:definition "Songs."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "sg"@en ;
+    skos:notation "sg" ;
     skos:prefLabel "songs"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#sn> a skos:Concept ;
     skos:definition "Sonatas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "sn"@en ;
+    skos:notation "sn" ;
     skos:prefLabel "sonatas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#sp> a skos:Concept ;
     skos:definition "Symphonic poems."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "sp"@en ;
+    skos:notation "sp" ;
     skos:prefLabel "symphonic poems"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#st> a skos:Concept ;
     skos:definition "Studies and exercises."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "st"@en ;
+    skos:notation "st" ;
     skos:prefLabel "studies and exercises"@en ;
     skos:scopeNote """Used only when the work is intended for teaching purposes
             (usually entitled Studies, Etudes, etc.)."""@en .
@@ -388,25 +388,25 @@
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#su> a skos:Concept ;
     skos:definition "Suites."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "su"@en ;
+    skos:notation "su" ;
     skos:prefLabel "suites"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#sy> a skos:Concept ;
     skos:definition "Symphonies."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "sy"@en ;
+    skos:notation "sy" ;
     skos:prefLabel "symphonies"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#tc> a skos:Concept ;
     skos:definition "Toccatas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "tc"@en ;
+    skos:notation "tc" ;
     skos:prefLabel "toccatas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#tl> a skos:Concept ;
     skos:definition "Spanish and Spanish American theatre music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "tl"@en ;
+    skos:notation "tl" ;
     skos:prefLabel "teatro lirico"@en ;
     skos:scopeNote """Used for a large number of more specific terms which describe
             Spanish and Spanish American theatre music: "tonadilla escénica", "fiestas de música",
@@ -415,13 +415,13 @@
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#ts> a skos:Concept ;
     skos:definition "Trio-sonatas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "ts"@en ;
+    skos:notation "ts" ;
     skos:prefLabel "trio-sonatas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#uu> a skos:Concept ;
     skos:definition "Unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "uu"@en ;
+    skos:notation "uu" ;
     skos:prefLabel "unknown"@en ;
     skos:scopeNote """Used when the only indication given is the number of
             instruments and the medium of performance. No structure or genre is given, although they
@@ -433,19 +433,19 @@
             important ceremonies (including Christmas, when these songs were sometimes called
             "pastoradas")."""@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "vi"@en ;
+    skos:notation "vi" ;
     skos:prefLabel "villancicos"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#vr> a skos:Concept ;
     skos:definition "Variations."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "vr"@en ;
+    skos:notation "vr" ;
     skos:prefLabel "variations"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#wz> a skos:Concept ;
     skos:definition "Waltzes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "wz"@en ;
+    skos:notation "wz" ;
     skos:prefLabel "waltzes"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#za> a skos:Concept ;
@@ -454,7 +454,7 @@
             (“modern zarzuela”) from the mid 19th to the mid 20th-century."""@en,
         "Zarzuelas."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "za"@en ;
+    skos:notation "za" ;
     skos:prefLabel "zarzuelas"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77#zz> a skos:Concept ;
@@ -471,7 +471,7 @@
             sonatas; symphonic poems; studies and exercises; suites; symphonies; toccatas; teatro
             lirico; trio-sonatas; villancicos; variations; waltzes, or zarzuelas."""@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.8rpj-ek77> ;
-    skos:notation "zz"@en ;
+    skos:notation "zz" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.8rpj-ek77> a skos:ConceptScheme ;
@@ -488,13 +488,13 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_form_of_composition/music_form_of_composition.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: form of composition"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
     skos:scopeNote "Is based on the terminology in the work itself. Also includes musical genres (e.g., Ragtime music)."@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_format_of_music/music_format_of_music.html
+++ b/008/music_format_of_music/music_format_of_music.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
                         <td id="a">
@@ -367,7 +367,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
                         <td>
@@ -466,7 +466,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#c">
                         <td>
@@ -524,7 +524,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#d">
                         <td>
@@ -585,7 +585,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
                         <td>
@@ -634,7 +634,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
                         <td>
@@ -685,7 +685,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#h">
                         <td>
@@ -735,7 +735,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#i">
                         <td>
@@ -794,7 +794,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
                         <td>
@@ -844,7 +844,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
                         <td>
@@ -895,7 +895,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#l">
                         <td>
@@ -944,7 +944,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#m">
                         <td>
@@ -993,7 +993,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
                         <td>
@@ -1043,7 +1043,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
                         <td>
@@ -1101,7 +1101,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#u">
                         <td>
@@ -1153,7 +1153,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
                         <td>
@@ -1177,26 +1177,26 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;performer-conductor part&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;condensed score or piano-conductor score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;close score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score (e.g., a hymnal) that has separate parts transcribed in condensed form.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;vocal score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;multiple score formats&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Several types of scores are issued together, as is frequently the case with band music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1204,110 +1204,44 @@
     &lt;dct:title xml:lang="en"&gt;Music: format of music&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/20 values for music expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the format of a musical composition (e.g., piano-conductor score).&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;condensed score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for: Reduced score, Short score.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Format of the item is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;condensed score or piano-conductor score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#h"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;chorus score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;vocal score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;performer-conductor part&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;voice score with accompaniment omitted&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score for solo and/or choral voice(s) with the accompaniment omitted.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for vocal works originally unaccompanied.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;miniature or study score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;full score&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item is a sound recording.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;accompaniment reduced for keyboard&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Score with instrumental accompaniment reduced for keyboard(s).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for chorus scores and vocal scores.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1315,7 +1249,73 @@
     &lt;skos:prefLabel xml:lang="en"&gt;piano score&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;A reduction of an instrumental work or a vocal work with instruments to a version for piano.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;May include the words of a vocal work.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;condensed score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for: Reduced score, Short score.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;chorus score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item is a sound recording.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;full score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;close score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score (e.g., a hymnal) that has separate parts transcribed in condensed form.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;miniature or study score&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;voice score with accompaniment omitted&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score for solo and/or choral voice(s) with the accompaniment omitted.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for vocal works originally unaccompanied.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;accompaniment reduced for keyboard&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Score with instrumental accompaniment reduced for keyboard(s).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for chorus scores and vocal scores.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1330,101 +1330,101 @@
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; a skos:Concept ;
     skos:definition "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "full score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; a skos:Concept ;
     skos:definition "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "miniature or study score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; a skos:Concept ;
     skos:definition "Score with instrumental accompaniment reduced for keyboard(s)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "accompaniment reduced for keyboard"@en ;
     skos:scopeNote "Not used for chorus scores and vocal scores."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; a skos:Concept ;
     skos:definition "Score for solo and/or choral voice(s) with the accompaniment omitted."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "voice score with accompaniment omitted"@en ;
     skos:scopeNote "Not used for vocal works originally unaccompanied."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; a skos:Concept ;
     skos:definition "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "condensed score or piano-conductor score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; a skos:Concept ;
     skos:definition "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "close score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; a skos:Concept ;
     skos:definition "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "chorus score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; a skos:Concept ;
     skos:definition "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "condensed score"@en ;
     skos:scopeNote "Used for: Reduced score, Short score."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; a skos:Concept ;
     skos:definition "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "performer-conductor part"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; a skos:Concept ;
     skos:definition "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "vocal score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; a skos:Concept ;
     skos:definition "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "score"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; a skos:Concept ;
     skos:definition "Several types of scores are issued together, as is frequently the case with band music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multiple score formats"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; a skos:Concept ;
     skos:definition "Item is a sound recording."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; a skos:Concept ;
     skos:definition "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "piano score"@en ;
     skos:scopeNote "May include the words of a vocal work."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; a skos:Concept ;
     skos:definition "Format of the item is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; a skos:Concept ;
     skos:definition "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; a skos:ConceptScheme ;
@@ -1441,304 +1441,130 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: format of music"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple score formats"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/20 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorus score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "vocal score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "condensed score or piano-conductor score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score for solo and/or choral voice(s) with the accompaniment omitted."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Several types of scores are issued together, as is frequently the case with band music."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/20 values for music expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the format of a musical composition (e.g., piano-conductor score)."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "condensed score or piano-conductor score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "piano score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: format of music"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chorus score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Format of the item is unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "miniature or study score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for vocal works originally unaccompanied."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score with instrumental accompaniment reduced for keyboard(s)."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "voice score with accompaniment omitted"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "accompaniment reduced for keyboard"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "close score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is a sound recording."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for chorus scores and vocal scores."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Several types of scores are issued together, as is frequently the case with band music."@en .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "score"@en .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Format of the item is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score with instrumental accompaniment reduced for keyboard(s)."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is a sound recording."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "close score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for: Reduced score, Short score."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "miniature or study score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "full score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "piano score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "accompaniment reduced for keyboard"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: format of music"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "performer-conductor part"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for vocal works originally unaccompanied."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the format of a musical composition (e.g., piano-conductor score)."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for chorus scores and vocal scores."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "condensed score"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May include the words of a vocal work."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multiple score formats"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "performer-conductor part"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Score for solo and/or choral voice(s) with the accompaniment omitted."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for: Reduced score, Short score."@en .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "voice score with accompaniment omitted"@en .
-&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "vocal score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "full score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "condensed score"@en .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.06xx-6744#p&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May include the words of a vocal work."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "performer-conductor part"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "vocal score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Format of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "miniature or study score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is a sound recording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "full score"
-      }
-    ]
-  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#h",
     "@type": [
@@ -1757,7 +1583,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -1765,134 +1590,6 @@
       {
         "@language": "en",
         "@value": "chorus score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score for solo and/or choral voice(s) with the accompaniment omitted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "voice score with accompaniment omitted"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for vocal works originally unaccompanied."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "condensed score"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for: Reduced score, Short score."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "condensed score or piano-conductor score"
       }
     ]
   },
@@ -1914,7 +1611,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -1922,41 +1618,6 @@
       {
         "@language": "en",
         "@value": "multiple score formats"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score with instrumental accompaniment reduced for keyboard(s)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "accompaniment reduced for keyboard"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for chorus scores and vocal scores."
       }
     ]
   },
@@ -1978,7 +1639,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],
@@ -1992,6 +1652,34 @@
       {
         "@language": "en",
         "@value": "May include the words of a vocal work."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item is a sound recording."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
       }
     ]
   },
@@ -2013,7 +1701,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -2021,6 +1708,68 @@
       {
         "@language": "en",
         "@value": "close score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "condensed score or piano-conductor score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score with instrumental accompaniment reduced for keyboard(s)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "accompaniment reduced for keyboard"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for chorus scores and vocal scores."
       }
     ]
   },
@@ -2042,7 +1791,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -2050,6 +1798,34 @@
       {
         "@language": "en",
         "@value": "score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
       }
     ]
   },
@@ -2122,7 +1898,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -2151,12 +1927,221 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "performer-conductor part"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "full score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "vocal score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score for solo and/or choral voice(s) with the accompaniment omitted."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "voice score with accompaniment omitted"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for vocal works originally unaccompanied."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "condensed score"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for: Reduced score, Short score."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "miniature or study score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Format of the item is unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
       }
     ]
   }

--- a/008/music_format_of_music/music_format_of_music.jsonld
+++ b/008/music_format_of_music/music_format_of_music.jsonld
@@ -1,179 +1,5 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "performer-conductor part"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "vocal score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Format of the item is unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "miniature or study score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is a sound recording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "full score"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#h",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -191,7 +17,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "h"
       }
     ],
@@ -199,134 +24,6 @@
       {
         "@language": "en",
         "@value": "chorus score"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score for solo and/or choral voice(s) with the accompaniment omitted."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "voice score with accompaniment omitted"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for vocal works originally unaccompanied."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "condensed score"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for: Reduced score, Short score."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "condensed score or piano-conductor score"
       }
     ]
   },
@@ -348,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -356,41 +52,6 @@
       {
         "@language": "en",
         "@value": "multiple score formats"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Score with instrumental accompaniment reduced for keyboard(s)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "accompaniment reduced for keyboard"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not used for chorus scores and vocal scores."
       }
     ]
   },
@@ -412,7 +73,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "p"
       }
     ],
@@ -426,6 +86,34 @@
       {
         "@language": "en",
         "@value": "May include the words of a vocal work."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item is a sound recording."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
       }
     ]
   },
@@ -447,7 +135,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "g"
       }
     ],
@@ -455,6 +142,68 @@
       {
         "@language": "en",
         "@value": "close score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "condensed score or piano-conductor score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score with instrumental accompaniment reduced for keyboard(s)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "accompaniment reduced for keyboard"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for chorus scores and vocal scores."
       }
     ]
   },
@@ -476,7 +225,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -484,6 +232,34 @@
       {
         "@language": "en",
         "@value": "score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
       }
     ]
   },
@@ -556,7 +332,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -585,12 +361,221 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "performer-conductor part"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "full score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "vocal score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score for solo and/or choral voice(s) with the accompaniment omitted."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "voice score with accompaniment omitted"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not used for vocal works originally unaccompanied."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "condensed score"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for: Reduced score, Short score."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "miniature or study score"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.06xx-6744#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Format of the item is unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.06xx-6744"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
       }
     ]
   }

--- a/008/music_format_of_music/music_format_of_music.nt
+++ b/008/music_format_of_music/music_format_of_music.nt
@@ -1,106 +1,106 @@
-<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#definition> "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple score formats"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/alternative> "MARC21 008/20 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#definition> "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorus score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#definition> "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "vocal score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "condensed score or piano-conductor score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#definition> "Score for solo and/or choral voice(s) with the accompaniment omitted."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#definition> "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#definition> "Several types of scores are issued together, as is frequently the case with band music."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/alternative> "MARC21 008/20 values for music expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/description> "Indicates the format of a musical composition (e.g., piano-conductor score)."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "condensed score or piano-conductor score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#definition> "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#definition> "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "piano score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/title> "Music: format of music"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#definition> "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "chorus score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#definition> "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#definition> "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#definition> "Format of the item is unknown."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "miniature or study score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#definition> "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for vocal works originally unaccompanied."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#definition> "Score with instrumental accompaniment reduced for keyboard(s)."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "voice score with accompaniment omitted"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "accompaniment reduced for keyboard"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "close score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is a sound recording."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for chorus scores and vocal scores."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#definition> "Several types of scores are issued together, as is frequently the case with band music."@en .
 <https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "score"@en .
 <https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#definition> "Format of the item is unknown."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#definition> "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#definition> "Score with instrumental accompaniment reduced for keyboard(s)."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#definition> "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is a sound recording."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "close score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#definition> "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for: Reduced score, Short score."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "miniature or study score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "full score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "piano score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "accompaniment reduced for keyboard"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/title> "Music: format of music"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "performer-conductor part"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for vocal works originally unaccompanied."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#definition> "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
 <https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/description> "Indicates the format of a musical composition (e.g., piano-conductor score)."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for chorus scores and vocal scores."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "condensed score"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#scopeNote> "May include the words of a vocal work."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
 <https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#definition> "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#definition> "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#definition> "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multiple score formats"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "performer-conductor part"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#h> <http://www.w3.org/2004/02/skos/core#definition> "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#definition> "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#definition> "Score for solo and/or choral voice(s) with the accompaniment omitted."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for: Reduced score, Short score."@en .
 <https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#definition> "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
-<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "voice score with accompaniment omitted"@en .
-<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/elements/1.1/language> "en" .
 <https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html> .
 <https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#definition> "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "vocal score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "full score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.06xx-6744> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.06xx-6744#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "condensed score"@en .
+<https://doi.org/10.6069/uwlswd.06xx-6744> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.06xx-6744#p> <http://www.w3.org/2004/02/skos/core#scopeNote> "May include the words of a vocal work."@en .

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -1,18 +1,24 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">performer-conductor part</skos:prefLabel>
-    <skos:definition xml:lang="en">A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:prefLabel xml:lang="en">condensed score or piano-conductor score</skos:prefLabel>
+    <skos:definition xml:lang="en">Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.</skos:definition>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">close score</skos:prefLabel>
-    <skos:definition xml:lang="en">Score (e.g., a hymnal) that has separate parts transcribed in condensed form.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:prefLabel xml:lang="en">vocal score</skos:prefLabel>
+    <skos:definition xml:lang="en">Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -45,14 +51,6 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">condensed score</skos:prefLabel>
-    <skos:definition xml:lang="en">A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used for: Reduced score, Short score.</skos:scopeNote>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
@@ -60,12 +58,35 @@
     <skos:definition xml:lang="en">Format of the item is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">condensed score or piano-conductor score</skos:prefLabel>
-    <skos:definition xml:lang="en">Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:prefLabel xml:lang="en">performer-conductor part</skos:prefLabel>
+    <skos:definition xml:lang="en">A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.</skos:definition>
+    <skos:notation>z</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
+    <skos:prefLabel xml:lang="en">piano score</skos:prefLabel>
+    <skos:definition xml:lang="en">A reduction of an instrumental work or a vocal work with instruments to a version for piano.</skos:definition>
+    <skos:scopeNote xml:lang="en">May include the words of a vocal work.</skos:scopeNote>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
+    <skos:prefLabel xml:lang="en">condensed score</skos:prefLabel>
+    <skos:definition xml:lang="en">A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used for: Reduced score, Short score.</skos:scopeNote>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -81,19 +102,33 @@
     <skos:definition xml:lang="en">Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
     <skos:notation>h</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">vocal score</skos:prefLabel>
-    <skos:definition xml:lang="en">Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
+    <skos:definition xml:lang="en">Item is a sound recording.</skos:definition>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:prefLabel xml:lang="en">full score</skos:prefLabel>
+    <skos:definition xml:lang="en">Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
+    <skos:prefLabel xml:lang="en">close score</skos:prefLabel>
+    <skos:definition xml:lang="en">Score (e.g., a hymnal) that has separate parts transcribed in condensed form.</skos:definition>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
+    <skos:prefLabel xml:lang="en">miniature or study score</skos:prefLabel>
+    <skos:definition xml:lang="en">Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.</skos:definition>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -103,27 +138,6 @@
     <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for vocal works originally unaccompanied.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">miniature or study score</skos:prefLabel>
-    <skos:definition xml:lang="en">Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.</skos:definition>
-    <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">full score</skos:prefLabel>
-    <skos:definition xml:lang="en">Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
-    <skos:definition xml:lang="en">Item is a sound recording.</skos:definition>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
@@ -131,13 +145,5 @@
     <skos:definition xml:lang="en">Score with instrumental accompaniment reduced for keyboard(s).</skos:definition>
     <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for chorus scores and vocal scores.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
-    <skos:prefLabel xml:lang="en">piano score</skos:prefLabel>
-    <skos:definition xml:lang="en">A reduction of an instrumental work or a vocal work with instruments to a version for piano.</skos:definition>
-    <skos:scopeNote xml:lang="en">May include the words of a vocal work.</skos:scopeNote>
-    <skos:notation>p</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -1,31 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">performer-conductor part</skos:prefLabel>
     <skos:definition xml:lang="en">A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">close score</skos:prefLabel>
     <skos:definition xml:lang="en">Score (e.g., a hymnal) that has separate parts transcribed in condensed form.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">multiple score formats</skos:prefLabel>
     <skos:definition xml:lang="en">Several types of scores are issued together, as is frequently the case with band music.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -33,7 +27,7 @@
     <dct:title xml:lang="en">Music: format of music</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/20 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the format of a musical composition (e.g., piano-conductor score).</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -44,7 +38,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld"/>
@@ -57,56 +51,56 @@
     <skos:prefLabel xml:lang="en">condensed score</skos:prefLabel>
     <skos:definition xml:lang="en">A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for: Reduced score, Short score.</skos:scopeNote>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Format of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">condensed score or piano-conductor score</skos:prefLabel>
     <skos:definition xml:lang="en">Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">score</skos:prefLabel>
     <skos:definition xml:lang="en">Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">chorus score</skos:prefLabel>
     <skos:definition xml:lang="en">Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">vocal score</skos:prefLabel>
     <skos:definition xml:lang="en">Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">voice score with accompaniment omitted</skos:prefLabel>
     <skos:definition xml:lang="en">Score for solo and/or choral voice(s) with the accompaniment omitted.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for vocal works originally unaccompanied.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
@@ -114,28 +108,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">miniature or study score</skos:prefLabel>
     <skos:definition xml:lang="en">Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">full score</skos:prefLabel>
     <skos:definition xml:lang="en">Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a sound recording.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">accompaniment reduced for keyboard</skos:prefLabel>
     <skos:definition xml:lang="en">Score with instrumental accompaniment reduced for keyboard(s).</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for chorus scores and vocal scores.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
@@ -144,6 +138,6 @@
     <skos:prefLabel xml:lang="en">piano score</skos:prefLabel>
     <skos:definition xml:lang="en">A reduction of an instrumental work or a vocal work with instruments to a version for piano.</skos:definition>
     <skos:scopeNote xml:lang="en">May include the words of a vocal work.</skos:scopeNote>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -1,25 +1,31 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">performer-conductor part</skos:prefLabel>
     <skos:definition xml:lang="en">A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">close score</skos:prefLabel>
     <skos:definition xml:lang="en">Score (e.g., a hymnal) that has separate parts transcribed in condensed form.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">multiple score formats</skos:prefLabel>
     <skos:definition xml:lang="en">Several types of scores are issued together, as is frequently the case with band music.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -27,7 +33,7 @@
     <dct:title xml:lang="en">Music: format of music</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/20 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the format of a musical composition (e.g., piano-conductor score).</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -38,7 +44,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld"/>
@@ -51,56 +57,56 @@
     <skos:prefLabel xml:lang="en">condensed score</skos:prefLabel>
     <skos:definition xml:lang="en">A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for: Reduced score, Short score.</skos:scopeNote>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Format of the item is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">condensed score or piano-conductor score</skos:prefLabel>
     <skos:definition xml:lang="en">Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">score</skos:prefLabel>
     <skos:definition xml:lang="en">Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">chorus score</skos:prefLabel>
     <skos:definition xml:lang="en">Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">vocal score</skos:prefLabel>
     <skos:definition xml:lang="en">Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">voice score with accompaniment omitted</skos:prefLabel>
     <skos:definition xml:lang="en">Score for solo and/or choral voice(s) with the accompaniment omitted.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for vocal works originally unaccompanied.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
@@ -108,28 +114,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">miniature or study score</skos:prefLabel>
     <skos:definition xml:lang="en">Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">full score</skos:prefLabel>
     <skos:definition xml:lang="en">Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a sound recording.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">accompaniment reduced for keyboard</skos:prefLabel>
     <skos:definition xml:lang="en">Score with instrumental accompaniment reduced for keyboard(s).</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for chorus scores and vocal scores.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
@@ -138,6 +144,6 @@
     <skos:prefLabel xml:lang="en">piano score</skos:prefLabel>
     <skos:definition xml:lang="en">A reduction of an instrumental work or a vocal work with instruments to a version for piano.</skos:definition>
     <skos:scopeNote xml:lang="en">May include the words of a vocal work.</skos:scopeNote>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -1,31 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">performer-conductor part</skos:prefLabel>
     <skos:definition xml:lang="en">A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">close score</skos:prefLabel>
     <skos:definition xml:lang="en">Score (e.g., a hymnal) that has separate parts transcribed in condensed form.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">multiple score formats</skos:prefLabel>
     <skos:definition xml:lang="en">Several types of scores are issued together, as is frequently the case with band music.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -33,7 +27,7 @@
     <dct:title xml:lang="en">Music: format of music</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/20 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the format of a musical composition (e.g., piano-conductor score).</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -57,56 +51,56 @@
     <skos:prefLabel xml:lang="en">condensed score</skos:prefLabel>
     <skos:definition xml:lang="en">A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for: Reduced score, Short score.</skos:scopeNote>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Format of the item is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">condensed score or piano-conductor score</skos:prefLabel>
     <skos:definition xml:lang="en">Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">score</skos:prefLabel>
     <skos:definition xml:lang="en">Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">chorus score</skos:prefLabel>
     <skos:definition xml:lang="en">Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">vocal score</skos:prefLabel>
     <skos:definition xml:lang="en">Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">voice score with accompaniment omitted</skos:prefLabel>
     <skos:definition xml:lang="en">Score for solo and/or choral voice(s) with the accompaniment omitted.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for vocal works originally unaccompanied.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#b">
@@ -114,28 +108,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">miniature or study score</skos:prefLabel>
     <skos:definition xml:lang="en">Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">full score</skos:prefLabel>
     <skos:definition xml:lang="en">Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a sound recording.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.06xx-6744"/>
     <skos:prefLabel xml:lang="en">accompaniment reduced for keyboard</skos:prefLabel>
     <skos:definition xml:lang="en">Score with instrumental accompaniment reduced for keyboard(s).</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for chorus scores and vocal scores.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.06xx-6744#p">
@@ -144,6 +138,6 @@
     <skos:prefLabel xml:lang="en">piano score</skos:prefLabel>
     <skos:definition xml:lang="en">A reduction of an instrumental work or a vocal work with instruments to a version for piano.</skos:definition>
     <skos:scopeNote xml:lang="en">May include the words of a vocal work.</skos:scopeNote>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -38,7 +38,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.jsonld"/>

--- a/008/music_format_of_music/music_format_of_music.rdf
+++ b/008/music_format_of_music/music_format_of_music.rdf
@@ -31,7 +31,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/music_format_of_music/music_format_of_music.ttl
+++ b/008/music_format_of_music/music_format_of_music.ttl
@@ -6,101 +6,101 @@
 <https://doi.org/10.6069/uwlswd.06xx-6744#a> a skos:Concept ;
     skos:definition "Staff notation representing the sounds of all the parts of an ensemble (instrumental and/or vocal), arranged so that they can be read simultaneously."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "full score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#b> a skos:Concept ;
     skos:definition "Score issued in a musical image of small size, usually redueced from a larger original, and not primarily intended for use in performance."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "miniature or study score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#c> a skos:Concept ;
     skos:definition "Score with instrumental accompaniment reduced for keyboard(s)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "accompaniment reduced for keyboard"@en ;
     skos:scopeNote "Not used for chorus scores and vocal scores."@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#d> a skos:Concept ;
     skos:definition "Score for solo and/or choral voice(s) with the accompaniment omitted."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "voice score with accompaniment omitted"@en ;
     skos:scopeNote "Not used for vocal works originally unaccompanied."@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#e> a skos:Concept ;
     skos:definition "Orchestral or band music that has been reduced. It may be part of an ensemble work for a particular instrument, with cues for other instruments. Such a score is used by an individual playing the instrument for which the score was written or for the conductor."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "condensed score or piano-conductor score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#g> a skos:Concept ;
     skos:definition "Score (e.g., a hymnal) that has separate parts transcribed in condensed form."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "close score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#h> a skos:Concept ;
     skos:definition "Score of a work for solo voices and chorus showing only the parts for chorus, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "chorus score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#i> a skos:Concept ;
     skos:definition "A score in which the number of staves is reduced to two or a few, generally organized by instrumental sections or vocal parts, and often with cues for individual parts."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "condensed score"@en ;
     skos:scopeNote "Used for: Reduced score, Short score."@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#j> a skos:Concept ;
     skos:definition "A performance part for a single instrument in an ensemble, with cues for the other instruments that enable the performer of that part also to conduct."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "performer-conductor part"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#k> a skos:Concept ;
     skos:definition "Score showing all vocal parts, solo and/or choral, with the instrumental accompaniment either arranged for keyboard(s) or other chordal instrument(s) or omitted."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "vocal score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#l> a skos:Concept ;
     skos:definition "Graphical, symbolic (e.g., staff), or word-based musical notation representing the sounds of all the parts of an ensemble, or a work for solo performer or electronic media. Do not confuse with Part."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "score"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#m> a skos:Concept ;
     skos:definition "Several types of scores are issued together, as is frequently the case with band music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multiple score formats"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#n> a skos:Concept ;
     skos:definition "Item is a sound recording."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#p> a skos:Concept ;
     skos:definition "A reduction of an instrumental work or a vocal work with instruments to a version for piano."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "piano score"@en ;
     skos:scopeNote "May include the words of a vocal work."@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#u> a skos:Concept ;
     skos:definition "Format of the item is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744#z> a skos:Concept ;
     skos:definition "Format of music other than full score, miniature or study score, accompaniment reduced for keyboard, voice score with accompaniment omitted, condensed score or piano-conductor score, close score, chorus score, condensed score, performer-conductor part, vocal score, score, multiple score formats, piano score, or unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.06xx-6744> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.06xx-6744> a skos:ConceptScheme ;
@@ -117,12 +117,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_format_of_music/music_format_of_music.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: format of music"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
                         <td id="a">
@@ -366,7 +366,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
                         <td>
@@ -415,7 +415,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#b">
                         <td>
@@ -464,7 +464,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
                         <td>
@@ -513,7 +513,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
                         <td>
@@ -562,7 +562,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
                         <td>
@@ -611,7 +611,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
                         <td>
@@ -669,7 +669,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
                         <td>
@@ -727,7 +727,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#h">
                         <td>
@@ -776,7 +776,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#i">
                         <td>
@@ -835,7 +835,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
                         <td>
@@ -884,7 +884,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
                         <td>
@@ -933,7 +933,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
                         <td>
@@ -982,7 +982,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
                         <td>
@@ -1031,7 +1031,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
                         <td>
@@ -1080,7 +1080,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
                         <td>
@@ -1129,7 +1129,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
                         <td>
@@ -1178,7 +1178,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound">
                         <td>
@@ -1227,7 +1227,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
                         <td>
@@ -1276,7 +1276,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#s">
                         <td>
@@ -1334,7 +1334,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
                         <td>
@@ -1385,7 +1385,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
                         <td>
@@ -1409,109 +1409,47 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
-    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
-    &lt;dct:title xml:lang="en"&gt;Music: literary text of sound recordings&lt;/dct:title&gt;
-    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/30-31 values for music expressed using RDF&lt;/dct:alternative&gt;
-    &lt;dct:description xml:lang="en"&gt;Indicates the type of literary text contained in a nonmusical sound recording.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
-    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
-    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
-    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
-    &lt;dc:language&gt;en&lt;/dc:language&gt;
-    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html"/&gt;
-    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#h"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;history&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;History.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;interviews&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Interviews.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;instruction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Instruction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;autobiography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Autobiography&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Biography&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Not a sound recording (e.g., printed or manuscript music).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;rehearsals&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Performances of any of a variety of nonmusical productions.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;lectures, speeches&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Lectures, speeches.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;fiction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Fiction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes novels, short stories, etc.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;conference proceedings&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Conference proceedings&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;drama&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Drama&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;essays&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Essays.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;sounds&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Sounds.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes nonmusical utterances and vocalizations that may or may not convey meaning.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;lectures, speeches&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Lectures, speeches.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;folktales&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Folktales.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;rehearsals&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Performances of any of a variety of nonmusical productions.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -1519,70 +1457,132 @@
     &lt;skos:prefLabel xml:lang="en"&gt;reporting&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Reporting.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Reports of newsworthy events and informative messages are included in this category.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;folktales&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Folktales.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;comedy&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Spoken comedy.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;poetry&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Poetry.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;memoirs&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Memoirs.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;interviews&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Interviews.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;conference proceedings&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Conference proceedings&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;fiction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Fiction.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes novels, short stories, etc.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Music: literary text of sound recordings&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/30-31 values for music expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Indicates the type of literary text contained in a nonmusical sound recording.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html"/&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;language instruction&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Language instruction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;poetry&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Poetry.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;comedy&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Spoken comedy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;autobiography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Autobiography&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#h"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;history&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;History.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Not a sound recording (e.g., printed or manuscript music).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;instruction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Instruction.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;biography&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Biography&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;sounds&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Sounds.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes nonmusical utterances and vocalizations that may or may not convey meaning.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;item is a music sound recording&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Item is a music sound recording&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;drama&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Drama&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1597,131 +1597,131 @@
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; a skos:Concept ;
     skos:definition "Autobiography"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autobiography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; a skos:Concept ;
     skos:definition "Biography"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "biography"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; a skos:Concept ;
     skos:definition "Conference proceedings"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "conference proceedings"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; a skos:Concept ;
     skos:definition "Drama"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "drama"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; a skos:Concept ;
     skos:definition "Essays."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "essays"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; a skos:Concept ;
     skos:definition "Fiction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "fiction"@en ;
     skos:scopeNote "Includes novels, short stories, etc."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; a skos:Concept ;
     skos:definition "Reporting."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "reporting"@en ;
     skos:scopeNote "Reports of newsworthy events and informative messages are included in this category."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; a skos:Concept ;
     skos:definition "History."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "history"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; a skos:Concept ;
     skos:definition "Instruction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "instruction"@en ;
     skos:scopeNote "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; a skos:Concept ;
     skos:definition "Language instruction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "language instruction"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; a skos:Concept ;
     skos:definition "Spoken comedy."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "comedy"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; a skos:Concept ;
     skos:definition "Lectures, speeches."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "lectures, speeches"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; a skos:Concept ;
     skos:definition "Memoirs."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "memoirs"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; a skos:Concept ;
     skos:definition "Not a sound recording (e.g., printed or manuscript music)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; a skos:Concept ;
     skos:definition "Folktales."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "folktales"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; a skos:Concept ;
     skos:definition "Poetry."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "poetry"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; a skos:Concept ;
     skos:definition "Item is a music sound recording"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "item is a music sound recording"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; a skos:Concept ;
     skos:definition "Performances of any of a variety of nonmusical productions."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "rehearsals"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; a skos:Concept ;
     skos:definition "Sounds."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "sounds"@en ;
     skos:scopeNote "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; a skos:Concept ;
     skos:definition "Interviews."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "interviews"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; a skos:Concept ;
     skos:definition "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; a skos:ConceptScheme ;
@@ -1738,155 +1738,767 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: literary text of sound recordings"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Performances of any of a variety of nonmusical productions."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Interviews."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Lectures, speeches."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rehearsals"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sounds."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reporting"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "History."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "folktales"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comedy"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "memoirs"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not a sound recording (e.g., printed or manuscript music)."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "reporting"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Memoirs."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fiction"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Language instruction."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Poetry."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Folktales."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "drama"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: literary text of sound recordings"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "History."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Drama"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instruction."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autobiography"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "poetry"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Spoken comedy."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "language instruction"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "essays"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "interviews"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "comedy"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conference proceedings"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Sounds."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Autobiography"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "memoirs"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "lectures, speeches"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sounds"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reporting."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of literary text contained in a nonmusical sound recording."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "item is a music sound recording"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "rehearsals"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/30-31 values for music expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Reports of newsworthy events and informative messages are included in this category."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fiction."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instruction"@en .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Conference proceedings"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Interviews."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Memoirs."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "item is a music sound recording"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/30-31 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "sounds"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of literary text contained in a nonmusical sound recording."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "folktales"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "language instruction"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "fiction"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Reporting."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Reports of newsworthy events and informative messages are included in this category."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "interviews"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: literary text of sound recordings"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Poetry."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes novels, short stories, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "drama"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "essays"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Language instruction."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "lectures, speeches"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autobiography"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Folktales."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Spoken comedy."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "poetry"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Autobiography"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Fiction."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Essays."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is a music sound recording"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "biography"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Performances of any of a variety of nonmusical productions."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#h&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "history"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Drama"@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instruction."@en .
-&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "conference proceedings"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Essays."@en .
 &lt;https://doi.org/10.6069/uwlswd.23tq-5e25#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes novels, short stories, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is a music sound recording"@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.23tq-5e25&gt; .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
+&lt;https://doi.org/10.6069/uwlswd.23tq-5e25#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not a sound recording (e.g., printed or manuscript music)."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Autobiography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "autobiography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not a sound recording (e.g., printed or manuscript music)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Essays."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "essays"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item is a music sound recording"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "item is a music sound recording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Drama"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "drama"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lectures, speeches."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "lectures, speeches"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Spoken comedy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comedy"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Folktales."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "folktales"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reporting."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reporting"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Reports of newsworthy events and informative messages are included in this category."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Interviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "interviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conference proceedings"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conference proceedings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Poetry."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "poetry"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Biography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Language instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "language instruction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Fiction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "fiction"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes novels, short stories, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Memoirs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "memoirs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "instruction"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Performances of any of a variety of nonmusical productions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rehearsals"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Sounds."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "sounds"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes nonmusical utterances and vocalizations that may or may not convey meaning."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "History."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "history"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25",
     "@type": [
@@ -1956,7 +2568,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1985,645 +2597,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not a sound recording (e.g., printed or manuscript music)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Language instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "language instruction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Folktales."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "folktales"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Spoken comedy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comedy"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Interviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "interviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sounds."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sounds"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes nonmusical utterances and vocalizations that may or may not convey meaning."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Autobiography"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "autobiography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is a music sound recording"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "item is a music sound recording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Poetry."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "poetry"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conference proceedings"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conference proceedings"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Fiction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fiction"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes novels, short stories, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "instruction"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Memoirs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "memoirs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Performances of any of a variety of nonmusical productions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rehearsals"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Drama"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "drama"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Essays."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "essays"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Biography"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "History."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "history"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reporting."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reporting"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Reports of newsworthy events and informative messages are included in this category."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lectures, speeches."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "lectures, speeches"
+        "@value": "1-1-0"
       }
     ]
   }

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld
@@ -1,5 +1,617 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Autobiography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "autobiography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not a sound recording (e.g., printed or manuscript music)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#e",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Essays."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "essays"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item is a music sound recording"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "item is a music sound recording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Drama"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "drama"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Lectures, speeches."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "lectures, speeches"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Spoken comedy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "comedy"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Folktales."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "folktales"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Reporting."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "reporting"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Reports of newsworthy events and informative messages are included in this category."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#t",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Interviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "interviews"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Conference proceedings"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "conference proceedings"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Poetry."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "poetry"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Biography"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "biography"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#j",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Language instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "language instruction"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Fiction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "fiction"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes novels, short stories, etc."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Memoirs."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "memoirs"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "instruction"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Performances of any of a variety of nonmusical productions."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "rehearsals"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Sounds."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "sounds"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes nonmusical utterances and vocalizations that may or may not convey meaning."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#h",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "History."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "history"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#ConceptScheme"
@@ -68,7 +680,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -97,645 +709,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not a sound recording (e.g., printed or manuscript music)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#j",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Language instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "j"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "language instruction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Folktales."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "folktales"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Spoken comedy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "comedy"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#t",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Interviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "interviews"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Sounds."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "sounds"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes nonmusical utterances and vocalizations that may or may not convey meaning."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Autobiography"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "autobiography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is a music sound recording"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "item is a music sound recording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Poetry."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "poetry"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Conference proceedings"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "conference proceedings"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Fiction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "fiction"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes novels, short stories, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "instruction"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Memoirs."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "memoirs"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Performances of any of a variety of nonmusical productions."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "rehearsals"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Drama"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "drama"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#e",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Essays."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "essays"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Biography"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "biography"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#h",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "History."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "history"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Reporting."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "reporting"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Reports of newsworthy events and informative messages are included in this category."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Lectures, speeches."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.23tq-5e25"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "lectures, speeches"
+        "@value": "1-1-0"
       }
     ]
   }

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt
@@ -1,131 +1,131 @@
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#definition> "Biography"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#definition> "Performances of any of a variety of nonmusical productions."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#definition> "Interviews."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#definition> "Lectures, speeches."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "rehearsals"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#definition> "Sounds."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "reporting"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#definition> "History."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#definition> "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "folktales"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "comedy"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "memoirs"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#definition> "Not a sound recording (e.g., printed or manuscript music)."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "reporting"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#definition> "Memoirs."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "fiction"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#definition> "Language instruction."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#definition> "Poetry."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#definition> "Folktales."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "drama"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/title> "Music: literary text of sound recordings"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#definition> "History."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#definition> "Drama"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#definition> "Instruction."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autobiography"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "poetry"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#definition> "Spoken comedy."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "language instruction"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "essays"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "interviews"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "comedy"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "conference proceedings"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#definition> "Sounds."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#definition> "Autobiography"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "memoirs"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "lectures, speeches"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#definition> "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "sounds"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#definition> "Reporting."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/description> "Indicates the type of literary text contained in a nonmusical sound recording."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "item is a music sound recording"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "rehearsals"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/alternative> "MARC21 008/30-31 values for music expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "Reports of newsworthy events and informative messages are included in this category."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#definition> "Biography"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#definition> "Fiction."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "instruction"@en .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#definition> "Conference proceedings"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#definition> "Interviews."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#definition> "Memoirs."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "item is a music sound recording"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/alternative> "MARC21 008/30-31 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "sounds"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
 <https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/description> "Indicates the type of literary text contained in a nonmusical sound recording."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "folktales"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "language instruction"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "fiction"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#definition> "Reporting."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "Reports of newsworthy events and informative messages are included in this category."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "interviews"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/title> "Music: literary text of sound recordings"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#definition> "Poetry."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes novels, short stories, etc."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "drama"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "essays"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/2004/02/skos/core#definition> "Language instruction."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "lectures, speeches"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autobiography"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#definition> "Folktales."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/2004/02/skos/core#definition> "Spoken comedy."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "poetry"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#a> <http://www.w3.org/2004/02/skos/core#definition> "Autobiography"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#definition> "Fiction."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#definition> "Essays."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#definition> "Item is a music sound recording"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "biography"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#definition> "Performances of any of a variety of nonmusical productions."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#h> <http://www.w3.org/2004/02/skos/core#prefLabel> "history"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#d> <http://www.w3.org/2004/02/skos/core#definition> "Drama"@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#definition> "Instruction."@en .
-<https://doi.org/10.6069/uwlswd.23tq-5e25#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "conference proceedings"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#e> <http://www.w3.org/2004/02/skos/core#definition> "Essays."@en .
 <https://doi.org/10.6069/uwlswd.23tq-5e25#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes novels, short stories, etc."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#pound> <http://www.w3.org/2004/02/skos/core#definition> "Item is a music sound recording"@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.23tq-5e25> .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
+<https://doi.org/10.6069/uwlswd.23tq-5e25#n> <http://www.w3.org/2004/02/skos/core#definition> "Not a sound recording (e.g., printed or manuscript music)."@en .

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: literary text of sound recordings</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/30-31 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of literary text contained in a nonmusical sound recording.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld"/>
@@ -29,14 +35,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">history</skos:prefLabel>
     <skos:definition xml:lang="en">History.</skos:definition>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Instruction.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
     <skos:scopeNote xml:lang="en">Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
@@ -44,42 +50,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not a sound recording (e.g., printed or manuscript music).</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">rehearsals</skos:prefLabel>
     <skos:definition xml:lang="en">Performances of any of a variety of nonmusical productions.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">lectures, speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Lectures, speeches.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">fiction</skos:prefLabel>
     <skos:definition xml:lang="en">Fiction.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
     <skos:scopeNote xml:lang="en">Includes novels, short stories, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
@@ -87,14 +93,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">conference proceedings</skos:prefLabel>
     <skos:definition xml:lang="en">Conference proceedings</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -102,7 +108,7 @@
     <skos:prefLabel xml:lang="en">sounds</skos:prefLabel>
     <skos:definition xml:lang="en">Sounds.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes nonmusical utterances and vocalizations that may or may not convey meaning.</skos:scopeNote>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -110,69 +116,69 @@
     <skos:prefLabel xml:lang="en">reporting</skos:prefLabel>
     <skos:definition xml:lang="en">Reporting.</skos:definition>
     <skos:scopeNote xml:lang="en">Reports of newsworthy events and informative messages are included in this category.</skos:scopeNote>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">folktales</skos:prefLabel>
     <skos:definition xml:lang="en">Folktales.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">comedy</skos:prefLabel>
     <skos:definition xml:lang="en">Spoken comedy.</skos:definition>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poetry.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">memoirs</skos:prefLabel>
     <skos:definition xml:lang="en">Memoirs.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">interviews</skos:prefLabel>
     <skos:definition xml:lang="en">Interviews.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">language instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Language instruction.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">item is a music sound recording</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a music sound recording</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">drama</skos:prefLabel>
     <skos:definition xml:lang="en">Drama</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld"/>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: literary text of sound recordings</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/30-31 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of literary text contained in a nonmusical sound recording.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">history</skos:prefLabel>
     <skos:definition xml:lang="en">History.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Instruction.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
     <skos:scopeNote xml:lang="en">Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
@@ -50,42 +44,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not a sound recording (e.g., printed or manuscript music).</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">rehearsals</skos:prefLabel>
     <skos:definition xml:lang="en">Performances of any of a variety of nonmusical productions.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">lectures, speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Lectures, speeches.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">fiction</skos:prefLabel>
     <skos:definition xml:lang="en">Fiction.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Includes novels, short stories, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
@@ -93,14 +87,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">conference proceedings</skos:prefLabel>
     <skos:definition xml:lang="en">Conference proceedings</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -108,7 +102,7 @@
     <skos:prefLabel xml:lang="en">sounds</skos:prefLabel>
     <skos:definition xml:lang="en">Sounds.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes nonmusical utterances and vocalizations that may or may not convey meaning.</skos:scopeNote>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -116,69 +110,69 @@
     <skos:prefLabel xml:lang="en">reporting</skos:prefLabel>
     <skos:definition xml:lang="en">Reporting.</skos:definition>
     <skos:scopeNote xml:lang="en">Reports of newsworthy events and informative messages are included in this category.</skos:scopeNote>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">folktales</skos:prefLabel>
     <skos:definition xml:lang="en">Folktales.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">comedy</skos:prefLabel>
     <skos:definition xml:lang="en">Spoken comedy.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poetry.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">memoirs</skos:prefLabel>
     <skos:definition xml:lang="en">Memoirs.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">interviews</skos:prefLabel>
     <skos:definition xml:lang="en">Interviews.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">language instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Language instruction.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">item is a music sound recording</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a music sound recording</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">drama</skos:prefLabel>
     <skos:definition xml:lang="en">Drama</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -1,5 +1,83 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">interviews</skos:prefLabel>
+    <skos:definition xml:lang="en">Interviews.</skos:definition>
+    <skos:notation>t</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">drama</skos:prefLabel>
+    <skos:definition xml:lang="en">Drama</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
+    <skos:definition xml:lang="en">Essays.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">lectures, speeches</skos:prefLabel>
+    <skos:definition xml:lang="en">Lectures, speeches.</skos:definition>
+    <skos:notation>l</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">folktales</skos:prefLabel>
+    <skos:definition xml:lang="en">Folktales.</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">rehearsals</skos:prefLabel>
+    <skos:definition xml:lang="en">Performances of any of a variety of nonmusical productions.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">reporting</skos:prefLabel>
+    <skos:definition xml:lang="en">Reporting.</skos:definition>
+    <skos:scopeNote xml:lang="en">Reports of newsworthy events and informative messages are included in this category.</skos:scopeNote>
+    <skos:notation>g</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">memoirs</skos:prefLabel>
+    <skos:definition xml:lang="en">Memoirs.</skos:definition>
+    <skos:notation>m</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">conference proceedings</skos:prefLabel>
+    <skos:definition xml:lang="en">Conference proceedings</skos:definition>
+    <skos:notation>c</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">fiction</skos:prefLabel>
+    <skos:definition xml:lang="en">Fiction.</skos:definition>
+    <skos:notation>f</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes novels, short stories, etc.</skos:scopeNote>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,12 +102,47 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">language instruction</skos:prefLabel>
+    <skos:definition xml:lang="en">Language instruction.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
+    <skos:definition xml:lang="en">Poetry.</skos:definition>
+    <skos:notation>p</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">comedy</skos:prefLabel>
+    <skos:definition xml:lang="en">Spoken comedy.</skos:definition>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
+    <skos:definition xml:lang="en">Autobiography</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#h">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">history</skos:prefLabel>
     <skos:definition xml:lang="en">History.</skos:definition>
     <skos:notation>h</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
+    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
+    <skos:definition xml:lang="en">Not a sound recording (e.g., printed or manuscript music).</skos:definition>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -39,12 +152,12 @@
     <skos:notation>i</skos:notation>
     <skos:scopeNote xml:lang="en">Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
-    <skos:definition xml:lang="en">Autobiography</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.</skos:definition>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -52,49 +165,6 @@
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography</skos:definition>
     <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
-    <skos:definition xml:lang="en">Not a sound recording (e.g., printed or manuscript music).</skos:definition>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">rehearsals</skos:prefLabel>
-    <skos:definition xml:lang="en">Performances of any of a variety of nonmusical productions.</skos:definition>
-    <skos:notation>r</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">lectures, speeches</skos:prefLabel>
-    <skos:definition xml:lang="en">Lectures, speeches.</skos:definition>
-    <skos:notation>l</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">fiction</skos:prefLabel>
-    <skos:definition xml:lang="en">Fiction.</skos:definition>
-    <skos:notation>f</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes novels, short stories, etc.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">conference proceedings</skos:prefLabel>
-    <skos:definition xml:lang="en">Conference proceedings</skos:definition>
-    <skos:notation>c</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
-    <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -104,75 +174,11 @@
     <skos:scopeNote xml:lang="en">Includes nonmusical utterances and vocalizations that may or may not convey meaning.</skos:scopeNote>
     <skos:notation>s</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">reporting</skos:prefLabel>
-    <skos:definition xml:lang="en">Reporting.</skos:definition>
-    <skos:scopeNote xml:lang="en">Reports of newsworthy events and informative messages are included in this category.</skos:scopeNote>
-    <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">folktales</skos:prefLabel>
-    <skos:definition xml:lang="en">Folktales.</skos:definition>
-    <skos:notation>o</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.</skos:definition>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">comedy</skos:prefLabel>
-    <skos:definition xml:lang="en">Spoken comedy.</skos:definition>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
-    <skos:definition xml:lang="en">Poetry.</skos:definition>
-    <skos:notation>p</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">memoirs</skos:prefLabel>
-    <skos:definition xml:lang="en">Memoirs.</skos:definition>
-    <skos:notation>m</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">interviews</skos:prefLabel>
-    <skos:definition xml:lang="en">Interviews.</skos:definition>
-    <skos:notation>t</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">language instruction</skos:prefLabel>
-    <skos:definition xml:lang="en">Language instruction.</skos:definition>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">item is a music sound recording</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a music sound recording</skos:definition>
     <skos:notation>#</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
-    <skos:prefLabel xml:lang="en">drama</skos:prefLabel>
-    <skos:definition xml:lang="en">Drama</skos:definition>
-    <skos:notation>d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: literary text of sound recordings</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/30-31 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of literary text contained in a nonmusical sound recording.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.jsonld"/>
@@ -35,14 +29,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">history</skos:prefLabel>
     <skos:definition xml:lang="en">History.</skos:definition>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Instruction.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
     <skos:scopeNote xml:lang="en">Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#a">
@@ -50,42 +44,42 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">autobiography</skos:prefLabel>
     <skos:definition xml:lang="en">Autobiography</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">biography</skos:prefLabel>
     <skos:definition xml:lang="en">Biography</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Not a sound recording (e.g., printed or manuscript music).</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">rehearsals</skos:prefLabel>
     <skos:definition xml:lang="en">Performances of any of a variety of nonmusical productions.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">lectures, speeches</skos:prefLabel>
     <skos:definition xml:lang="en">Lectures, speeches.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">fiction</skos:prefLabel>
     <skos:definition xml:lang="en">Fiction.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Includes novels, short stories, etc.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#c">
@@ -93,14 +87,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">conference proceedings</skos:prefLabel>
     <skos:definition xml:lang="en">Conference proceedings</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">essays</skos:prefLabel>
     <skos:definition xml:lang="en">Essays.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -108,7 +102,7 @@
     <skos:prefLabel xml:lang="en">sounds</skos:prefLabel>
     <skos:definition xml:lang="en">Sounds.</skos:definition>
     <skos:scopeNote xml:lang="en">Includes nonmusical utterances and vocalizations that may or may not convey meaning.</skos:scopeNote>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -116,69 +110,69 @@
     <skos:prefLabel xml:lang="en">reporting</skos:prefLabel>
     <skos:definition xml:lang="en">Reporting.</skos:definition>
     <skos:scopeNote xml:lang="en">Reports of newsworthy events and informative messages are included in this category.</skos:scopeNote>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">folktales</skos:prefLabel>
     <skos:definition xml:lang="en">Folktales.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">comedy</skos:prefLabel>
     <skos:definition xml:lang="en">Spoken comedy.</skos:definition>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">poetry</skos:prefLabel>
     <skos:definition xml:lang="en">Poetry.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">memoirs</skos:prefLabel>
     <skos:definition xml:lang="en">Memoirs.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">interviews</skos:prefLabel>
     <skos:definition xml:lang="en">Interviews.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#j">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">language instruction</skos:prefLabel>
     <skos:definition xml:lang="en">Language instruction.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">item is a music sound recording</skos:prefLabel>
     <skos:definition xml:lang="en">Item is a music sound recording</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.23tq-5e25#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.23tq-5e25"/>
     <skos:prefLabel xml:lang="en">drama</skos:prefLabel>
     <skos:definition xml:lang="en">Drama</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl
+++ b/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.ttl
@@ -6,131 +6,131 @@
 <https://doi.org/10.6069/uwlswd.23tq-5e25#a> a skos:Concept ;
     skos:definition "Autobiography"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autobiography"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#b> a skos:Concept ;
     skos:definition "Biography"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "biography"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#c> a skos:Concept ;
     skos:definition "Conference proceedings"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "conference proceedings"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#d> a skos:Concept ;
     skos:definition "Drama"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "drama"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#e> a skos:Concept ;
     skos:definition "Essays."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "essays"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#f> a skos:Concept ;
     skos:definition "Fiction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "fiction"@en ;
     skos:scopeNote "Includes novels, short stories, etc."@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#g> a skos:Concept ;
     skos:definition "Reporting."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "reporting"@en ;
     skos:scopeNote "Reports of newsworthy events and informative messages are included in this category."@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#h> a skos:Concept ;
     skos:definition "History."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "history"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#i> a skos:Concept ;
     skos:definition "Instruction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "instruction"@en ;
     skos:scopeNote "Includes instructions on how to accomplish a task, learn an art, etc. (e.g., how to replace a light switch). Not used for language instruction."@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#j> a skos:Concept ;
     skos:definition "Language instruction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "language instruction"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#k> a skos:Concept ;
     skos:definition "Spoken comedy."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "comedy"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#l> a skos:Concept ;
     skos:definition "Lectures, speeches."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "lectures, speeches"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#m> a skos:Concept ;
     skos:definition "Memoirs."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "memoirs"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#n> a skos:Concept ;
     skos:definition "Not a sound recording (e.g., printed or manuscript music)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#o> a skos:Concept ;
     skos:definition "Folktales."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "folktales"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#p> a skos:Concept ;
     skos:definition "Poetry."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "poetry"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#pound> a skos:Concept ;
     skos:definition "Item is a music sound recording"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "item is a music sound recording"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#r> a skos:Concept ;
     skos:definition "Performances of any of a variety of nonmusical productions."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "rehearsals"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#s> a skos:Concept ;
     skos:definition "Sounds."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "sounds"@en ;
     skos:scopeNote "Includes nonmusical utterances and vocalizations that may or may not convey meaning."@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#t> a skos:Concept ;
     skos:definition "Interviews."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "interviews"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25#z> a skos:Concept ;
     skos:definition "Literary text for sound recordings other than autobiography, biography, conference proceedings, drama, essays, fiction, reporting, history, instruction, language instruction, comedy, lectures, speeches, memoirs, folktales, poetry, rehearsals, sounds, or interviews."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.23tq-5e25> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.23tq-5e25> a skos:ConceptScheme ;
@@ -147,12 +147,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_literary_text_for_sound_recordings/music_literary_text_for_sound_recordings.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: literary text of sound recordings"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_music_parts/music_music_parts.html
+++ b/008/music_music_parts/music_music_parts.html
@@ -52,7 +52,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -245,8 +245,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
@@ -320,7 +320,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
                         <td>
@@ -329,7 +329,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
                         <td>
@@ -369,7 +369,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="http://fakeIRI.edu/terms/mapspe#ax">
                         <td>
@@ -418,7 +418,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
                         <td>
@@ -467,7 +467,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
                         <td>
@@ -516,7 +516,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
                         <td>
@@ -565,7 +565,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#n">
                         <td>
@@ -614,7 +614,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound">
                         <td>
@@ -663,7 +663,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u">
                         <td>
@@ -697,13 +697,6 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;instrumental parts&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Instrumental parts are present.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
@@ -711,7 +704,7 @@
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/21 values for music expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether the item being cataloged is, or contains parts.&lt;/dct:description&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Is not used to indicate that parts may exist elsewhere.&lt;/skos:scopeNote&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
@@ -720,56 +713,63 @@
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#n"&gt;
+  &lt;rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item is not notated music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;instrumental and vocal parts&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Both instrumental and vocal parts are present.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
+    &lt;skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;parts exist [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Unknown whether the item being cataloged contains parts.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;May be used for records created without examining the item, such as retrospective conversion from a printed card.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;parts exist [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;no parts in hand or not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;No parts in hand or the musical parts are not specified.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;vocal parts&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Vocal parts are present.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;no parts in hand or not specified&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;No parts in hand or the musical parts are not specified.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;instrumental and vocal parts&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Both instrumental and vocal parts are present.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item is not notated music.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;instrumental parts&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Instrumental parts are present.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -783,43 +783,43 @@
 
 &lt;http://fakeIRI.edu/terms/mapspe#ax&gt; a skos:Concept ;
     skos:inScheme &lt;http://fakeIRI.edu/terms/mapspe#&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "parts exist [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; a skos:Concept ;
     skos:definition "Both instrumental and vocal parts are present."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "instrumental and vocal parts"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; a skos:Concept ;
     skos:definition "Instrumental parts are present."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "instrumental parts"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; a skos:Concept ;
     skos:definition "Vocal parts are present."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "vocal parts"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; a skos:Concept ;
     skos:definition "Item is not notated music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; a skos:Concept ;
     skos:definition "No parts in hand or the musical parts are not specified."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no parts in hand or not specified"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; a skos:Concept ;
     skos:definition "Unknown whether the item being cataloged contains parts."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en ;
     skos:scopeNote "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
 
@@ -837,92 +837,92 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: music parts"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
     skos:scopeNote "Is not used to indicate that parts may exist elsewhere."@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item being cataloged is, or contains parts."@en .
-&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No parts in hand or the musical parts are not specified."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: music parts"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Is not used to indicate that parts may exist elsewhere."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Both instrumental and vocal parts are present."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "vocal parts"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instrumental parts"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is not notated music."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;http://fakeIRI.edu/terms/mapspe#&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instrumental and vocal parts"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instrumental parts are present."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no parts in hand or not specified"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown whether the item being cataloged contains parts."@en .
-&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/21 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
 &lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "parts exist [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Vocal parts are present."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Is not used to indicate that parts may exist elsewhere."@en .
 &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown whether the item being cataloged contains parts."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "no parts in hand or not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Both instrumental and vocal parts are present."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instrumental and vocal parts"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;http://fakeIRI.edu/terms/mapspe#&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Instrumental parts are present."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "No parts in hand or the musical parts are not specified."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is not notated music."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/21 values for music expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item being cataloged is, or contains parts."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Vocal parts are present."@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: music parts"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;http://fakeIRI.edu/terms/mapspe#ax&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "vocal parts"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "instrumental parts"@en .
+&lt;https://doi.org/10.6069/uwlswd.ywjs-vr46#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.ywjs-vr46&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#f",
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Vocal parts are present."
+        "@value": "Item is not notated music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -932,26 +932,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "vocal parts"
+        "@value": "not applicable"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#pound",
+    "@id": "http://fakeIRI.edu/terms/mapspe#ax",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "http://fakeIRI.edu/terms/mapspe#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "parts exist [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "No parts in hand or the musical parts are not specified."
+        "@value": "Unknown whether the item being cataloged contains parts."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -961,14 +982,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "no parts in hand or not specified"
+        "@value": "unknown"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "May be used for records created without examining the item, such as retrospective conversion from a printed card."
       }
     ]
   },
@@ -1041,7 +1067,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1076,24 +1102,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#n",
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Item is not notated music."
+        "@value": "Vocal parts are present."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1103,101 +1130,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Both instrumental and vocal parts are present."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "instrumental and vocal parts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Unknown whether the item being cataloged contains parts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "May be used for records created without examining the item, such as retrospective conversion from a printed card."
-      }
-    ]
-  },
-  {
-    "@id": "http://fakeIRI.edu/terms/mapspe#ax",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "http://fakeIRI.edu/terms/mapspe#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "parts exist [obsolete]"
+        "@value": "vocal parts"
       }
     ]
   },
@@ -1219,7 +1158,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -1227,6 +1165,62 @@
       {
         "@language": "en",
         "@value": "instrumental parts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No parts in hand or the musical parts are not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no parts in hand or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Both instrumental and vocal parts are present."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "instrumental and vocal parts"
       }
     ]
   }

--- a/008/music_music_parts/music_music_parts.jsonld
+++ b/008/music_music_parts/music_music_parts.jsonld
@@ -1,13 +1,13 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#f",
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Vocal parts are present."
+        "@value": "Item is not notated music."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -17,26 +17,47 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "f"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "vocal parts"
+        "@value": "not applicable"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#pound",
+    "@id": "http://fakeIRI.edu/terms/mapspe#ax",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "http://fakeIRI.edu/terms/mapspe#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "parts exist [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#u",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "No parts in hand or the musical parts are not specified."
+        "@value": "Unknown whether the item being cataloged contains parts."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -46,14 +67,19 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "u"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "no parts in hand or not specified"
+        "@value": "unknown"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "May be used for records created without examining the item, such as retrospective conversion from a printed card."
       }
     ]
   },
@@ -126,7 +152,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -161,24 +187,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#n",
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Item is not notated music."
+        "@value": "Vocal parts are present."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -188,101 +215,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "n"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Both instrumental and vocal parts are present."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "instrumental and vocal parts"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#u",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Unknown whether the item being cataloged contains parts."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "u"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "May be used for records created without examining the item, such as retrospective conversion from a printed card."
-      }
-    ]
-  },
-  {
-    "@id": "http://fakeIRI.edu/terms/mapspe#ax",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "http://fakeIRI.edu/terms/mapspe#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "parts exist [obsolete]"
+        "@value": "vocal parts"
       }
     ]
   },
@@ -304,7 +243,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -312,6 +250,62 @@
       {
         "@language": "en",
         "@value": "instrumental parts"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "No parts in hand or the musical parts are not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "no parts in hand or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Both instrumental and vocal parts are present."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.ywjs-vr46"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "instrumental and vocal parts"
       }
     ]
   }

--- a/008/music_music_parts/music_music_parts.nt
+++ b/008/music_music_parts/music_music_parts.nt
@@ -1,58 +1,58 @@
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/description> "Indicates whether the item being cataloged is, or contains parts."@en .
-<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
 <https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#definition> "No parts in hand or the musical parts are not specified."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/title> "Music: music parts"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://www.w3.org/2004/02/skos/core#scopeNote> "Is not used to indicate that parts may exist elsewhere."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#definition> "Both instrumental and vocal parts are present."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "vocal parts"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "instrumental parts"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is not notated music."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
-<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/2004/02/skos/core#inScheme> <http://fakeIRI.edu/terms/mapspe#> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "instrumental and vocal parts"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#definition> "Instrumental parts are present."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#scopeNote> "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no parts in hand or not specified"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown whether the item being cataloged contains parts."@en .
-<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/alternative> "MARC21 008/21 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
 <http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/2004/02/skos/core#prefLabel> "parts exist [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#definition> "Vocal parts are present."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://www.w3.org/2004/02/skos/core#scopeNote> "Is not used to indicate that parts may exist elsewhere."@en .
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown whether the item being cataloged contains parts."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "no parts in hand or not specified"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#definition> "Both instrumental and vocal parts are present."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "instrumental and vocal parts"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/2004/02/skos/core#inScheme> <http://fakeIRI.edu/terms/mapspe#> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#scopeNote> "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#definition> "Instrumental parts are present."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#definition> "No parts in hand or the musical parts are not specified."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is not notated music."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/alternative> "MARC21 008/21 values for music expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/description> "Indicates whether the item being cataloged is, or contains parts."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#definition> "Vocal parts are present."@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/title> "Music: music parts"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<http://fakeIRI.edu/terms/mapspe#ax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "vocal parts"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "instrumental parts"@en .
+<https://doi.org/10.6069/uwlswd.ywjs-vr46#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.ywjs-vr46> .

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -23,7 +23,7 @@
     <dc:language>en</dc:language>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
     <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl"/>

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental parts</skos:prefLabel>
     <skos:definition xml:lang="en">Instrumental parts are present.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +14,7 @@
     <dct:alternative xml:lang="en">MARC21 008/21 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item being cataloged is, or contains parts.</dct:description>
     <skos:scopeNote xml:lang="en">Is not used to indicate that parts may exist elsewhere.</skos:scopeNote>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
@@ -31,7 +25,7 @@
     <dct:source rdf:resource="http://marc21rdf.info"/>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld"/>
@@ -43,41 +37,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental and vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Both instrumental and vocal parts are present.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item being cataloged contains parts.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
     <skos:scopeNote xml:lang="en">May be used for records created without examining the item, such as retrospective conversion from a printed card.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/>
     <skos:prefLabel xml:lang="en">parts exist [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">no parts in hand or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">No parts in hand or the musical parts are not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Vocal parts are present.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental parts</skos:prefLabel>
     <skos:definition xml:lang="en">Instrumental parts are present.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +14,7 @@
     <dct:alternative xml:lang="en">MARC21 008/21 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item being cataloged is, or contains parts.</dct:description>
     <skos:scopeNote xml:lang="en">Is not used to indicate that parts may exist elsewhere.</skos:scopeNote>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
@@ -43,41 +37,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental and vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Both instrumental and vocal parts are present.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item being cataloged contains parts.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
     <skos:scopeNote xml:lang="en">May be used for records created without examining the item, such as retrospective conversion from a printed card.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/>
     <skos:prefLabel xml:lang="en">parts exist [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">no parts in hand or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">No parts in hand or the musical parts are not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Vocal parts are present.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental parts</skos:prefLabel>
     <skos:definition xml:lang="en">Instrumental parts are present.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -14,7 +20,7 @@
     <dct:alternative xml:lang="en">MARC21 008/21 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item being cataloged is, or contains parts.</dct:description>
     <skos:scopeNote xml:lang="en">Is not used to indicate that parts may exist elsewhere.</skos:scopeNote>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
@@ -25,7 +31,7 @@
     <dct:source rdf:resource="http://marc21rdf.info"/>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld"/>
@@ -37,41 +43,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">instrumental and vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Both instrumental and vocal parts are present.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item being cataloged contains parts.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
     <skos:scopeNote xml:lang="en">May be used for records created without examining the item, such as retrospective conversion from a printed card.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/>
     <skos:prefLabel xml:lang="en">parts exist [obsolete]</skos:prefLabel>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">no parts in hand or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">No parts in hand or the musical parts are not specified.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
     <skos:prefLabel xml:lang="en">vocal parts</skos:prefLabel>
     <skos:definition xml:lang="en">Vocal parts are present.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -25,7 +25,7 @@
     <dct:source rdf:resource="http://marc21rdf.info"/>
     <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.jsonld"/>

--- a/008/music_music_parts/music_music_parts.rdf
+++ b/008/music_music_parts/music_music_parts.rdf
@@ -1,12 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
-    <skos:prefLabel xml:lang="en">instrumental parts</skos:prefLabel>
-    <skos:definition xml:lang="en">Instrumental parts are present.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -32,19 +31,11 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#n">
+  <rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
-    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
-    <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
-    <skos:prefLabel xml:lang="en">instrumental and vocal parts</skos:prefLabel>
-    <skos:definition xml:lang="en">Both instrumental and vocal parts are present.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/>
+    <skos:prefLabel xml:lang="en">parts exist [obsolete]</skos:prefLabel>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -54,11 +45,12 @@
     <skos:notation>u</skos:notation>
     <skos:scopeNote xml:lang="en">May be used for records created without examining the item, such as retrospective conversion from a printed card.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="http://fakeIRI.edu/terms/mapspe#ax">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="http://fakeIRI.edu/terms/mapspe#"/>
-    <skos:prefLabel xml:lang="en">parts exist [obsolete]</skos:prefLabel>
-    <skos:notation>a</skos:notation>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
+    <skos:prefLabel xml:lang="en">vocal parts</skos:prefLabel>
+    <skos:definition xml:lang="en">Vocal parts are present.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -67,11 +59,25 @@
     <skos:definition xml:lang="en">No parts in hand or the musical parts are not specified.</skos:definition>
     <skos:notation>#</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#f">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
-    <skos:prefLabel xml:lang="en">vocal parts</skos:prefLabel>
-    <skos:definition xml:lang="en">Vocal parts are present.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">instrumental and vocal parts</skos:prefLabel>
+    <skos:definition xml:lang="en">Both instrumental and vocal parts are present.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#n">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
+    <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
+    <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
+    <skos:notation>n</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.ywjs-vr46#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.ywjs-vr46"/>
+    <skos:prefLabel xml:lang="en">instrumental parts</skos:prefLabel>
+    <skos:definition xml:lang="en">Instrumental parts are present.</skos:definition>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_music_parts/music_music_parts.ttl
+++ b/008/music_music_parts/music_music_parts.ttl
@@ -5,43 +5,43 @@
 
 <http://fakeIRI.edu/terms/mapspe#ax> a skos:Concept ;
     skos:inScheme <http://fakeIRI.edu/terms/mapspe#> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "parts exist [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#d> a skos:Concept ;
     skos:definition "Both instrumental and vocal parts are present."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "instrumental and vocal parts"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#e> a skos:Concept ;
     skos:definition "Instrumental parts are present."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "instrumental parts"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#f> a skos:Concept ;
     skos:definition "Vocal parts are present."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "vocal parts"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#n> a skos:Concept ;
     skos:definition "Item is not notated music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#pound> a skos:Concept ;
     skos:definition "No parts in hand or the musical parts are not specified."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "no parts in hand or not specified"@en .
 
 <https://doi.org/10.6069/uwlswd.ywjs-vr46#u> a skos:Concept ;
     skos:definition "Unknown whether the item being cataloged contains parts."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.ywjs-vr46> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en ;
     skos:scopeNote "May be used for records created without examining the item, such as retrospective conversion from a printed card."@en .
 
@@ -59,13 +59,13 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_music_parts/music_music_parts.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: music parts"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
     skos:scopeNote "Is not used to indicate that parts may exist elsewhere."@en ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -244,8 +244,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371">
@@ -319,7 +319,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371">
                         <td>
@@ -328,7 +328,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
                         <td id="a">
@@ -368,7 +368,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
                         <td>
@@ -467,7 +467,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#c">
                         <td>
@@ -516,7 +516,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#n">
                         <td>
@@ -565,7 +565,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
                         <td>
@@ -614,7 +614,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
                         <td>
@@ -644,65 +644,65 @@
     &lt;dct:title xml:lang="en"&gt;Music: transposition and arrangement&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for music expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Whether all or part of the item being cataloged is a transposition and/or arrangement of another work.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html"/&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;arrangement&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item has been adapted as regards medium and/or texture.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#n"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Item is not notated music.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;transposition&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item has been transposed to a different pitch from the original.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not arrangement or transposition or not specified&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Not arrangements or the transposition of the item is not specified.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Unknown whether the item is a transposition or arrangement.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;both transposed and arranged&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;arrangement&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item has been adapted as regards medium and/or texture.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;transposition&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item has been transposed to a different pitch from the original.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Unknown whether the item is a transposition or arrangement.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not arrangement or transposition or not specified&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Not arrangements or the transposition of the item is not specified.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -717,37 +717,37 @@
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; a skos:Concept ;
     skos:definition "Item has been transposed to a different pitch from the original."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "transposition"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; a skos:Concept ;
     skos:definition "Item has been adapted as regards medium and/or texture."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "arrangement"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; a skos:Concept ;
     skos:definition "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "both transposed and arranged"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; a skos:Concept ;
     skos:definition "Item is not notated music."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; a skos:Concept ;
     skos:definition "Not arrangements or the transposition of the item is not specified."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not arrangement or transposition or not specified"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; a skos:Concept ;
     skos:definition "Unknown whether the item is a transposition or arrangement."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; a skos:ConceptScheme ;
@@ -764,105 +764,76 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Music: transposition and arrangement"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/description&gt; "Whether all or part of the item being cataloged is a transposition and/or arrangement of another work."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not arrangements or the transposition of the item is not specified."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transposition"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item has been transposed to a different pitch from the original."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "arrangement"@en .
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item has been adapted as regards medium and/or texture."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: transposition and arrangement"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not arrangement or transposition or not specified"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is not notated music."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for music expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown whether the item is a transposition or arrangement."@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "both transposed and arranged"@en .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is not notated music."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Unknown whether the item is a transposition or arrangement."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for music expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not arrangements or the transposition of the item is not specified."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "both transposed and arranged"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/title&gt; "Music: transposition and arrangement"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not arrangement or transposition or not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transposition"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/description&gt; "Whether all or part of the item being cataloged is a transposition and/or arrangement of another work."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "arrangement"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
 &lt;https://doi.org/10.6069/uwlswd.axz0-z371#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item has been transposed to a different pitch from the original."@en .
+&lt;https://doi.org/10.6069/uwlswd.axz0-z371#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.axz0-z371&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been adapted as regards medium and/or texture."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "arrangement"
-      }
-    ]
-  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#n",
     "@type": [
@@ -881,7 +852,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "n"
       }
     ],
@@ -893,14 +863,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#u",
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Unknown whether the item is a transposition or arrangement."
+        "@value": "Item has been adapted as regards medium and/or texture."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -910,101 +880,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "u"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been transposed to a different pitch from the original."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "transposition"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "both transposed and arranged"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not arrangements or the transposition of the item is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not arrangement or transposition or not specified"
+        "@value": "arrangement"
       }
     ]
   },
@@ -1077,7 +959,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1106,12 +988,125 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item has been transposed to a different pitch from the original."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "transposition"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not arrangements or the transposition of the item is not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not arrangement or transposition or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Unknown whether the item is a transposition or arrangement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "both transposed and arranged"
       }
     ]
   }

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld
@@ -1,34 +1,5 @@
 [
   {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been adapted as regards medium and/or texture."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "arrangement"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -46,7 +17,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "n"
       }
     ],
@@ -58,14 +28,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#u",
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Unknown whether the item is a transposition or arrangement."
+        "@value": "Item has been adapted as regards medium and/or texture."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -75,101 +45,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "u"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been transposed to a different pitch from the original."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "transposition"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "both transposed and arranged"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Not arrangements or the transposition of the item is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not arrangement or transposition or not specified"
+        "@value": "arrangement"
       }
     ]
   },
@@ -242,7 +124,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -271,12 +153,125 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item has been transposed to a different pitch from the original."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "transposition"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not arrangements or the transposition of the item is not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not arrangement or transposition or not specified"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Unknown whether the item is a transposition or arrangement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.axz0-z371#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.axz0-z371"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "both transposed and arranged"
       }
     ]
   }

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt
@@ -1,52 +1,52 @@
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/description> "Whether all or part of the item being cataloged is a transposition and/or arrangement of another work."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
 <https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#definition> "Not arrangements or the transposition of the item is not specified."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "transposition"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#definition> "Item has been transposed to a different pitch from the original."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
 <https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#definition> "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "arrangement"@en .
 <https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#definition> "Item has been adapted as regards medium and/or texture."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/title> "Music: transposition and arrangement"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not arrangement or transposition or not specified"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is not notated music."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for music expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown whether the item is a transposition or arrangement."@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "both transposed and arranged"@en .
-<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
-<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/elements/1.1/language> "en" .
 <https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is not notated music."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#definition> "Unknown whether the item is a transposition or arrangement."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for music expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#definition> "Not arrangements or the transposition of the item is not specified."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "both transposed and arranged"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/title> "Music: transposition and arrangement"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#c> <http://www.w3.org/2004/02/skos/core#definition> "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not arrangement or transposition or not specified"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "transposition"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/description> "Whether all or part of the item being cataloged is a transposition and/or arrangement of another work."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "arrangement"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
 <https://doi.org/10.6069/uwlswd.axz0-z371#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .
+<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.axz0-z371> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.axz0-z371#a> <http://www.w3.org/2004/02/skos/core#definition> "Item has been transposed to a different pitch from the original."@en .
+<https://doi.org/10.6069/uwlswd.axz0-z371#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.axz0-z371> .

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -1,5 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -24,33 +30,19 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
+    <skos:prefLabel xml:lang="en">arrangement</skos:prefLabel>
+    <skos:definition xml:lang="en">Item has been adapted as regards medium and/or texture.</skos:definition>
+    <skos:notation>b</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
     <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
-    <skos:prefLabel xml:lang="en">transposition</skos:prefLabel>
-    <skos:definition xml:lang="en">Item has been transposed to a different pitch from the original.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
-    <skos:prefLabel xml:lang="en">not arrangement or transposition or not specified</skos:prefLabel>
-    <skos:definition xml:lang="en">Not arrangements or the transposition of the item is not specified.</skos:definition>
-    <skos:notation>#</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
-    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
-    <skos:definition xml:lang="en">Unknown whether the item is a transposition or arrangement.</skos:definition>
-    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -59,11 +51,25 @@
     <skos:definition xml:lang="en">Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture.</skos:definition>
     <skos:notation>c</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
-    <skos:prefLabel xml:lang="en">arrangement</skos:prefLabel>
-    <skos:definition xml:lang="en">Item has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:prefLabel xml:lang="en">transposition</skos:prefLabel>
+    <skos:definition xml:lang="en">Item has been transposed to a different pitch from the original.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
+    <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
+    <skos:definition xml:lang="en">Unknown whether the item is a transposition or arrangement.</skos:definition>
+    <skos:notation>u</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
+    <skos:prefLabel xml:lang="en">not arrangement or transposition or not specified</skos:prefLabel>
+    <skos:definition xml:lang="en">Not arrangements or the transposition of the item is not specified.</skos:definition>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: transposition and arrangement</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Whether all or part of the item being cataloged is a transposition and/or arrangement of another work.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -35,41 +29,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">transposition</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been transposed to a different pitch from the original.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not arrangement or transposition or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Not arrangements or the transposition of the item is not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item is a transposition or arrangement.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">both transposed and arranged</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">arrangement</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -10,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld"/>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -1,18 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: transposition and arrangement</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Whether all or part of the item being cataloged is a transposition and/or arrangement of another work.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +17,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld"/>
@@ -35,41 +29,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">transposition</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been transposed to a different pitch from the original.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not arrangement or transposition or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Not arrangements or the transposition of the item is not specified.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item is a transposition or arrangement.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">both transposed and arranged</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">arrangement</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf
@@ -1,12 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
     <dct:title xml:lang="en">Music: transposition and arrangement</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for music expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Whether all or part of the item being cataloged is a transposition and/or arrangement of another work.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -17,7 +23,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.jsonld"/>
@@ -29,41 +35,41 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not notated music.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">transposition</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been transposed to a different pitch from the original.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">not arrangement or transposition or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Not arrangements or the transposition of the item is not specified.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Unknown whether the item is a transposition or arrangement.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">both transposed and arranged</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.axz0-z371#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.axz0-z371"/>
     <skos:prefLabel xml:lang="en">arrangement</skos:prefLabel>
     <skos:definition xml:lang="en">Item has been adapted as regards medium and/or texture.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl
+++ b/008/music_transposition_and_arrangement/music_transposition_and_arrangement.ttl
@@ -6,37 +6,37 @@
 <https://doi.org/10.6069/uwlswd.axz0-z371#a> a skos:Concept ;
     skos:definition "Item has been transposed to a different pitch from the original."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "transposition"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371#b> a skos:Concept ;
     skos:definition "Item has been adapted as regards medium and/or texture."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "arrangement"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371#c> a skos:Concept ;
     skos:definition "Item has been both transposed to a different pitch from the original and has been adapted as regards medium and/or texture."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "both transposed and arranged"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371#n> a skos:Concept ;
     skos:definition "Item is not notated music."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371#pound> a skos:Concept ;
     skos:definition "Not arrangements or the transposition of the item is not specified."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not arrangement or transposition or not specified"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371#u> a skos:Concept ;
     skos:definition "Unknown whether the item is a transposition or arrangement."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.axz0-z371> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.axz0-z371> a skos:ConceptScheme ;
@@ -53,12 +53,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/music_transposition_and_arrangement/music_transposition_and_arrangement.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Music: transposition and arrangement"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/some_form_of_item/some_form_of_item.html
+++ b/008/some_form_of_item/some_form_of_item.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-2" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-2</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
                         <td>
@@ -402,7 +402,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
                         <td>
@@ -451,7 +451,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
                         <td>
@@ -500,7 +500,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
                         <td>
@@ -549,7 +549,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
                         <td>
@@ -598,7 +598,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
                         <td>
@@ -638,7 +638,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx">
                         <td>
@@ -678,7 +678,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">h</td>
+                        <td property="skos:notation">h</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
                         <td>
@@ -718,7 +718,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
                         <td>
@@ -758,7 +758,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
                         <td>
@@ -807,7 +807,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
                         <td>
@@ -857,7 +857,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
                         <td>
@@ -906,7 +906,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
                         <td>
@@ -956,7 +956,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
                         <td>
@@ -1005,7 +1005,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
                         <td>
@@ -1056,7 +1056,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
                         <td>
@@ -1106,7 +1106,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
                         <td>
@@ -1146,7 +1146,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">x</td>
+                        <td property="skos:notation">x</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
                         <td>
@@ -1186,7 +1186,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
                         <td>
@@ -1211,11 +1211,12 @@
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
    xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -1223,18 +1224,18 @@
     &lt;dct:title xml:lang="en"&gt;Some: form of item&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/23 values for some materials expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Specifies the form of material.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-2&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/&gt;
@@ -1245,119 +1246,118 @@
     &lt;uwp:appliesToMaterial&gt;continuing resources&lt;/uwp:appliesToMaterial&gt;
     &lt;uwp:appliesToMaterial&gt;mixed materials&lt;/uwp:appliesToMaterial&gt;
   &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;punched paper tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete] [USMARC only]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;x&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;h&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;typewritten transcript [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;online&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Accessed by means of hardware and software connections to a communications network.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfiche&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfiche.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;typewritten transcript [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;magnetic tape [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;h&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other form of reproduction [obsolete] [USMARC only]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;x&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;handwritten transcript [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;photocopy [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;multimedia [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1373,103 +1373,103 @@
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; a skos:Concept ;
     skos:definition "Microfilm."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "microfilm"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; a skos:Concept ;
     skos:definition "Microfiche."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "microfiche"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; a skos:Concept ;
     skos:definition "Microopaque."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "microopaque"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; a skos:Concept ;
     skos:definition "Large print."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "large print"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; a skos:Concept ;
     skos:definition "Braille."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "braille"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "punched paper tape [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "magnetic tape [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "multimedia [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "handwritten transcript [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; a skos:Concept ;
     skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en ;
     skos:scopeNote "Not specified by one of the other codes."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "photocopy [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; a skos:Concept ;
     skos:definition "Eye-readable print, such as a photocopy."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "regular print reproduction"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; a skos:Concept ;
     skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "electronic"@en ;
     skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "typewritten transcript [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "other form of reproduction [obsolete] [USMARC only]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other form of reproduction [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; a skos:ConceptScheme ;
@@ -1486,7 +1486,7 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; ;
     dct:issued "2024" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
@@ -1496,128 +1496,150 @@
         "continuing resources",
         "mixed materials",
         "music" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "continuing resources" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete] [USMARC only]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for some materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/version&gt; "1-0-2" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "mixed materials" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "typewritten transcript [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "punched paper tape [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handwritten transcript [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/23 values for some materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "mixed materials" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "music" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "h" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "handwritten transcript [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other form of reproduction [obsolete] [USMARC only]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
-&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#hx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "magnetic tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#ix&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multimedia [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "continuing resources" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#xx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "x" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#px&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "photocopy [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: form of item"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#tx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#zx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#jx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#gx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "punched paper tape [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.dh5m-5y16&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handwritten transcript [obsolete]"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
     "@type": [
@@ -1636,7 +1658,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "s"
       }
     ],
@@ -1654,60 +1675,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "typewritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "magnetic tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Large print."
+        "@value": "Accessed by means of hardware and software connections to a communications network."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1717,95 +1692,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "large print"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#zx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other form of reproduction [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
+        "@value": "online"
       }
     ]
   },
@@ -1827,7 +1720,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "#"
       }
     ],
@@ -1841,110 +1733,6 @@
       {
         "@language": "en",
         "@value": "Not specified by one of the other codes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microopaque."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "punched paper tape [obsolete]"
       }
     ]
   },
@@ -1966,7 +1754,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -1989,7 +1776,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -1997,6 +1783,200 @@
       {
         "@language": "en",
         "@value": "multimedia [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "typewritten transcript [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#zx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete] [USMARC only]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magnetic tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
       }
     ]
   },
@@ -2069,7 +2049,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -2112,24 +2092,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#a",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "punched paper tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microfilm."
+        "@value": "Braille."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2139,49 +2142,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfilm"
+        "@value": "braille"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "x"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other form of reproduction [obsolete] [USMARC only]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Microfiche."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2191,21 +2170,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "o"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "microfiche"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -2214,14 +2198,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "handwritten transcript [obsolete]"
+        "@value": "microopaque"
       }
     ]
   }

--- a/008/some_form_of_item/some_form_of_item.jsonld
+++ b/008/some_form_of_item/some_form_of_item.jsonld
@@ -1,5 +1,27 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "j"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "handwritten transcript [obsolete]"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -17,7 +39,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "s"
       }
     ],
@@ -35,60 +56,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "t"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "typewritten transcript [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "h"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "magnetic tape [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Large print."
+        "@value": "Accessed by means of hardware and software connections to a communications network."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -98,95 +73,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "o"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "large print"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#zx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other form of reproduction [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
+        "@value": "online"
       }
     ]
   },
@@ -208,7 +101,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "#"
       }
     ],
@@ -222,110 +114,6 @@
       {
         "@language": "en",
         "@value": "Not specified by one of the other codes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microopaque."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Braille."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "braille"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "photocopy [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "punched paper tape [obsolete]"
       }
     ]
   },
@@ -347,7 +135,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "r"
       }
     ],
@@ -370,7 +157,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -378,6 +164,200 @@
       {
         "@language": "en",
         "@value": "multimedia [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#tx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "t"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "typewritten transcript [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#zx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "x"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other form of reproduction [obsolete] [USMARC only]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#px",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "photocopy [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Large print."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#hx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "h"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "magnetic tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
       }
     ]
   },
@@ -450,7 +430,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -493,24 +473,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#a",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#gx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "punched paper tape [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#f",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Microfilm."
+        "@value": "Braille."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -520,49 +523,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "f"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "microfilm"
+        "@value": "braille"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#xx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "x"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other form of reproduction [obsolete] [USMARC only]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#o",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
+        "@value": "Microfiche."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -572,21 +551,26 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "o"
+        "@value": "b"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "online"
+        "@value": "microfiche"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#jx",
+    "@id": "https://doi.org/10.6069/uwlswd.dh5m-5y16#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microopaque."
+      }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
       {
@@ -595,14 +579,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "j"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "handwritten transcript [obsolete]"
+        "@value": "microopaque"
       }
     ]
   }

--- a/008/some_form_of_item/some_form_of_item.nt
+++ b/008/some_form_of_item/some_form_of_item.nt
@@ -1,110 +1,110 @@
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "continuing resources" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete] [USMARC only]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for some materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#notation> "x"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#notation> "h"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/version> "1-0-2" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "mixed materials" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#prefLabel> "typewritten transcript [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "punched paper tape [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "handwritten transcript [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/alternative> "MARC21 008/23 values for some materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/title> "Some: form of item"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "mixed materials" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "music" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#notation> "h" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#prefLabel> "handwritten transcript [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/issued> "2024" .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.html> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#prefLabel> "other form of reproduction [obsolete] [USMARC only]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
-<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> <http://www.w3.org/2004/02/skos/core#prefLabel> "magnetic tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/issued> "2024" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> <http://www.w3.org/2004/02/skos/core#prefLabel> "multimedia [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "continuing resources" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> <http://www.w3.org/2004/02/skos/core#notation> "x" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#px> <http://www.w3.org/2004/02/skos/core#prefLabel> "photocopy [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/title> "Some: form of item"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> <http://www.w3.org/2004/02/skos/core#prefLabel> "punched paper tape [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.dh5m-5y16> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.dh5m-5y16> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -1,10 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation>p</skos:notation>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:definition xml:lang="en">Braille.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -34,50 +42,18 @@
     <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>mixed materials</uwp:appliesToMaterial>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
+    <skos:definition xml:lang="en">Microopaque.</skos:definition>
+    <skos:notation>c</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#gx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
     <skos:notation>g</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
-    <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation>r</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
-    <skos:notation>x</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -86,6 +62,26 @@
     <skos:definition xml:lang="en">Large print.</skos:definition>
     <skos:notation>d</skos:notation>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
+    <skos:notation>t</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
@@ -93,12 +89,11 @@
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
     <skos:notation>o</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
-    <skos:definition xml:lang="en">Microopaque.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -106,21 +101,6 @@
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
     <skos:definition xml:lang="en">Microfiche.</skos:definition>
     <skos:notation>b</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
-    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -130,17 +110,44 @@
     <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
-    <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation>t</skos:notation>
+    <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
+    <skos:notation>h</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
+    <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
+    <skos:notation>r</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">handwritten transcript [obsolete]</skos:prefLabel>
     <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
+    <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -1,17 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +12,7 @@
     <dct:title xml:lang="en">Some: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -45,81 +38,81 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
     <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
     <skos:definition xml:lang="en">Large print.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
     <skos:definition xml:lang="en">Microopaque.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
     <skos:definition xml:lang="en">Microfiche.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
     <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
@@ -127,32 +120,32 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
     <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">handwritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -1,10 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -12,7 +19,7 @@
     <dct:title xml:lang="en">Some: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -23,7 +30,7 @@
     <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-3</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/>
@@ -38,81 +45,81 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
     <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
-    <skos:notation>x</skos:notation>
+    <skos:notation xml:lang="en">x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation>h</skos:notation>
+    <skos:notation xml:lang="en">h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
     <skos:definition xml:lang="en">Large print.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
     <skos:definition xml:lang="en">Microopaque.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
     <skos:definition xml:lang="en">Microfiche.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
     <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
@@ -120,32 +127,32 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
     <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">handwritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -1,17 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#px">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">photocopy [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +12,7 @@
     <dct:title xml:lang="en">Some: form of item</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/23 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Specifies the form of material.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -30,7 +23,7 @@
     <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-3</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/>
@@ -45,81 +38,81 @@
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">punched paper tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#zx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
     <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">regular print reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Eye-readable print, such as a photocopy.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#xx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">other form of reproduction [obsolete] [USMARC only]</skos:prefLabel>
-    <skos:notation xml:lang="en">x</skos:notation>
+    <skos:notation>x</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#hx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">magnetic tape [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">h</skos:notation>
+    <skos:notation>h</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
     <skos:definition xml:lang="en">Large print.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">online</skos:prefLabel>
     <skos:definition xml:lang="en">Accessed by means of hardware and software connections to a communications network.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
     <skos:definition xml:lang="en">Microopaque.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfiche</skos:prefLabel>
     <skos:definition xml:lang="en">Microfiche.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
     <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
     <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#a">
@@ -127,32 +120,32 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
     <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#tx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">typewritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#jx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">handwritten transcript [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.dh5m-5y16#ix">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.dh5m-5y16"/>
     <skos:prefLabel xml:lang="en">multimedia [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -23,7 +23,7 @@
     <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.jsonld"/>

--- a/008/some_form_of_item/some_form_of_item.rdf
+++ b/008/some_form_of_item/some_form_of_item.rdf
@@ -16,7 +16,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/some_form_of_item/some_form_of_item.ttl
+++ b/008/some_form_of_item/some_form_of_item.ttl
@@ -7,103 +7,103 @@
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#a> a skos:Concept ;
     skos:definition "Microfilm."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "microfilm"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#b> a skos:Concept ;
     skos:definition "Microfiche."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "microfiche"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#c> a skos:Concept ;
     skos:definition "Microopaque."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "microopaque"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#d> a skos:Concept ;
     skos:definition "Large print."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "large print"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#f> a skos:Concept ;
     skos:definition "Braille."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "braille"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#gx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "punched paper tape [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#hx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "h"@en ;
+    skos:notation "h" ;
     skos:prefLabel "magnetic tape [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#ix> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "multimedia [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#jx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "handwritten transcript [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#o> a skos:Concept ;
     skos:definition "Accessed by means of hardware and software connections to a communications network."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "online"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#pound> a skos:Concept ;
     skos:definition "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "none of the following"@en ;
     skos:scopeNote "Not specified by one of the other codes."@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#px> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "photocopy [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#q> a skos:Concept ;
     skos:definition "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "direct electronic"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#r> a skos:Concept ;
     skos:definition "Eye-readable print, such as a photocopy."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "regular print reproduction"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#s> a skos:Concept ;
     skos:definition "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "electronic"@en ;
     skos:scopeNote "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#tx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "typewritten transcript [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#xx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "x"@en ;
+    skos:notation "x" ;
     skos:prefLabel "other form of reproduction [obsolete] [USMARC only]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16#zx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.dh5m-5y16> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other form of reproduction [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.dh5m-5y16> a skos:ConceptScheme ;
@@ -120,7 +120,7 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_form_of_item/some_form_of_item.rdf> ;
     dct:issued "2024" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
@@ -130,6 +130,6 @@
         "continuing resources",
         "mixed materials",
         "music" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/some_government_publication/some_government_publication.html
+++ b/008/some_government_publication/some_government_publication.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-2" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -246,8 +246,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
@@ -321,7 +321,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
                         <td>
@@ -330,7 +330,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-2</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
                         <td>
@@ -416,7 +416,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
                         <td>
@@ -466,7 +466,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
                         <td>
@@ -517,7 +517,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#f">
                         <td>
@@ -566,7 +566,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i">
                         <td>
@@ -616,7 +616,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l">
                         <td>
@@ -666,7 +666,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m">
                         <td>
@@ -706,7 +706,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
                         <td>
@@ -756,7 +756,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
                         <td>
@@ -805,7 +805,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
                         <td>
@@ -855,7 +855,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
                         <td>
@@ -905,7 +905,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u">
                         <td>
@@ -956,7 +956,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z">
                         <td>
@@ -981,12 +981,12 @@
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
    xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not a government publication&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Not published by or for a government body.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;federal or national&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -994,18 +994,18 @@
     &lt;dct:title xml:lang="en"&gt;Some: government publication&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/28 values for some materials expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-2&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld"/&gt;
@@ -1017,81 +1017,81 @@
     &lt;uwp:appliesToMaterial&gt;continuing resources&lt;/uwp:appliesToMaterial&gt;
     &lt;uwp:appliesToMaterial&gt;visual materials&lt;/uwp:appliesToMaterial&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;federal or national&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;multistate&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;international intergovernmental&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for an international intergovernmental body.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;government publication - level undetermined [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;state, provincial, territorial, dependent, etc.&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;unknown if item is government publication&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Whether or not the item is published or produced by or for a government agency is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;government publication - level undetermined&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a government body but that the jurisdictional level cannot be determined.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;local&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a local government jurisdiction such as a town, city, county, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;autonomous or semi-autonomous component&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not a government publication&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Not published by or for a government body.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;multilocal&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;international intergovernmental&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for an international intergovernmental body.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;autonomous or semi-autonomous component&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;unknown if item is government publication&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Whether or not the item is published or produced by or for a government agency is unknown.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;government publication - level undetermined [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;local&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Published or produced by or for a local government jurisdiction such as a town, city, county, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1107,72 +1107,72 @@
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autonomous or semi-autonomous component"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "multilocal"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "federal or national"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; a skos:Concept ;
     skos:definition "Published or produced by or for an international intergovernmental body."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "international intergovernmental"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "local"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multistate"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "government publication - level undetermined [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; a skos:Concept ;
     skos:definition "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "government publication - level undetermined"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; a skos:Concept ;
     skos:definition "Not published by or for a government body."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not a government publication"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; a skos:Concept ;
     skos:definition "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "state, provincial, territorial, dependent, etc."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; a skos:Concept ;
     skos:definition "Whether or not the item is published or produced by or for a government agency is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown if item is government publication"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; a skos:Concept ;
     skos:definition "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; a skos:ConceptScheme ;
@@ -1189,7 +1189,7 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
@@ -1200,99 +1200,99 @@
         "continuing resources",
         "maps",
         "visual materials" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://schema.org/version&gt; "1-0-2" .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "federal or national"@en .
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "international intergovernmental"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not a government publication"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "maps" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Whether or not the item is published or produced by or for a government agency is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not published by or for a government body."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/28 values for some materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: government publication"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multistate"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "visual materials" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "computer files" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multilocal"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "government publication - level undetermined"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "continuing resources" .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "local"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for an international intergovernmental body."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "government publication - level undetermined [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "state, provincial, territorial, dependent, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autonomous or semi-autonomous component"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "federal or national"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown if item is government publication"@en .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
-&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multilocal"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "computer files" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown if item is government publication"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for an international intergovernmental body."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "visual materials" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "government publication - level undetermined"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Not published by or for a government body."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "continuing resources" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "state, provincial, territorial, dependent, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/28 values for some materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "government publication - level undetermined [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "multistate"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: government publication"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Whether or not the item is published or produced by or for a government agency is unknown."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#nx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not a government publication"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "international intergovernmental"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "maps" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "autonomous or semi-autonomous component"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.2eg3-1x53&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.2eg3-1x53#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "local"@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
@@ -1316,7 +1316,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -1324,64 +1323,6 @@
       {
         "@language": "en",
         "@value": "local"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "autonomous or semi-autonomous component"
       }
     ]
   },
@@ -1403,7 +1344,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -1411,6 +1351,140 @@
       {
         "@language": "en",
         "@value": "multistate"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not published by or for a government body."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not a government publication"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "government publication - level undetermined [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "federal or national"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Whether or not the item is published or produced by or for a government agency is unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown if item is government publication"
       }
     ]
   },
@@ -1483,7 +1557,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1529,64 +1603,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "state, provincial, territorial, dependent, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "government publication - level undetermined [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1608,7 +1631,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "o"
       }
     ],
@@ -1620,14 +1642,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#c",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."
+        "@value": "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1637,14 +1659,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "multilocal"
+        "@value": "autonomous or semi-autonomous component"
       }
     ]
   },
@@ -1666,7 +1687,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -1678,14 +1698,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#pound",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Not published by or for a government body."
+        "@value": "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1695,26 +1715,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not a government publication"
+        "@value": "state, provincial, territorial, dependent, etc."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#u",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Whether or not the item is published or produced by or for a government agency is unknown."
+        "@value": "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1724,43 +1743,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "u"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown if item is government publication"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "federal or national"
+        "@value": "multilocal"
       }
     ]
   }

--- a/008/some_government_publication/some_government_publication.jsonld
+++ b/008/some_government_publication/some_government_publication.jsonld
@@ -17,7 +17,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -25,64 +24,6 @@
       {
         "@language": "en",
         "@value": "local"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "autonomous or semi-autonomous component"
       }
     ]
   },
@@ -104,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "m"
       }
     ],
@@ -112,6 +52,140 @@
       {
         "@language": "en",
         "@value": "multistate"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Not published by or for a government body."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not a government publication"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#nx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "government publication - level undetermined [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "federal or national"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#u",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Whether or not the item is published or produced by or for a government agency is unknown."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "u"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown if item is government publication"
       }
     ]
   },
@@ -184,7 +258,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -230,64 +304,13 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "state, provincial, territorial, dependent, etc."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#nx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "government publication - level undetermined [obsolete]"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -309,7 +332,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "o"
       }
     ],
@@ -321,14 +343,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#c",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#a",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."
+        "@value": "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -338,14 +360,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "a"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "multilocal"
+        "@value": "autonomous or semi-autonomous component"
       }
     ]
   },
@@ -367,7 +388,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "i"
       }
     ],
@@ -379,14 +399,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#pound",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Not published by or for a government body."
+        "@value": "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -396,26 +416,25 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "#"
+        "@value": "s"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "not a government publication"
+        "@value": "state, provincial, territorial, dependent, etc."
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#u",
+    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Whether or not the item is published or produced by or for a government agency is unknown."
+        "@value": "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -425,43 +444,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "u"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "unknown if item is government publication"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.2eg3-1x53"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "federal or national"
+        "@value": "multilocal"
       }
     ]
   }

--- a/008/some_government_publication/some_government_publication.nt
+++ b/008/some_government_publication/some_government_publication.nt
@@ -1,86 +1,86 @@
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://schema.org/version> "1-0-2" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "international intergovernmental"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not a government publication"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "maps" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#definition> "Whether or not the item is published or produced by or for a government agency is unknown."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#definition> "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#definition> "Not published by or for a government body."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/alternative> "MARC21 008/28 values for some materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/description> "Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/title> "Some: government publication"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multistate"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "visual materials" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "computer files" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "multilocal"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "government publication - level undetermined"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "continuing resources" .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "local"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for an international intergovernmental body."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "government publication - level undetermined [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#definition> "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "state, provincial, territorial, dependent, etc."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autonomous or semi-autonomous component"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.html> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "federal or national"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown if item is government publication"@en .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
-<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
 <https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "multilocal"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "computer files" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/description> "Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown if item is government publication"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for an international intergovernmental body."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "visual materials" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "government publication - level undetermined"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#definition> "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#definition> "Not published by or for a government body."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "continuing resources" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "state, provincial, territorial, dependent, etc."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/alternative> "MARC21 008/28 values for some materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.html> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/2004/02/skos/core#prefLabel> "government publication - level undetermined [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "multistate"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/title> "Some: government publication"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#z> <http://www.w3.org/2004/02/skos/core#definition> "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/2004/02/skos/core#definition> "Whether or not the item is published or produced by or for a government agency is unknown."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#definition> "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "not a government publication"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "international intergovernmental"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "maps" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "autonomous or semi-autonomous component"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.2eg3-1x53> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.2eg3-1x53#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "local"@en .

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -1,18 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">not a government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Not published by or for a government body.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +13,7 @@
     <dct:title xml:lang="en">Some: government publication</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/28 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -31,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-3</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld"/>
@@ -48,75 +41,75 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">federal or national</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multistate</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">international intergovernmental</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for an international intergovernmental body.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">state, provincial, territorial, dependent, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">unknown if item is government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Whether or not the item is published or produced by or for a government agency is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body but that the jurisdictional level cannot be determined.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">local</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a local government jurisdiction such as a town, city, county, etc.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">autonomous or semi-autonomous component</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multilocal</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -24,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld"/>

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -1,11 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">not a government publication</skos:prefLabel>
-    <skos:definition xml:lang="en">Not published by or for a government body.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:prefLabel xml:lang="en">federal or national</skos:prefLabel>
+    <skos:definition xml:lang="en">Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -36,19 +43,40 @@
     <uwp:appliesToMaterial>continuing resources</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>visual materials</uwp:appliesToMaterial>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">federal or national</skos:prefLabel>
-    <skos:definition xml:lang="en">Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multistate</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level.</skos:definition>
     <skos:notation>m</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
+    <skos:prefLabel xml:lang="en">state, provincial, territorial, dependent, etc.</skos:prefLabel>
+    <skos:definition xml:lang="en">Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.</skos:definition>
+    <skos:notation>s</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
+    <skos:prefLabel xml:lang="en">government publication - level undetermined</skos:prefLabel>
+    <skos:definition xml:lang="en">Published or produced by or for a government body but that the jurisdictional level cannot be determined.</skos:definition>
+    <skos:notation>o</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
+    <skos:prefLabel xml:lang="en">not a government publication</skos:prefLabel>
+    <skos:definition xml:lang="en">Not published by or for a government body.</skos:definition>
+    <skos:notation>#</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
+    <skos:prefLabel xml:lang="en">multilocal</skos:prefLabel>
+    <skos:definition xml:lang="en">Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -64,18 +92,12 @@
     <skos:definition xml:lang="en">Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.</skos:definition>
     <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">government publication - level undetermined [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">state, provincial, territorial, dependent, etc.</skos:prefLabel>
-    <skos:definition xml:lang="en">Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:prefLabel xml:lang="en">autonomous or semi-autonomous component</skos:prefLabel>
+    <skos:definition xml:lang="en">Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -84,12 +106,11 @@
     <skos:definition xml:lang="en">Whether or not the item is published or produced by or for a government agency is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">government publication - level undetermined</skos:prefLabel>
-    <skos:definition xml:lang="en">Published or produced by or for a government body but that the jurisdictional level cannot be determined.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:prefLabel xml:lang="en">government publication - level undetermined [obsolete]</skos:prefLabel>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -97,19 +118,5 @@
     <skos:prefLabel xml:lang="en">local</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a local government jurisdiction such as a town, city, county, etc.</skos:definition>
     <skos:notation>l</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">autonomous or semi-autonomous component</skos:prefLabel>
-    <skos:definition xml:lang="en">Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
-    <skos:prefLabel xml:lang="en">multilocal</skos:prefLabel>
-    <skos:definition xml:lang="en">Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.</skos:definition>
-    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -1,11 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">not a government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Not published by or for a government body.</skos:definition>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -13,7 +20,7 @@
     <dct:title xml:lang="en">Some: government publication</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/28 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -24,7 +31,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-3</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.jsonld"/>
@@ -41,75 +48,75 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">federal or national</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multistate</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">international intergovernmental</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for an international intergovernmental body.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined [obsolete]</skos:prefLabel>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">state, provincial, territorial, dependent, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">unknown if item is government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Whether or not the item is published or produced by or for a government agency is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body but that the jurisdictional level cannot be determined.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">local</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a local government jurisdiction such as a town, city, county, etc.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">autonomous or semi-autonomous component</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multilocal</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -17,7 +17,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/some_government_publication/some_government_publication.rdf
+++ b/008/some_government_publication/some_government_publication.rdf
@@ -1,18 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">not a government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Not published by or for a government body.</skos:definition>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +13,7 @@
     <dct:title xml:lang="en">Some: government publication</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/28 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates whether the item is published or produced by or for an international, provincial, national, state, or local government agency, or by any subdivision of such a body, and, if so, the jurisdictional level of the agency.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -48,75 +41,75 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">federal or national</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multistate</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">international intergovernmental</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for an international intergovernmental body.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#nx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">state, provincial, territorial, dependent, etc.</skos:prefLabel>
     <skos:definition xml:lang="en">Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">unknown if item is government publication</skos:prefLabel>
     <skos:definition xml:lang="en">Whether or not the item is published or produced by or for a government agency is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">government publication - level undetermined</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body but that the jurisdictional level cannot be determined.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">local</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a local government jurisdiction such as a town, city, county, etc.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">autonomous or semi-autonomous component</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a government body of an autonomous or semi-autonomous component of a country.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.2eg3-1x53#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.2eg3-1x53"/>
     <skos:prefLabel xml:lang="en">multilocal</skos:prefLabel>
     <skos:definition xml:lang="en">Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_government_publication/some_government_publication.ttl
+++ b/008/some_government_publication/some_government_publication.ttl
@@ -7,72 +7,72 @@
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#a> a skos:Concept ;
     skos:definition "Published or produced by or for a government body of an autonomous or semi-autonomous component of a country."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "autonomous or semi-autonomous component"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#c> a skos:Concept ;
     skos:definition "Published or produced by or for a multilocal jurisdiction which is defined as a regional combination of jurisdictions below the state level."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "multilocal"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#f> a skos:Concept ;
     skos:definition "Published or produced by or for a federal or national government body (e.g., a sovereign nation, such as Canada). Used for the governments of England, Wales, Scotland, and Northern Ireland. Also used for American Indian tribes."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "federal or national"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#i> a skos:Concept ;
     skos:definition "Published or produced by or for an international intergovernmental body."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "international intergovernmental"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#l> a skos:Concept ;
     skos:definition "Published or produced by or for a local government jurisdiction such as a town, city, county, etc."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "local"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#m> a skos:Concept ;
     skos:definition "Published or produced by or for a regional combination of jurisdictions at the state, provincial, territorial, etc. level."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "multistate"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#nx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "government publication - level undetermined [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#o> a skos:Concept ;
     skos:definition "Published or produced by or for a government body but that the jurisdictional level cannot be determined."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "government publication - level undetermined"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#pound> a skos:Concept ;
     skos:definition "Not published by or for a government body."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not a government publication"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#s> a skos:Concept ;
     skos:definition "Jurisdictional level of the government body is a state, province, territory, or other dependent jurisdiction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "state, provincial, territorial, dependent, etc."@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#u> a skos:Concept ;
     skos:definition "Whether or not the item is published or produced by or for a government agency is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown if item is government publication"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53#z> a skos:Concept ;
     skos:definition "Government publication other than autonomous or semi-autonomous component, multilocal, federal or national, international intergovernmental, local, multistate, government publication - level undetermined, state, provincial, territorial, or dependent."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.2eg3-1x53> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.2eg3-1x53> a skos:ConceptScheme ;
@@ -89,7 +89,7 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_government_publication/some_government_publication.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
@@ -100,6 +100,6 @@
         "continuing resources",
         "maps",
         "visual materials" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/some_target_audience/some_target_audience.html
+++ b/008/some_target_audience/some_target_audience.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-2" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-2</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40">
                         <td>
@@ -402,7 +402,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
                         <td>
@@ -451,7 +451,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#b">
                         <td>
@@ -500,7 +500,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
                         <td>
@@ -549,7 +549,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
                         <td>
@@ -598,7 +598,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
                         <td>
@@ -648,7 +648,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#f">
                         <td>
@@ -707,7 +707,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#g">
                         <td>
@@ -756,7 +756,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">j</td>
+                        <td property="skos:notation">j</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#j">
                         <td>
@@ -805,7 +805,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.aec4-nv40#pound">
                         <td>
@@ -839,12 +839,12 @@
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
    xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;preschool&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Children, approximate ages 0-5 years.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;pre-adolescent&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Young people, approximate ages 9-13.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
@@ -852,18 +852,18 @@
     &lt;dct:title xml:lang="en"&gt;Some: target audience&lt;/dct:title&gt;
     &lt;dct:alternative xml:lang="en"&gt;MARC21 008/22 values for some materials expressed using RDF&lt;/dct:alternative&gt;
     &lt;dct:description xml:lang="en"&gt;Indicates the audience for which the item is intended.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-2&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.nt"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld"/&gt;
@@ -874,40 +874,12 @@
     &lt;uwp:appliesToMaterial&gt;music&lt;/uwp:appliesToMaterial&gt;
     &lt;uwp:appliesToMaterial&gt;visual materials&lt;/uwp:appliesToMaterial&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#j"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;juvenile&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Children and young people, approximate ages 0-15.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;j&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;adolescent&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Young people, approximate ages 14-17.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;adult&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended for adults.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;pre-adolescent&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Young people, approximate ages 9-13.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#f"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;specialized&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#g"&gt;
@@ -915,7 +887,7 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;general&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Of general interest and not aimed at a particular target audience.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#pound"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -923,14 +895,42 @@
     &lt;skos:prefLabel xml:lang="en"&gt;unknown or not specified&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Target audience for which the material is intended is unknown or is not specified.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;For video visual materials: use for all original or historical graphic material.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#b"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;primary&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Children, approximate ages 6-8 years.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;adolescent&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Young people, approximate ages 14-17.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;adult&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for adults.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#j"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;juvenile&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Children and young people, approximate ages 0-15.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;j&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;preschool&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Children, approximate ages 0-5 years.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -946,56 +946,56 @@
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; a skos:Concept ;
     skos:definition "Children, approximate ages 0-5 years."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "preschool"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; a skos:Concept ;
     skos:definition "Children, approximate ages 6-8 years."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "primary"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; a skos:Concept ;
     skos:definition "Young people, approximate ages 9-13."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "pre-adolescent"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; a skos:Concept ;
     skos:definition "Young people, approximate ages 14-17."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "adolescent"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; a skos:Concept ;
     skos:definition "Intended for adults."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "adult"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; a skos:Concept ;
     skos:definition "Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "specialized"@en ;
     skos:scopeNote "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; a skos:Concept ;
     skos:definition "Of general interest and not aimed at a particular target audience."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "general"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; a skos:Concept ;
     skos:definition "Children and young people, approximate ages 0-15."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "juvenile"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; a skos:Concept ;
     skos:definition "Target audience for which the material is intended is unknown or is not specified."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "unknown or not specified"@en ;
     skos:scopeNote "For video visual materials: use for all original or historical graphic material."@en .
 
@@ -1013,7 +1013,7 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
@@ -1023,91 +1023,175 @@
         "computer files",
         "music",
         "visual materials" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children, approximate ages 0-5 years."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "adolescent"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://schema.org/version&gt; "1-0-2" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "adult"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Young people, approximate ages 9-13."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22 values for some materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "general"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "For video visual materials: use for all original or historical graphic material."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the audience for which the item is intended."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "visual materials" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Of general interest and not aimed at a particular target audience."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for adults."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Young people, approximate ages 14-17."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pre-adolescent"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "preschool"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "music" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "computer files" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "primary"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "juvenile"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "specialized"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown or not specified"@en .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "pre-adolescent"@en .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "general"@en .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "books" .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children and young people, approximate ages 0-15."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children, approximate ages 6-8 years."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown or not specified"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "adult"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/22 values for some materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/title&gt; "Some: target audience"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j"@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Target audience for which the material is intended is unknown or is not specified."@en .
-&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "adolescent"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Of general interest and not aimed at a particular target audience."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "j" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "computer files" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children, approximate ages 6-8 years."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "preschool"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "For video visual materials: use for all original or historical graphic material."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for adults."@en .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Target audience for which the material is intended is unknown or is not specified."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "specialized"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "visual materials" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Young people, approximate ages 14-17."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children and young people, approximate ages 0-15."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial&gt; "music" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
 &lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Children, approximate ages 0-5 years."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Young people, approximate ages 9-13."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "primary"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#f&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#j&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "juvenile"@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the audience for which the item is intended."@en .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.aec4-nv40#e&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Of general interest and not aimed at a particular target audience."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "general"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Young people, approximate ages 14-17."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "adolescent"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Young people, approximate ages 9-13."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "pre-adolescent"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#b",
     "@type": [
@@ -1126,7 +1210,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -1155,7 +1238,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "f"
       }
     ],
@@ -1169,128 +1251,6 @@
       {
         "@language": "en",
         "@value": "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Of general interest and not aimed at a particular target audience."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "general"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Target audience for which the material is intended is unknown or is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown or not specified"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "For video visual materials: use for all original or historical graphic material."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Young people, approximate ages 9-13."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "pre-adolescent"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Children, approximate ages 0-5 years."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "preschool"
       }
     ]
   },
@@ -1312,7 +1272,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -1320,6 +1279,34 @@
       {
         "@language": "en",
         "@value": "juvenile"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Children, approximate ages 0-5 years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "preschool"
       }
     ]
   },
@@ -1341,7 +1328,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -1349,35 +1335,6 @@
       {
         "@language": "en",
         "@value": "adult"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Young people, approximate ages 14-17."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "adolescent"
       }
     ]
   },
@@ -1450,7 +1407,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1493,12 +1450,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Target audience for which the material is intended is unknown or is not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown or not specified"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "For video visual materials: use for all original or historical graphic material."
       }
     ]
   }

--- a/008/some_target_audience/some_target_audience.jsonld
+++ b/008/some_target_audience/some_target_audience.jsonld
@@ -1,5 +1,89 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Of general interest and not aimed at a particular target audience."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "general"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Young people, approximate ages 14-17."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "adolescent"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#c",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Young people, approximate ages 9-13."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "c"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "pre-adolescent"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#b",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -17,7 +101,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "b"
       }
     ],
@@ -46,7 +129,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "f"
       }
     ],
@@ -60,128 +142,6 @@
       {
         "@language": "en",
         "@value": "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Of general interest and not aimed at a particular target audience."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "general"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Target audience for which the material is intended is unknown or is not specified."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "unknown or not specified"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "For video visual materials: use for all original or historical graphic material."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#c",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Young people, approximate ages 9-13."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "c"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "pre-adolescent"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Children, approximate ages 0-5 years."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "preschool"
       }
     ]
   },
@@ -203,7 +163,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "j"
       }
     ],
@@ -211,6 +170,34 @@
       {
         "@language": "en",
         "@value": "juvenile"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Children, approximate ages 0-5 years."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "preschool"
       }
     ]
   },
@@ -232,7 +219,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "e"
       }
     ],
@@ -240,35 +226,6 @@
       {
         "@language": "en",
         "@value": "adult"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#d",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Young people, approximate ages 14-17."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "d"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "adolescent"
       }
     ]
   },
@@ -341,7 +298,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -384,12 +341,47 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-2"
+        "@value": "1-1-0"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Target audience for which the material is intended is unknown or is not specified."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.aec4-nv40"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "unknown or not specified"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "For video visual materials: use for all original or historical graphic material."
       }
     ]
   }

--- a/008/some_target_audience/some_target_audience.nt
+++ b/008/some_target_audience/some_target_audience.nt
@@ -1,73 +1,73 @@
-<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#definition> "Children, approximate ages 0-5 years."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "adolescent"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://schema.org/version> "1-0-2" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "adult"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#definition> "Young people, approximate ages 9-13."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/alternative> "MARC21 008/22 values for some materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "general"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "For video visual materials: use for all original or historical graphic material."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/description> "Indicates the audience for which the item is intended."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "visual materials" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#definition> "Of general interest and not aimed at a particular target audience."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#definition> "Intended for adults."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#definition> "Young people, approximate ages 14-17."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/issued> "2023" .
 <https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "pre-adolescent"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "preschool"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "music" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "computer files" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "primary"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "juvenile"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "specialized"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown or not specified"@en .
 <https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
 <https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#definition> "Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "general"@en .
 <https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "books" .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#definition> "Children and young people, approximate ages 0-15."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#definition> "Children, approximate ages 6-8 years."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown or not specified"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#prefLabel> "adult"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/alternative> "MARC21 008/22 values for some materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#notation> "e" .
 <https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/title> "Some: target audience"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#notation> "j"@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#definition> "Target audience for which the material is intended is unknown or is not specified."@en .
-<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "adolescent"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#definition> "Of general interest and not aimed at a particular target audience."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#notation> "j" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "computer files" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#definition> "Children, approximate ages 6-8 years."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "preschool"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "For video visual materials: use for all original or historical graphic material."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#definition> "Intended for adults."@en .
 <https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.html> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#definition> "Target audience for which the material is intended is unknown or is not specified."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "specialized"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "visual materials" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.aec4-nv40> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#d> <http://www.w3.org/2004/02/skos/core#definition> "Young people, approximate ages 14-17."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#definition> "Children and young people, approximate ages 0-15."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <https://doi.org/10.6069/uwlib.55.d.3#appliesToMaterial> "music" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/issued> "2023" .
 <https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#definition> "Children, approximate ages 0-5 years."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#c> <http://www.w3.org/2004/02/skos/core#definition> "Young people, approximate ages 9-13."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "primary"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#f> <http://www.w3.org/2004/02/skos/core#scopeNote> "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#j> <http://www.w3.org/2004/02/skos/core#prefLabel> "juvenile"@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40> <http://purl.org/dc/terms/description> "Indicates the audience for which the item is intended."@en .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.aec4-nv40#e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -1,18 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">preschool</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 0-5 years.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +13,7 @@
     <dct:title xml:lang="en">Some: target audience</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the audience for which the item is intended.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -31,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-3</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld"/>
@@ -47,35 +40,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">juvenile</skos:prefLabel>
     <skos:definition xml:lang="en">Children and young people, approximate ages 0-15.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 14-17.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adult</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for adults.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">pre-adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 9-13.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">specialized</skos:prefLabel>
     <skos:definition xml:lang="en">Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#g">
@@ -83,7 +76,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">general</skos:prefLabel>
     <skos:definition xml:lang="en">Of general interest and not aimed at a particular target audience.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -91,13 +84,13 @@
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Target audience for which the material is intended is unknown or is not specified.</skos:definition>
     <skos:scopeNote xml:lang="en">For video visual materials: use for all original or historical graphic material.</skos:scopeNote>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">primary</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 6-8 years.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -24,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld"/>

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -1,18 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">preschool</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 0-5 years.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -20,7 +13,7 @@
     <dct:title xml:lang="en">Some: target audience</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the audience for which the item is intended.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -47,35 +40,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">juvenile</skos:prefLabel>
     <skos:definition xml:lang="en">Children and young people, approximate ages 0-15.</skos:definition>
-    <skos:notation xml:lang="en">j</skos:notation>
+    <skos:notation>j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 14-17.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adult</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for adults.</skos:definition>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">pre-adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 9-13.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">specialized</skos:prefLabel>
     <skos:definition xml:lang="en">Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
     <skos:scopeNote xml:lang="en">Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#g">
@@ -83,7 +76,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">general</skos:prefLabel>
     <skos:definition xml:lang="en">Of general interest and not aimed at a particular target audience.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -91,13 +84,13 @@
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Target audience for which the material is intended is unknown or is not specified.</skos:definition>
     <skos:scopeNote xml:lang="en">For video visual materials: use for all original or historical graphic material.</skos:scopeNote>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">primary</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 6-8 years.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -17,7 +17,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -1,11 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
-    <skos:prefLabel xml:lang="en">preschool</skos:prefLabel>
-    <skos:definition xml:lang="en">Children, approximate ages 0-5 years.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:prefLabel xml:lang="en">pre-adolescent</skos:prefLabel>
+    <skos:definition xml:lang="en">Young people, approximate ages 9-13.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -34,34 +41,6 @@
     <uwp:appliesToMaterial>computer files</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>music</uwp:appliesToMaterial>
     <uwp:appliesToMaterial>visual materials</uwp:appliesToMaterial>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#j">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
-    <skos:prefLabel xml:lang="en">juvenile</skos:prefLabel>
-    <skos:definition xml:lang="en">Children and young people, approximate ages 0-15.</skos:definition>
-    <skos:notation>j</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
-    <skos:prefLabel xml:lang="en">adolescent</skos:prefLabel>
-    <skos:definition xml:lang="en">Young people, approximate ages 14-17.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
-    <skos:prefLabel xml:lang="en">adult</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended for adults.</skos:definition>
-    <skos:notation>e</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
-    <skos:prefLabel xml:lang="en">pre-adolescent</skos:prefLabel>
-    <skos:definition xml:lang="en">Young people, approximate ages 9-13.</skos:definition>
-    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -92,5 +71,33 @@
     <skos:prefLabel xml:lang="en">primary</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 6-8 years.</skos:definition>
     <skos:notation>b</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
+    <skos:prefLabel xml:lang="en">adolescent</skos:prefLabel>
+    <skos:definition xml:lang="en">Young people, approximate ages 14-17.</skos:definition>
+    <skos:notation>d</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
+    <skos:prefLabel xml:lang="en">adult</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for adults.</skos:definition>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#j">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
+    <skos:prefLabel xml:lang="en">juvenile</skos:prefLabel>
+    <skos:definition xml:lang="en">Children and young people, approximate ages 0-15.</skos:definition>
+    <skos:notation>j</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
+    <skos:prefLabel xml:lang="en">preschool</skos:prefLabel>
+    <skos:definition xml:lang="en">Children, approximate ages 0-5 years.</skos:definition>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_target_audience/some_target_audience.rdf
+++ b/008/some_target_audience/some_target_audience.rdf
@@ -1,11 +1,18 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:uwp="https://doi.org/10.6069/uwlib.55.d.3#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">preschool</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 0-5 years.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -13,7 +20,7 @@
     <dct:title xml:lang="en">Some: target audience</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/22 values for some materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the audience for which the item is intended.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -24,7 +31,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-3</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.jsonld"/>
@@ -40,35 +47,35 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">juvenile</skos:prefLabel>
     <skos:definition xml:lang="en">Children and young people, approximate ages 0-15.</skos:definition>
-    <skos:notation>j</skos:notation>
+    <skos:notation xml:lang="en">j</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 14-17.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#e">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">adult</skos:prefLabel>
     <skos:definition xml:lang="en">Intended for adults.</skos:definition>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#c">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">pre-adolescent</skos:prefLabel>
     <skos:definition xml:lang="en">Young people, approximate ages 9-13.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">specialized</skos:prefLabel>
     <skos:definition xml:lang="en">Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
     <skos:scopeNote xml:lang="en">Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#g">
@@ -76,7 +83,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">general</skos:prefLabel>
     <skos:definition xml:lang="en">Of general interest and not aimed at a particular target audience.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#pound">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -84,13 +91,13 @@
     <skos:prefLabel xml:lang="en">unknown or not specified</skos:prefLabel>
     <skos:definition xml:lang="en">Target audience for which the material is intended is unknown or is not specified.</skos:definition>
     <skos:scopeNote xml:lang="en">For video visual materials: use for all original or historical graphic material.</skos:scopeNote>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.aec4-nv40#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.aec4-nv40"/>
     <skos:prefLabel xml:lang="en">primary</skos:prefLabel>
     <skos:definition xml:lang="en">Children, approximate ages 6-8 years.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/some_target_audience/some_target_audience.ttl
+++ b/008/some_target_audience/some_target_audience.ttl
@@ -7,56 +7,56 @@
 <https://doi.org/10.6069/uwlswd.aec4-nv40#a> a skos:Concept ;
     skos:definition "Children, approximate ages 0-5 years."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "preschool"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#b> a skos:Concept ;
     skos:definition "Children, approximate ages 6-8 years."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "primary"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#c> a skos:Concept ;
     skos:definition "Young people, approximate ages 9-13."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "pre-adolescent"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#d> a skos:Concept ;
     skos:definition "Young people, approximate ages 14-17."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "adolescent"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#e> a skos:Concept ;
     skos:definition "Intended for adults."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "adult"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#f> a skos:Concept ;
     skos:definition "Aimed at a particular audience and the nature of the presentation would make the item of little interest to other audiences."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "specialized"@en ;
     skos:scopeNote "Examples include: 1) technical material geared to a specialized audience, and 2) items which address a limited audience; for example, the employees of a single organization."@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#g> a skos:Concept ;
     skos:definition "Of general interest and not aimed at a particular target audience."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "general"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#j> a skos:Concept ;
     skos:definition "Children and young people, approximate ages 0-15."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "j"@en ;
+    skos:notation "j" ;
     skos:prefLabel "juvenile"@en .
 
 <https://doi.org/10.6069/uwlswd.aec4-nv40#pound> a skos:Concept ;
     skos:definition "Target audience for which the material is intended is unknown or is not specified."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.aec4-nv40> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "unknown or not specified"@en ;
     skos:scopeNote "For video visual materials: use for all original or historical graphic material."@en .
 
@@ -74,7 +74,7 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/some_target_audience/some_target_audience.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
@@ -84,6 +84,6 @@
         "computer files",
         "music",
         "visual materials" ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-2" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/visual_form_of_item/visual_form_of_item.html
+++ b/008/visual_form_of_item/visual_form_of_item.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-0" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828">
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-0</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
                         <td id="a">
@@ -854,6 +854,43 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
     &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
@@ -864,14 +901,14 @@
     &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
     &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
     &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
     &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
     &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
     &lt;dct:issued&gt;2024&lt;/dct:issued&gt;
     &lt;dc:language&gt;en&lt;/dc:language&gt;
     &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-0&lt;/schema:version&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
     &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"/&gt;
     &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"/&gt;
@@ -884,50 +921,6 @@
     &lt;skos:prefLabel xml:lang="en"&gt;regular print reproduction&lt;/skos:prefLabel&gt;
     &lt;skos:definition&gt;Eye-readable print, such as a photocopy.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;r&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;none of the following&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Not specified by one of the other codes.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microfilm&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Microfilm.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;braille&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Braille.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;direct electronic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
-    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -949,6 +942,13 @@
     &lt;skos:prefLabel xml:lang="en"&gt;microopaque&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Microopaque.&lt;/skos:definition&gt;
     &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;large print&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Large print.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1036,93 +1036,93 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf&gt; ;
     dct:issued "2024" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Visual: form of item"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
-    schema:version "1-0-0" .
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for visual materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Large print."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Accessed by means of hardware and software connections to a communications network."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not specified by one of the other codes."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: form of item"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microopaque."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/29 values for visual materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/version&gt; "1-0-0" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Braille."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microopaque"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#pound&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "none of the following"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfilm."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfilm"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html&gt; .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microfiche"@en .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/issued&gt; "2024" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Microfiche."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic"@en .
 &lt;https://doi.org/10.6069/uwlswd.fr5p-1828#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "large print"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "online"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "braille"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/terms/description&gt; "Specifies the form of material."@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "regular print reproduction"@en .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "direct electronic"@en .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.fr5p-1828#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Eye-readable print, such as a photocopy." .
 </pre>
         </div>
         <div id="json" class="tabcontent">
@@ -1153,6 +1153,152 @@
       {
         "@language": "en",
         "@value": "braille"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
       }
     ]
   },
@@ -1191,61 +1337,6 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Eye-readable print, such as a photocopy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "regular print reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#d",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -1270,6 +1361,33 @@
       {
         "@language": "en",
         "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
       }
     ]
   },
@@ -1342,7 +1460,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1377,69 +1495,7 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not specified by one of the other codes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "online"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -1468,62 +1524,6 @@
       {
         "@language": "en",
         "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfilm."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfilm"
       }
     ]
   }

--- a/008/visual_form_of_item/visual_form_of_item.jsonld
+++ b/008/visual_form_of_item/visual_form_of_item.jsonld
@@ -28,6 +28,152 @@
     ]
   },
   {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "none of the following"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Not specified by one of the other codes."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfiche."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfiche"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Microfilm."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microfilm"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Accessed by means of hardware and software connections to a communications network."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "online"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "direct electronic"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#s",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -62,61 +208,6 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "Eye-readable print, such as a photocopy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "regular print reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "direct electronic"
-      }
-    ]
-  },
-  {
     "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#d",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -141,6 +232,33 @@
       {
         "@language": "en",
         "@value": "large print"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "Eye-readable print, such as a photocopy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "regular print reproduction"
       }
     ]
   },
@@ -213,7 +331,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -248,69 +366,7 @@
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-0"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#pound",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "none of the following"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Not specified by one of the other codes."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Accessed by means of hardware and software connections to a communications network."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "online"
+        "@value": "1-1-0"
       }
     ]
   },
@@ -339,62 +395,6 @@
       {
         "@language": "en",
         "@value": "microopaque"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfiche."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfiche"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Microfilm."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.fr5p-1828"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microfilm"
       }
     ]
   }

--- a/008/visual_form_of_item/visual_form_of_item.nt
+++ b/008/visual_form_of_item/visual_form_of_item.nt
@@ -1,74 +1,74 @@
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for visual materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#definition> "Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/issued> "2024" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#definition> "Large print."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#definition> "Accessed by means of hardware and software connections to a communications network."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not specified by one of the other codes."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/title> "Visual: form of item"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#definition> "Microopaque."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/alternative> "MARC21 008/29 values for visual materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/version> "1-0-0" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#definition> "Braille."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "microopaque"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#definition> "Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#pound> <http://www.w3.org/2004/02/skos/core#prefLabel> "none of the following"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.jsonld> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#definition> "Microfilm."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfilm"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.html> .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "microfiche"@en .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/issued> "2024" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/2004/02/skos/core#definition> "Microfiche."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs)."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic"@en .
 <https://doi.org/10.6069/uwlswd.fr5p-1828#s> <http://www.w3.org/2004/02/skos/core#definition> "Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player)."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "large print"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "online"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "braille"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/terms/description> "Specifies the form of material."@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "regular print reproduction"@en .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.fr5p-1828> .
-<https://doi.org/10.6069/uwlswd.fr5p-1828> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.fr5p-1828#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "direct electronic"@en .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.fr5p-1828#r> <http://www.w3.org/2004/02/skos/core#definition> "Eye-readable print, such as a photocopy." .

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -1,5 +1,48 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
+    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
+    <skos:notation>#</skos:notation>
+    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
+    <skos:definition xml:lang="en">Braille.</skos:definition>
+    <skos:notation>f</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
+    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
+    <skos:definition xml:lang="en">Microfilm.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -31,50 +74,6 @@
     <skos:definition>Eye-readable print, such as a photocopy.</skos:definition>
     <skos:notation>r</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Intended for manipulation by a computer. May reside in a carrier accessed either directly or remotely, in some cases requiring the use of peripheral devices attached to the computer (e.g., a CD-ROM player).</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Not used for items that do not require the use of a computer (e.g., music compact discs, videodiscs).</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#pound">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">none of the following</skos:prefLabel>
-    <skos:definition xml:lang="en">Form of item other than microfilm, microfiche, microopaque, large print, braille, online, direct electronic, regular print reproduction, or electronic.</skos:definition>
-    <skos:notation>#</skos:notation>
-    <skos:scopeNote xml:lang="en">Not specified by one of the other codes.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#a">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">microfilm</skos:prefLabel>
-    <skos:definition xml:lang="en">Microfilm.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">braille</skos:prefLabel>
-    <skos:definition xml:lang="en">Braille.</skos:definition>
-    <skos:notation>f</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">direct electronic</skos:prefLabel>
-    <skos:definition xml:lang="en">Storage on a directly accessible tangible recording medium, e.g. disc, tape, playaway device, flashdrive, portable hard drive, etc.</skos:definition>
-    <skos:notation>q</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
-    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
-    <skos:definition xml:lang="en">Large print.</skos:definition>
-    <skos:notation>d</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
@@ -95,5 +94,12 @@
     <skos:prefLabel xml:lang="en">microopaque</skos:prefLabel>
     <skos:definition xml:lang="en">Microopaque.</skos:definition>
     <skos:notation>c</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828#d">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.fr5p-1828"/>
+    <skos:prefLabel xml:lang="en">large print</skos:prefLabel>
+    <skos:definition xml:lang="en">Large print.</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -17,7 +17,7 @@
     <dct:issued>2024</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-0</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.nt"/>

--- a/008/visual_form_of_item/visual_form_of_item.rdf
+++ b/008/visual_form_of_item/visual_form_of_item.rdf
@@ -1,11 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.fr5p-1828">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -16,7 +10,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/visual_form_of_item/visual_form_of_item.ttl
+++ b/008/visual_form_of_item/visual_form_of_item.ttl
@@ -79,12 +79,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_form_of_item/visual_form_of_item.rdf> ;
     dct:issued "2024" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Visual: form of item"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
     schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
-    schema:version "1-0-0" .
+    schema:version "1-1-0" .
 

--- a/008/visual_technique/visual_technique.html
+++ b/008/visual_technique/visual_technique.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
                         <td id="a">
@@ -369,7 +369,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
                         <td>
@@ -418,7 +418,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#c">
                         <td>
@@ -467,7 +467,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#l">
                         <td>
@@ -516,7 +516,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#n">
                         <td>
@@ -556,7 +556,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">#</td>
+                        <td property="skos:notation">#</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
                         <td>
@@ -605,7 +605,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">u</td>
+                        <td property="skos:notation">u</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#u">
                         <td>
@@ -654,7 +654,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
                         <td>
@@ -695,52 +695,7 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;unknown&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Technique for creating motion is unknown.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;u&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
-    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
-    &lt;dct:title xml:lang="en"&gt;Visual: technique&lt;/dct:title&gt;
-    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/34 values for visual materials expressed using RDF&lt;/dct:alternative&gt;
-    &lt;dct:description xml:lang="en"&gt;Indicates the technique used in creating motion in motion pictures or videorecordings.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
-    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
-    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
-    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
-    &lt;dc:language&gt;en&lt;/dc:language&gt;
-    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html"/&gt;
-    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;animation and live action&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Combination of animation and live action.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;live action&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Live action&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item is not a motion picture or a videorecording.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;u&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
@@ -748,20 +703,65 @@
     &lt;skos:prefLabel xml:lang="en"&gt;other technique&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Primarily of special techniques which are neither animation nor live action.&lt;/skos:definition&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. &lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Visual: technique&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/34 values for visual materials expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Indicates the technique used in creating motion in motion pictures or videorecordings.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html"/&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;not applicable [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;#&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;live action&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Live action&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;animation and live action&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Combination of animation and live action.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item is not a motion picture or a videorecording.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#a"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;animation&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;not applicable [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;#&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -776,42 +776,42 @@
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; a skos:Concept ;
     skos:definition "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "animation"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; a skos:Concept ;
     skos:definition "Combination of animation and live action."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "animation and live action"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; a skos:Concept ;
     skos:definition "Live action"@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "live action"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; a skos:Concept ;
     skos:definition "Item is not a motion picture or a videorecording."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not applicable [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; a skos:Concept ;
     skos:definition "Technique for creating motion is unknown."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; a skos:Concept ;
     skos:definition "Primarily of special techniques which are neither animation nor live action."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other technique"@en ;
     skos:scopeNote "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
 
@@ -829,81 +829,159 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Visual: technique"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: technique"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Technique for creating motion is unknown."@en .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for visual materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other technique"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Combination of animation and live action."@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Live action"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;https://schema.org/version&gt; "1-0-1" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "unknown"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Primarily of special techniques which are neither animation nor live action."@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the technique used in creating motion in motion pictures or videorecordings."@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "animation"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "animation and live action"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Technique for creating motion is unknown."@en .
-&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "live action"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: technique"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Combination of animation and live action."@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other technique"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Primarily of special techniques which are neither animation nor live action."@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable"@en .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/34 values for visual materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Live action"@en .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item is not a motion picture or a videorecording."@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the technique used in creating motion in motion pictures or videorecordings."@en .
 &lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "animation"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "live action"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "animation and live action"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#u&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "u" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "#" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#poundx&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "not applicable [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.eje7-jq11#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
 </pre>
         </div>
         <div id="json" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld" download="" target="_blank" rel="noopener noreferrer">Download JSON-LD</a>
             <pre>[
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#poundx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Live action"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "live action"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "animation"
+      }
+    ]
+  },
   {
     "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#z",
     "@type": [
@@ -922,7 +1000,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "z"
       }
     ],
@@ -940,37 +1017,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#poundx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#c",
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Combination of animation and live action."
+        "@value": "Item is not a motion picture or a videorecording."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -980,14 +1034,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "animation and live action"
+        "@value": "not applicable"
       }
     ]
   },
@@ -1060,7 +1113,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -1089,24 +1142,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#a",
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."
+        "@value": "Combination of animation and live action."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -1116,14 +1170,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "animation"
+        "@value": "animation and live action"
       }
     ]
   },
@@ -1145,7 +1198,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -1153,64 +1205,6 @@
       {
         "@language": "en",
         "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is not a motion picture or a videorecording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Live action"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "live action"
       }
     ]
   }

--- a/008/visual_technique/visual_technique.jsonld
+++ b/008/visual_technique/visual_technique.jsonld
@@ -1,5 +1,83 @@
 [
   {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#poundx",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "#"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "not applicable [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#l",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Live action"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "l"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "live action"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "animation"
+      }
+    ]
+  },
+  {
     "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#z",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -17,7 +95,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "z"
       }
     ],
@@ -35,37 +112,14 @@
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#poundx",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "#"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable [obsolete]"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#c",
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#n",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Combination of animation and live action."
+        "@value": "Item is not a motion picture or a videorecording."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -75,14 +129,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "c"
+        "@value": "n"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "animation and live action"
+        "@value": "not applicable"
       }
     ]
   },
@@ -155,7 +208,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -184,24 +237,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#a",
+    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#c",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."
+        "@value": "Combination of animation and live action."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -211,14 +265,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "a"
+        "@value": "c"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "animation"
+        "@value": "animation and live action"
       }
     ]
   },
@@ -240,7 +293,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "u"
       }
     ],
@@ -248,64 +300,6 @@
       {
         "@language": "en",
         "@value": "unknown"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item is not a motion picture or a videorecording."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "not applicable"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11#l",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Live action"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.eje7-jq11"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "l"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "live action"
       }
     ]
   }

--- a/008/visual_technique/visual_technique.nt
+++ b/008/visual_technique/visual_technique.nt
@@ -1,57 +1,57 @@
-<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#notation> "u"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/title> "Visual: technique"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#definition> "Technique for creating motion is unknown."@en .
 <https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for visual materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other technique"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#definition> "Combination of animation and live action."@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#notation> "#"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#definition> "Live action"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <https://schema.org/version> "1-0-1" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
 <https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/issued> "2023" .
 <https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#prefLabel> "unknown"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#scopeNote> "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#definition> "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#definition> "Primarily of special techniques which are neither animation nor live action."@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/description> "Indicates the technique used in creating motion in motion pictures or videorecordings."@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "animation"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "animation and live action"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#definition> "Technique for creating motion is unknown."@en .
-<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "live action"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/title> "Visual: technique"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#definition> "Combination of animation and live action."@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other technique"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#definition> "Primarily of special techniques which are neither animation nor live action."@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable"@en .
 <https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/alternative> "MARC21 008/34 values for visual materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#definition> "Live action"@en .
 <https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#definition> "Item is not a motion picture or a videorecording."@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/description> "Indicates the technique used in creating motion in motion pictures or videorecordings."@en .
 <https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "animation"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#definition> "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "live action"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "animation and live action"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.eje7-jq11> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#u> <http://www.w3.org/2004/02/skos/core#notation> "u" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#notation> "#" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#scopeNote> "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> <http://www.w3.org/2004/02/skos/core#prefLabel> "not applicable [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.eje7-jq11#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Technique for creating motion is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Visual: technique</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the technique used in creating motion in motion pictures or videorecordings.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -42,21 +36,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation and live action</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of animation and live action.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">live action</skos:prefLabel>
     <skos:definition xml:lang="en">Live action</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not a motion picture or a videorecording.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -64,19 +58,19 @@
     <skos:prefLabel xml:lang="en">other technique</skos:prefLabel>
     <skos:definition xml:lang="en">Primarily of special techniques which are neither animation nor live action.</skos:definition>
     <skos:scopeNote xml:lang="en">This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. </skos:scopeNote>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation</skos:prefLabel>
     <skos:definition xml:lang="en">Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -1,17 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Technique for creating motion is unknown.</skos:definition>
-    <skos:notation xml:lang="en">u</skos:notation>
+    <skos:notation>u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -19,7 +13,7 @@
     <dct:title xml:lang="en">Visual: technique</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the technique used in creating motion in motion pictures or videorecordings.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -30,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld"/>
@@ -42,21 +36,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation and live action</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of animation and live action.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">live action</skos:prefLabel>
     <skos:definition xml:lang="en">Live action</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not a motion picture or a videorecording.</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -64,19 +58,19 @@
     <skos:prefLabel xml:lang="en">other technique</skos:prefLabel>
     <skos:definition xml:lang="en">Primarily of special techniques which are neither animation nor live action.</skos:definition>
     <skos:scopeNote xml:lang="en">This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. </skos:scopeNote>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">#</skos:notation>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation</skos:prefLabel>
     <skos:definition xml:lang="en">Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -24,7 +24,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld"/>

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -1,11 +1,25 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Technique for creating motion is unknown.</skos:definition>
     <skos:notation>u</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
+    <skos:prefLabel xml:lang="en">other technique</skos:prefLabel>
+    <skos:definition xml:lang="en">Primarily of special techniques which are neither animation nor live action.</skos:definition>
+    <skos:scopeNote xml:lang="en">This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. </skos:scopeNote>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -31,19 +45,19 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#c">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
-    <skos:prefLabel xml:lang="en">animation and live action</skos:prefLabel>
-    <skos:definition xml:lang="en">Combination of animation and live action.</skos:definition>
-    <skos:notation>c</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">live action</skos:prefLabel>
     <skos:definition xml:lang="en">Live action</skos:definition>
     <skos:notation>l</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
+    <skos:prefLabel xml:lang="en">animation and live action</skos:prefLabel>
+    <skos:definition xml:lang="en">Combination of animation and live action.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -52,25 +66,17 @@
     <skos:definition xml:lang="en">Item is not a motion picture or a videorecording.</skos:definition>
     <skos:notation>n</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
-    <skos:prefLabel xml:lang="en">other technique</skos:prefLabel>
-    <skos:definition xml:lang="en">Primarily of special techniques which are neither animation nor live action.</skos:definition>
-    <skos:scopeNote xml:lang="en">This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. </skos:scopeNote>
-    <skos:notation>z</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
-    <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation>#</skos:notation>
-  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation</skos:prefLabel>
     <skos:definition xml:lang="en">Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques.</skos:definition>
     <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
+    <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
+    <skos:notation>#</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -1,11 +1,17 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#u">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">unknown</skos:prefLabel>
     <skos:definition xml:lang="en">Technique for creating motion is unknown.</skos:definition>
-    <skos:notation>u</skos:notation>
+    <skos:notation xml:lang="en">u</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -13,7 +19,7 @@
     <dct:title xml:lang="en">Visual: technique</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/34 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the technique used in creating motion in motion pictures or videorecordings.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -24,7 +30,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.jsonld"/>
@@ -36,21 +42,21 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation and live action</skos:prefLabel>
     <skos:definition xml:lang="en">Combination of animation and live action.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">live action</skos:prefLabel>
     <skos:definition xml:lang="en">Live action</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable</skos:prefLabel>
     <skos:definition xml:lang="en">Item is not a motion picture or a videorecording.</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -58,19 +64,19 @@
     <skos:prefLabel xml:lang="en">other technique</skos:prefLabel>
     <skos:definition xml:lang="en">Primarily of special techniques which are neither animation nor live action.</skos:definition>
     <skos:scopeNote xml:lang="en">This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. </skos:scopeNote>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#poundx">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">not applicable [obsolete]</skos:prefLabel>
-    <skos:notation>#</skos:notation>
+    <skos:notation xml:lang="en">#</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.eje7-jq11#a">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.eje7-jq11"/>
     <skos:prefLabel xml:lang="en">animation</skos:prefLabel>
     <skos:definition xml:lang="en">Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_technique/visual_technique.rdf
+++ b/008/visual_technique/visual_technique.rdf
@@ -17,7 +17,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/visual_technique/visual_technique.ttl
+++ b/008/visual_technique/visual_technique.ttl
@@ -6,42 +6,42 @@
 <https://doi.org/10.6069/uwlswd.eje7-jq11#a> a skos:Concept ;
     skos:definition "Animated films are produced using a variety of techniques including 1) cartoons; 2) graphic film (with paint or other media directly applied to the surface of the film); 3) model, clay, or puppet animation (where three-dimensional objects are photographed one frame at a time to achieve the effect of animation); and 4) other techniques."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "animation"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#c> a skos:Concept ;
     skos:definition "Combination of animation and live action."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "animation and live action"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#l> a skos:Concept ;
     skos:definition "Live action"@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "live action"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#n> a skos:Concept ;
     skos:definition "Item is not a motion picture or a videorecording."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "not applicable"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#poundx> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "#"@en ;
+    skos:notation "#" ;
     skos:prefLabel "not applicable [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#u> a skos:Concept ;
     skos:definition "Technique for creating motion is unknown."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "u"@en ;
+    skos:notation "u" ;
     skos:prefLabel "unknown"@en .
 
 <https://doi.org/10.6069/uwlswd.eje7-jq11#z> a skos:Concept ;
     skos:definition "Primarily of special techniques which are neither animation nor live action."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.eje7-jq11> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other technique"@en ;
     skos:scopeNote "This can include microcinematography, time lapse cinematography, trick cinematography, and other techniques. Also used for videorecordings and motion pictures which were made from still image slide sets or filmstrips without adding animation to the images. "@en .
 
@@ -59,12 +59,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_technique/visual_technique.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Visual: technique"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.html
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.html
@@ -50,7 +50,7 @@
         "inLanguage" : "en" ,  
         "license" : "http://creativecommons.org/publicdomain/zero/1.0", 
         
-        "version" : "1-0-1" , 
+        "version" : "1-1-0" , 
              
         "distribution" : [
             { "@type" : "DataDownload" , 
@@ -242,8 +242,8 @@
                         <td>
                             <a href="http://purl.org/dc/terms/provenance">dct:provenance</a>
                         </td>
-                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833">
-                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833">https://doi.org/10.6069/uwlswd.2e2b-y833</a>
+                        <td property="dct:provenance" resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">
+                            <a href="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues">https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues</a>
                         </td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
@@ -317,7 +317,7 @@
                         <td>
                             <a href="https://schema.org/disambiguatingDescription">schema:disambiguatingDescription</a>
                         </td>
-                        <td property="schema:disambiguatingDescription">SKOS Concept Scheme for MARC 00X Values</td>
+                        <td property="schema:disambiguatingDescription" xml:lang="en">SKOS Concept Scheme for MARC 00X Values</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
                         <td>
@@ -326,7 +326,7 @@
                         <td>
                             <a href="https://schema.org/version">schema:version</a>
                         </td>
-                        <td property="schema:version">1-0-1</td>
+                        <td property="schema:version">1-1-0</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
                         <td id="a">
@@ -367,7 +367,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">a</td>
+                        <td property="skos:notation">a</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
                         <td>
@@ -417,7 +417,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">b</td>
+                        <td property="skos:notation">b</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b">
                         <td>
@@ -479,7 +479,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">c</td>
+                        <td property="skos:notation">c</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
                         <td>
@@ -529,7 +529,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">d</td>
+                        <td property="skos:notation">d</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
                         <td>
@@ -569,7 +569,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">e</td>
+                        <td property="skos:notation">e</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
                         <td>
@@ -619,7 +619,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">f</td>
+                        <td property="skos:notation">f</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
                         <td>
@@ -669,7 +669,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">g</td>
+                        <td property="skos:notation">g</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g">
                         <td>
@@ -728,7 +728,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">i</td>
+                        <td property="skos:notation">i</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
                         <td>
@@ -777,7 +777,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">k</td>
+                        <td property="skos:notation">k</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
                         <td>
@@ -836,7 +836,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">l</td>
+                        <td property="skos:notation">l</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
                         <td>
@@ -886,7 +886,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">m</td>
+                        <td property="skos:notation">m</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#m">
                         <td>
@@ -935,7 +935,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">n</td>
+                        <td property="skos:notation">n</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
                         <td>
@@ -985,7 +985,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">o</td>
+                        <td property="skos:notation">o</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o">
                         <td>
@@ -1044,7 +1044,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">p</td>
+                        <td property="skos:notation">p</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
                         <td>
@@ -1094,7 +1094,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">q</td>
+                        <td property="skos:notation">q</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
                         <td>
@@ -1143,7 +1143,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">r</td>
+                        <td property="skos:notation">r</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
                         <td>
@@ -1203,7 +1203,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">s</td>
+                        <td property="skos:notation">s</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
                         <td>
@@ -1262,7 +1262,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">t</td>
+                        <td property="skos:notation">t</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
                         <td>
@@ -1322,7 +1322,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">v</td>
+                        <td property="skos:notation">v</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v">
                         <td>
@@ -1373,7 +1373,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">w</td>
+                        <td property="skos:notation">w</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
                         <td>
@@ -1424,7 +1424,7 @@
                         <td>
                             <a href="http://www.w3.org/2004/02/skos/core#notation">skos:notation</a>
                         </td>
-                        <td property="skos:notation" xml:lang="en">z</td>
+                        <td property="skos:notation">z</td>
                     </tr>
                     <tr about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
                         <td>
@@ -1448,20 +1448,44 @@
    xmlns:schema="https://schema.org/"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
 &gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
+    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
+    &lt;dct:title xml:lang="en"&gt;Visual: type of visual material&lt;/dct:title&gt;
+    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for visual materials expressed using RDF&lt;/dct:alternative&gt;
+    &lt;dct:description xml:lang="en"&gt;Indicates the type of visual material being described.&lt;/dct:description&gt;
+    &lt;schema:disambiguatingDescription xml:lang="en"&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
+    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
+    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
+    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/&gt;
+    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
+    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
+    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
+    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
+    &lt;dc:language&gt;en&lt;/dc:language&gt;
+    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
+    &lt;schema:version&gt;1-1-0&lt;/schema:version&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld"/&gt;
+    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html"/&gt;
+    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;graphic&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Graphic.&lt;/skos:definition&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Used for original or historical graphic material.&lt;/skos:scopeNote&gt;
-    &lt;skos:notation xml:lang="en"&gt;k&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;realia&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Realia.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;r&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;slide&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;s&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;s&lt;/skos:notation&gt;
     &lt;skos:scopeNote xml:lang="en"&gt;Modern stereographs, for example, Viewmaster reels, are included here.&lt;/skos:scopeNote&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n"&gt;
@@ -1469,161 +1493,137 @@
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;chart&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;n&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;n&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/&gt;
-    &lt;dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/&gt;
-    &lt;dct:title xml:lang="en"&gt;Visual: type of visual material&lt;/dct:title&gt;
-    &lt;dct:alternative xml:lang="en"&gt;MARC21 008/33 values for visual materials expressed using RDF&lt;/dct:alternative&gt;
-    &lt;dct:description xml:lang="en"&gt;Indicates the type of visual material being described.&lt;/dct:description&gt;
-    &lt;schema:disambiguatingDescription&gt;SKOS Concept Scheme for MARC 00X Values&lt;/schema:disambiguatingDescription&gt;
-    &lt;dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/&gt;
-    &lt;dct:source rdf:resource="http://marc21rdf.info"/&gt;
-    &lt;dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/&gt;
-    &lt;dct:creator rdf:resource="http://viaf.org/viaf/139541794"/&gt;
-    &lt;dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/&gt;
-    &lt;dc:contributor xml:lang="en"&gt;Metadata Management Associates&lt;/dc:contributor&gt;
-    &lt;dct:issued&gt;2023&lt;/dct:issued&gt;
-    &lt;dc:language&gt;en&lt;/dc:language&gt;
-    &lt;dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/&gt;
-    &lt;schema:version&gt;1-0-1&lt;/schema:version&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld"/&gt;
-    &lt;dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html"/&gt;
-    &lt;dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#m"&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;motion picture&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;m&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;diorama&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;d&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;z&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Item or set of items designed for play according to prescribed rules and intended for recreation or instruction.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;g&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;includes puzzles and simulations.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;kit&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;b&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;art original&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;a&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;technical drawing&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;l&lt;/skos:notation&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;electronic videorecording [obsolete]&lt;/skos:prefLabel&gt;
+    &lt;skos:notation&gt;e&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;picture&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;i&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;transparency&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;t&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;X-rays are coded as transparencies.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;filmstrip&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;f&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;flash card&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Card or other opaque material printed with words, numerals, or pictures and designed for rapid display.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;o&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Activity cards are included in this category.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;realia&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Realia.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;r&lt;/skos:notation&gt;
-    &lt;skos:scopeNote xml:lang="en"&gt;Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.&lt;/skos:scopeNote&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;art reproduction&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;c&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;electronic videorecording [obsolete]&lt;/skos:prefLabel&gt;
-    &lt;skos:notation xml:lang="en"&gt;e&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;microscope slide&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;p&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;toy&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;w&lt;/skos:notation&gt;
-  &lt;/rdf:Description&gt;
-  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v"&gt;
-    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
-    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
-    &lt;skos:prefLabel xml:lang="en"&gt;videorecording&lt;/skos:prefLabel&gt;
-    &lt;skos:definition xml:lang="en"&gt;Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;v&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;i&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
   &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q"&gt;
     &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
     &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
     &lt;skos:prefLabel xml:lang="en"&gt;model&lt;/skos:prefLabel&gt;
     &lt;skos:definition xml:lang="en"&gt;Three-dimensional representation of a real thing, either of the exact size of the original or to scale.&lt;/skos:definition&gt;
-    &lt;skos:notation xml:lang="en"&gt;q&lt;/skos:notation&gt;
+    &lt;skos:notation&gt;q&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;graphic&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Graphic.&lt;/skos:definition&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Used for original or historical graphic material.&lt;/skos:scopeNote&gt;
+    &lt;skos:notation&gt;k&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;toy&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;w&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;art original&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;a&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;art reproduction&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;c&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;game&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Item or set of items designed for play according to prescribed rules and intended for recreation or instruction.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;g&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;includes puzzles and simulations.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;technical drawing&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;l&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;kit&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;b&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;microscope slide&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;p&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;flash card&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Card or other opaque material printed with words, numerals, or pictures and designed for rapid display.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;o&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;Activity cards are included in this category.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;transparency&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;t&lt;/skos:notation&gt;
+    &lt;skos:scopeNote xml:lang="en"&gt;X-rays are coded as transparencies.&lt;/skos:scopeNote&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#m"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;motion picture&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;m&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;filmstrip&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;f&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;other&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;z&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;diorama&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;d&lt;/skos:notation&gt;
+  &lt;/rdf:Description&gt;
+  &lt;rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v"&gt;
+    &lt;rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/&gt;
+    &lt;skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/&gt;
+    &lt;skos:prefLabel xml:lang="en"&gt;videorecording&lt;/skos:prefLabel&gt;
+    &lt;skos:definition xml:lang="en"&gt;Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.&lt;/skos:definition&gt;
+    &lt;skos:notation&gt;v&lt;/skos:notation&gt;
   &lt;/rdf:Description&gt;
 &lt;/rdf:RDF&gt;
 </pre>
@@ -1638,133 +1638,133 @@
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; a skos:Concept ;
     skos:definition "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "art original"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; a skos:Concept ;
     skos:definition "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "kit"@en ;
     skos:scopeNote "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; a skos:Concept ;
     skos:definition "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "art reproduction"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; a skos:Concept ;
     skos:definition "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "diorama"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; a skos:Concept ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "electronic videorecording [obsolete]"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; a skos:Concept ;
     skos:definition "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "filmstrip"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; a skos:Concept ;
     skos:definition "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "game"@en ;
     skos:scopeNote "includes puzzles and simulations."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; a skos:Concept ;
     skos:definition "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "picture"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; a skos:Concept ;
     skos:definition "Graphic."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "graphic"@en ;
     skos:scopeNote "Used for original or historical graphic material."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; a skos:Concept ;
     skos:definition "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "technical drawing"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; a skos:Concept ;
     skos:definition "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "motion picture"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; a skos:Concept ;
     skos:definition "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "chart"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; a skos:Concept ;
     skos:definition "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "flash card"@en ;
     skos:scopeNote "Activity cards are included in this category."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; a skos:Concept ;
     skos:definition "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "microscope slide"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; a skos:Concept ;
     skos:definition "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "model"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; a skos:Concept ;
     skos:definition "Realia."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "realia"@en ;
     skos:scopeNote "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; a skos:Concept ;
     skos:definition "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "slide"@en ;
     skos:scopeNote "Modern stereographs, for example, Viewmaster reels, are included here."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; a skos:Concept ;
     skos:definition "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "transparency"@en ;
     skos:scopeNote "X-rays are coded as transparencies."@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; a skos:Concept ;
     skos:definition "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "v"@en ;
+    skos:notation "v" ;
     skos:prefLabel "videorecording"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; a skos:Concept ;
     skos:definition "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "toy"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; a skos:Concept ;
     skos:definition "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en ;
     skos:inScheme &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; a skos:ConceptScheme ;
@@ -1781,152 +1781,152 @@
         &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf&gt; ;
     dct:issued "2023" ;
     dct:license &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; ;
-    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; ;
+    dct:provenance &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; ;
     dct:publisher &lt;http://viaf.org/viaf/139541794&gt; ;
     dct:source &lt;http://marc21rdf.info&gt;,
         &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; ;
     dct:title "Visual: type of visual material"@en ;
     dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 
 </pre>
         </div>
         <div id="nt" class="tabcontent">
             <a class="download" href="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt" download="" target="_blank" rel="noopener noreferrer">Download N-Triples</a>
-            <pre>&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for original or historical graphic material."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Modern stereographs, for example, Viewmaster reels, are included here."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+            <pre>&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: type of visual material"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic videorecording [obsolete]"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "graphic"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Used for original or historical graphic material."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "art reproduction"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "includes puzzles and simulations."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "kit"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "picture"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Realia."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chart"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical drawing"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motion picture"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "X-rays are coded as transparencies."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/format&gt; &lt;http://www.w3.org/ns/formats/N-Triples&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "slide"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "diorama"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "flash card"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "toy"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "realia"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "model"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "art original"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmstrip"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of visual material being described."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microscope slide"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for visual materials expressed using RDF"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Modern stereographs, for example, Viewmaster reels, are included here."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transparency"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;https://schema.org/version&gt; "1-1-0" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "videorecording"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v" .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/contributor&gt; &lt;http://viaf.org/viaf/151962300&gt; .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "m"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "d"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/publisher&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/title&gt; "Visual: type of visual material"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "diorama"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;https://schema.org/version&gt; "1-0-1" .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "a"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "other"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "l"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "transparency"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/license&gt; &lt;http://creativecommons.org/publicdomain/zero/1.0&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "game"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "t"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "i"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "slide"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "e"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "filmstrip"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/creator&gt; &lt;http://viaf.org/viaf/139541794&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "graphic"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "flash card"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "art reproduction"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "kit"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "o"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;http://marc21rdf.info&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "includes puzzles and simulations."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "k"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "b"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "z"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "microscope slide"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Graphic."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/provenance&gt; &lt;https://doi.org/10.6069/uwlswd.2e2b-y833&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "s"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "art original"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "n"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "g"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/alternative&gt; "MARC21 008/33 values for visual materials expressed using RDF"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Realia."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "r"@en .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#f&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "f"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "model"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/description&gt; "Indicates the type of visual material being described."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "technical drawing"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "chart"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#n&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#i&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "picture"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "motion picture"@en .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#r&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "realia"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#s&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/source&gt; &lt;https://www.loc.gov/marc/bibliographic/bd008.html&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "p" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/type&gt; &lt;http://purl.org/dc/dcmitype/Dataset&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/issued&gt; "2023" .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#z&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#k&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Graphic."@en .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#o&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "Activity cards are included in this category."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#ex&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "electronic videorecording [obsolete]"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/elements/1.1/language&gt; "en" .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "w"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#l&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;https://schema.org/disambiguatingDescription&gt; "SKOS Concept Scheme for MARC 00X Values" .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/terms/hasFormat&gt; &lt;https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#w&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "toy"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#t&gt; &lt;http://www.w3.org/2004/02/skos/core#scopeNote&gt; "X-rays are coded as transparencies."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#ConceptScheme&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#g&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "c"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#prefLabel&gt; "videorecording"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#b&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en .
 &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#d&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#a&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; &lt;http://purl.org/dc/elements/1.1/contributor&gt; "Metadata Management Associates"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "q"@en .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#c&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#p&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#q&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;http://www.w3.org/2004/02/skos/core#Concept&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#inScheme&gt; &lt;https://doi.org/10.6069/uwlswd.qgc0-9r48&gt; .
-&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#v&gt; &lt;http://www.w3.org/2004/02/skos/core#notation&gt; "v"@en .
+&lt;https://doi.org/10.6069/uwlswd.qgc0-9r48#m&gt; &lt;http://www.w3.org/2004/02/skos/core#definition&gt; "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en .
 </pre>
         </div>
         <div id="json" class="tabcontent">
@@ -1950,7 +1950,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -1958,209 +1957,6 @@
       {
         "@language": "en",
         "@value": "art reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "flash card"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Activity cards are included in this category."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microscope slide"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motion picture"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chart"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "videorecording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#ex",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "electronic videorecording [obsolete]"
       }
     ]
   },
@@ -2182,7 +1978,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -2190,326 +1985,6 @@
       {
         "@language": "en",
         "@value": "technical drawing"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "picture"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "toy"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "art original"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Realia."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "realia"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "game"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "includes puzzles and simulations."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "slide"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Modern stereographs, for example, Viewmaster reels, are included here."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "model"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmstrip"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "kit"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Graphic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "graphic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for original or historical graphic material."
       }
     ]
   },
@@ -2582,7 +2057,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -2611,24 +2086,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#d",
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#w",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."
+        "@value": "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -2638,14 +2114,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "w"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "diorama"
+        "@value": "toy"
       }
     ]
   },
@@ -2667,7 +2142,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],
@@ -2681,6 +2155,512 @@
       {
         "@language": "en",
         "@value": "X-rays are coded as transparencies."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chart"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "slide"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Modern stereographs, for example, Viewmaster reels, are included here."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "picture"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microscope slide"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Realia."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "realia"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "art original"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "kit"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "diorama"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Graphic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "graphic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for original or historical graphic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#ex",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic videorecording [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "videorecording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmstrip"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "flash card"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Activity cards are included in this category."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motion picture"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "model"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "includes puzzles and simulations."
       }
     ]
   }

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld
@@ -17,7 +17,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "c"
       }
     ],
@@ -25,209 +24,6 @@
       {
         "@language": "en",
         "@value": "art reproduction"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#o",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "o"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "flash card"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Activity cards are included in this category."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#p",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "p"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "microscope slide"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#z",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "z"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "other"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#m",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "m"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "motion picture"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#n",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "n"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "chart"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#v",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "v"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "videorecording"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#ex",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "e"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "electronic videorecording [obsolete]"
       }
     ]
   },
@@ -249,7 +45,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "l"
       }
     ],
@@ -257,326 +52,6 @@
       {
         "@language": "en",
         "@value": "technical drawing"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#i",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "i"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "picture"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#w",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "w"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "toy"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#a",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "a"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "art original"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#r",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Realia."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "r"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "realia"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#g",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "g"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "game"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "includes puzzles and simulations."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#s",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "s"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "slide"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Modern stereographs, for example, Viewmaster reels, are included here."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#q",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "q"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "model"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#f",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "f"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "filmstrip"
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#b",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "b"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "kit"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."
-      }
-    ]
-  },
-  {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#k",
-    "@type": [
-      "http://www.w3.org/2004/02/skos/core#Concept"
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@language": "en",
-        "@value": "Graphic."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@language": "en",
-        "@value": "k"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@language": "en",
-        "@value": "graphic"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#scopeNote": [
-      {
-        "@language": "en",
-        "@value": "Used for original or historical graphic material."
       }
     ]
   },
@@ -649,7 +124,7 @@
     ],
     "http://purl.org/dc/terms/provenance": [
       {
-        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833"
+        "@id": "https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"
       }
     ],
     "http://purl.org/dc/terms/publisher": [
@@ -678,24 +153,25 @@
     ],
     "https://schema.org/disambiguatingDescription": [
       {
+        "@language": "en",
         "@value": "SKOS Concept Scheme for MARC 00X Values"
       }
     ],
     "https://schema.org/version": [
       {
-        "@value": "1-0-1"
+        "@value": "1-1-0"
       }
     ]
   },
   {
-    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#d",
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#w",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
     ],
     "http://www.w3.org/2004/02/skos/core#definition": [
       {
         "@language": "en",
-        "@value": "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."
+        "@value": "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."
       }
     ],
     "http://www.w3.org/2004/02/skos/core#inScheme": [
@@ -705,14 +181,13 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
-        "@value": "d"
+        "@value": "w"
       }
     ],
     "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
-        "@value": "diorama"
+        "@value": "toy"
       }
     ]
   },
@@ -734,7 +209,6 @@
     ],
     "http://www.w3.org/2004/02/skos/core#notation": [
       {
-        "@language": "en",
         "@value": "t"
       }
     ],
@@ -748,6 +222,512 @@
       {
         "@language": "en",
         "@value": "X-rays are coded as transparencies."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#n",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "n"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "chart"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#s",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "s"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "slide"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Modern stereographs, for example, Viewmaster reels, are included here."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#i",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "i"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "picture"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#p",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "p"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "microscope slide"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#r",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Realia."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "r"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "realia"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#a",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "a"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "art original"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#b",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "b"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "kit"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#d",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "d"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "diorama"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#k",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Graphic."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "k"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "graphic"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Used for original or historical graphic material."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#ex",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "e"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "electronic videorecording [obsolete]"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#v",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "v"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "videorecording"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#f",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "f"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "filmstrip"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#o",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "o"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "flash card"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "Activity cards are included in this category."
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#m",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "m"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "motion picture"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#q",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "q"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "model"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#z",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "z"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "other"
+      }
+    ]
+  },
+  {
+    "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48#g",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept"
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://doi.org/10.6069/uwlswd.qgc0-9r48"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "g"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "game"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#scopeNote": [
+      {
+        "@language": "en",
+        "@value": "includes puzzles and simulations."
       }
     ]
   }

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.nt
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.nt
@@ -1,133 +1,133 @@
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/title> "Visual: type of visual material"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#notation> "n" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#definition> "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic videorecording [obsolete]"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "graphic"@en .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#scopeNote> "Used for original or historical graphic material."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Modern stereographs, for example, Viewmaster reels, are included here."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#definition> "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "art reproduction"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#notation> "i" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "includes puzzles and simulations."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#notation> "g" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#notation> "l" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "kit"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#definition> "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "picture"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#definition> "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#definition> "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#notation> "s" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#definition> "Realia."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "chart"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical drawing"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "motion picture"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#scopeNote> "X-rays are coded as transparencies."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/format> <http://www.w3.org/ns/formats/N-Triples> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#notation> "m" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "slide"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "diorama"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#definition> "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#notation> "e" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "flash card"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#notation> "t" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "toy"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#notation> "w" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#notation> "b" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#notation> "c" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#definition> "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "realia"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#definition> "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#notation> "k" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#notation> "r" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "model"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "art original"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#notation> "z" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#definition> "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#notation> "a" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#notation> "o" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmstrip"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/description> "Indicates the type of visual material being described."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "microscope slide"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#definition> "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for visual materials expressed using RDF"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#scopeNote> "Modern stereographs, for example, Viewmaster reels, are included here."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/elements/1.1/language> "en" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#notation> "q" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "transparency"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#definition> "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#definition> "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#notation> "f" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#notation> "d" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <https://schema.org/version> "1-1-0" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "videorecording"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#notation> "v" .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/contributor> <http://viaf.org/viaf/151962300> .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#definition> "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#notation> "m"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#notation> "d"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/publisher> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/title> "Visual: type of visual material"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#prefLabel> "diorama"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <https://schema.org/version> "1-0-1" .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#notation> "a"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#prefLabel> "other"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#notation> "l"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#prefLabel> "transparency"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#definition> "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/license> <http://creativecommons.org/publicdomain/zero/1.0> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#scopeNote> "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#prefLabel> "game"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#scopeNote> "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#notation> "t"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#definition> "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#notation> "i"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#prefLabel> "slide"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#notation> "e"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#prefLabel> "filmstrip"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/creator> <http://viaf.org/viaf/139541794> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#prefLabel> "graphic"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#definition> "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#prefLabel> "flash card"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#prefLabel> "art reproduction"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#prefLabel> "kit"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#notation> "o"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/source> <http://marc21rdf.info> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#definition> "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#scopeNote> "includes puzzles and simulations."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#notation> "k"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#notation> "b"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#notation> "z"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#prefLabel> "microscope slide"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#definition> "Graphic."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/provenance> <https://doi.org/10.6069/uwlswd.2e2b-y833> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#notation> "s"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#definition> "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#definition> "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#prefLabel> "art original"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#notation> "p"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#notation> "n"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#notation> "g"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/alternative> "MARC21 008/33 values for visual materials expressed using RDF"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#definition> "Realia."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#notation> "r"@en .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#definition> "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#f> <http://www.w3.org/2004/02/skos/core#notation> "f"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/issued> "2023" .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#definition> "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#prefLabel> "model"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#definition> "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/description> "Indicates the type of visual material being described."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#prefLabel> "technical drawing"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#prefLabel> "chart"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#n> <http://www.w3.org/2004/02/skos/core#definition> "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#i> <http://www.w3.org/2004/02/skos/core#prefLabel> "picture"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#prefLabel> "motion picture"@en .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#r> <http://www.w3.org/2004/02/skos/core#prefLabel> "realia"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#s> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/source> <https://www.loc.gov/marc/bibliographic/bd008.html> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/2004/02/skos/core#definition> "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/2004/02/skos/core#notation> "p" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/type> <http://purl.org/dc/dcmitype/Dataset> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/issued> "2023" .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#z> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#k> <http://www.w3.org/2004/02/skos/core#definition> "Graphic."@en .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#o> <http://www.w3.org/2004/02/skos/core#scopeNote> "Activity cards are included in this category."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> <http://www.w3.org/2004/02/skos/core#prefLabel> "electronic videorecording [obsolete]"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/elements/1.1/language> "en" .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#notation> "w"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#l> <http://www.w3.org/2004/02/skos/core#definition> "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <https://schema.org/disambiguatingDescription> "SKOS Concept Scheme for MARC 00X Values" .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/terms/hasFormat> <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#w> <http://www.w3.org/2004/02/skos/core#prefLabel> "toy"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#t> <http://www.w3.org/2004/02/skos/core#scopeNote> "X-rays are coded as transparencies."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#definition> "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#g> <http://www.w3.org/2004/02/skos/core#definition> "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#notation> "c"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#definition> "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#prefLabel> "videorecording"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#b> <http://www.w3.org/2004/02/skos/core#definition> "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en .
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#d> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48> <http://purl.org/dc/elements/1.1/contributor> "Metadata Management Associates"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/2004/02/skos/core#notation> "q"@en .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#c> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#inScheme> <https://doi.org/10.6069/uwlswd.qgc0-9r48> .
-<https://doi.org/10.6069/uwlswd.qgc0-9r48#v> <http://www.w3.org/2004/02/skos/core#notation> "v"@en .
+<https://doi.org/10.6069/uwlswd.qgc0-9r48#m> <http://www.w3.org/2004/02/skos/core#definition> "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en .

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -1,25 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">graphic</skos:prefLabel>
     <skos:definition xml:lang="en">Graphic.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for original or historical graphic material.</skos:scopeNote>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Modern stereographs, for example, Viewmaster reels, are included here.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
@@ -27,7 +21,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">chart</skos:prefLabel>
     <skos:definition xml:lang="en">Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -35,7 +29,7 @@
     <dct:title xml:lang="en">Visual: type of visual material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of visual material being described.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -46,7 +40,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-0-2</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld"/>
@@ -58,28 +52,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">motion picture</skos:prefLabel>
     <skos:definition xml:lang="en">Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">diorama</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Item or set of items designed for play according to prescribed rules and intended for recreation or instruction.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">includes puzzles and simulations.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b">
@@ -87,7 +81,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">kit</skos:prefLabel>
     <skos:definition xml:lang="en">Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
@@ -95,28 +89,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art original</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">technical drawing</skos:prefLabel>
     <skos:definition xml:lang="en">Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">picture</skos:prefLabel>
     <skos:definition xml:lang="en">Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">transparency</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
     <skos:scopeNote xml:lang="en">X-rays are coded as transparencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
@@ -124,14 +118,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">filmstrip</skos:prefLabel>
     <skos:definition xml:lang="en">Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">flash card</skos:prefLabel>
     <skos:definition xml:lang="en">Card or other opaque material printed with words, numerals, or pictures and designed for rapid display.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
     <skos:scopeNote xml:lang="en">Activity cards are included in this category.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
@@ -139,7 +133,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">realia</skos:prefLabel>
     <skos:definition xml:lang="en">Realia.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
@@ -147,40 +141,40 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">electronic videorecording [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">microscope slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">toy</skos:prefLabel>
     <skos:definition xml:lang="en">Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">videorecording</skos:prefLabel>
     <skos:definition xml:lang="en">Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.</skos:definition>
-    <skos:notation xml:lang="en">v</skos:notation>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">model</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a real thing, either of the exact size of the original or to scale.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -1,28 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">graphic</skos:prefLabel>
-    <skos:definition xml:lang="en">Graphic.</skos:definition>
-    <skos:scopeNote xml:lang="en">Used for original or historical graphic material.</skos:scopeNote>
-    <skos:notation>k</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">slide</skos:prefLabel>
-    <skos:definition xml:lang="en">Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.</skos:definition>
-    <skos:notation>s</skos:notation>
-    <skos:scopeNote xml:lang="en">Modern stereographs, for example, Viewmaster reels, are included here.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">chart</skos:prefLabel>
-    <skos:definition xml:lang="en">Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).</skos:definition>
-    <skos:notation>n</skos:notation>
-  </rdf:Description>
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
     <dct:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
@@ -47,26 +30,77 @@
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.html"/>
     <dct:format rdf:resource="http://www.w3.org/ns/formats/RDF_XML"/>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#m">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">motion picture</skos:prefLabel>
-    <skos:definition xml:lang="en">Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:prefLabel xml:lang="en">realia</skos:prefLabel>
+    <skos:definition xml:lang="en">Realia.</skos:definition>
+    <skos:notation>r</skos:notation>
+    <skos:scopeNote xml:lang="en">Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">diorama</skos:prefLabel>
-    <skos:definition xml:lang="en">Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:prefLabel xml:lang="en">slide</skos:prefLabel>
+    <skos:definition xml:lang="en">Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.</skos:definition>
+    <skos:notation>s</skos:notation>
+    <skos:scopeNote xml:lang="en">Modern stereographs, for example, Viewmaster reels, are included here.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
-    <skos:definition xml:lang="en">Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:prefLabel xml:lang="en">chart</skos:prefLabel>
+    <skos:definition xml:lang="en">Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).</skos:definition>
+    <skos:notation>n</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">electronic videorecording [obsolete]</skos:prefLabel>
+    <skos:notation>e</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">picture</skos:prefLabel>
+    <skos:definition xml:lang="en">Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.</skos:definition>
+    <skos:notation>i</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">model</skos:prefLabel>
+    <skos:definition xml:lang="en">Three-dimensional representation of a real thing, either of the exact size of the original or to scale.</skos:definition>
+    <skos:notation>q</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">graphic</skos:prefLabel>
+    <skos:definition xml:lang="en">Graphic.</skos:definition>
+    <skos:scopeNote xml:lang="en">Used for original or historical graphic material.</skos:scopeNote>
+    <skos:notation>k</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">toy</skos:prefLabel>
+    <skos:definition xml:lang="en">Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.</skos:definition>
+    <skos:notation>w</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">art original</skos:prefLabel>
+    <skos:definition xml:lang="en">Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.</skos:definition>
+    <skos:notation>a</skos:notation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">art reproduction</skos:prefLabel>
+    <skos:definition xml:lang="en">Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.</skos:definition>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -76,6 +110,13 @@
     <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">includes puzzles and simulations.</skos:scopeNote>
   </rdf:Description>
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
+    <skos:prefLabel xml:lang="en">technical drawing</skos:prefLabel>
+    <skos:definition xml:lang="en">Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.</skos:definition>
+    <skos:notation>l</skos:notation>
+  </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
@@ -84,41 +125,12 @@
     <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">art original</skos:prefLabel>
-    <skos:definition xml:lang="en">Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.</skos:definition>
-    <skos:notation>a</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">technical drawing</skos:prefLabel>
-    <skos:definition xml:lang="en">Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.</skos:definition>
-    <skos:notation>l</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">picture</skos:prefLabel>
-    <skos:definition xml:lang="en">Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.</skos:definition>
-    <skos:notation>i</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">transparency</skos:prefLabel>
-    <skos:definition xml:lang="en">Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.</skos:definition>
-    <skos:notation>t</skos:notation>
-    <skos:scopeNote xml:lang="en">X-rays are coded as transparencies.</skos:scopeNote>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">filmstrip</skos:prefLabel>
-    <skos:definition xml:lang="en">Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:prefLabel xml:lang="en">microscope slide</skos:prefLabel>
+    <skos:definition xml:lang="en">Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.</skos:definition>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -128,40 +140,41 @@
     <skos:notation>o</skos:notation>
     <skos:scopeNote xml:lang="en">Activity cards are included in this category.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">realia</skos:prefLabel>
-    <skos:definition xml:lang="en">Realia.</skos:definition>
-    <skos:notation>r</skos:notation>
-    <skos:scopeNote xml:lang="en">Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.</skos:scopeNote>
+    <skos:prefLabel xml:lang="en">transparency</skos:prefLabel>
+    <skos:definition xml:lang="en">Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.</skos:definition>
+    <skos:notation>t</skos:notation>
+    <skos:scopeNote xml:lang="en">X-rays are coded as transparencies.</skos:scopeNote>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#m">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">art reproduction</skos:prefLabel>
-    <skos:definition xml:lang="en">Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:prefLabel xml:lang="en">motion picture</skos:prefLabel>
+    <skos:definition xml:lang="en">Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.</skos:definition>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">electronic videorecording [obsolete]</skos:prefLabel>
-    <skos:notation>e</skos:notation>
+    <skos:prefLabel xml:lang="en">filmstrip</skos:prefLabel>
+    <skos:definition xml:lang="en">Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.</skos:definition>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">microscope slide</skos:prefLabel>
-    <skos:definition xml:lang="en">Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:prefLabel xml:lang="en">other</skos:prefLabel>
+    <skos:definition xml:lang="en">Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.</skos:definition>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
+  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">toy</skos:prefLabel>
-    <skos:definition xml:lang="en">Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:prefLabel xml:lang="en">diorama</skos:prefLabel>
+    <skos:definition xml:lang="en">Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.</skos:definition>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
@@ -169,12 +182,5 @@
     <skos:prefLabel xml:lang="en">videorecording</skos:prefLabel>
     <skos:definition xml:lang="en">Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.</skos:definition>
     <skos:notation>v</skos:notation>
-  </rdf:Description>
-  <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
-    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
-    <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
-    <skos:prefLabel xml:lang="en">model</skos:prefLabel>
-    <skos:definition xml:lang="en">Three-dimensional representation of a real thing, either of the exact size of the original or to scale.</skos:definition>
-    <skos:notation>q</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -1,19 +1,25 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="https://schema.org/"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">graphic</skos:prefLabel>
     <skos:definition xml:lang="en">Graphic.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for original or historical graphic material.</skos:scopeNote>
-    <skos:notation>k</skos:notation>
+    <skos:notation xml:lang="en">k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.</skos:definition>
-    <skos:notation>s</skos:notation>
+    <skos:notation xml:lang="en">s</skos:notation>
     <skos:scopeNote xml:lang="en">Modern stereographs, for example, Viewmaster reels, are included here.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
@@ -21,7 +27,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">chart</skos:prefLabel>
     <skos:definition xml:lang="en">Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).</skos:definition>
-    <skos:notation>n</skos:notation>
+    <skos:notation xml:lang="en">n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -29,7 +35,7 @@
     <dct:title xml:lang="en">Visual: type of visual material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of visual material being described.</dct:description>
-    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -40,7 +46,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-2</schema:version>
+    <schema:version>1-0-1</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld"/>
@@ -52,28 +58,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">motion picture</skos:prefLabel>
     <skos:definition xml:lang="en">Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.</skos:definition>
-    <skos:notation>m</skos:notation>
+    <skos:notation xml:lang="en">m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">diorama</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.</skos:definition>
-    <skos:notation>d</skos:notation>
+    <skos:notation xml:lang="en">d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.</skos:definition>
-    <skos:notation>z</skos:notation>
+    <skos:notation xml:lang="en">z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Item or set of items designed for play according to prescribed rules and intended for recreation or instruction.</skos:definition>
-    <skos:notation>g</skos:notation>
+    <skos:notation xml:lang="en">g</skos:notation>
     <skos:scopeNote xml:lang="en">includes puzzles and simulations.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b">
@@ -81,7 +87,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">kit</skos:prefLabel>
     <skos:definition xml:lang="en">Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item.</skos:definition>
-    <skos:notation>b</skos:notation>
+    <skos:notation xml:lang="en">b</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
@@ -89,28 +95,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art original</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.</skos:definition>
-    <skos:notation>a</skos:notation>
+    <skos:notation xml:lang="en">a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">technical drawing</skos:prefLabel>
     <skos:definition xml:lang="en">Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.</skos:definition>
-    <skos:notation>l</skos:notation>
+    <skos:notation xml:lang="en">l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">picture</skos:prefLabel>
     <skos:definition xml:lang="en">Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.</skos:definition>
-    <skos:notation>i</skos:notation>
+    <skos:notation xml:lang="en">i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">transparency</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.</skos:definition>
-    <skos:notation>t</skos:notation>
+    <skos:notation xml:lang="en">t</skos:notation>
     <skos:scopeNote xml:lang="en">X-rays are coded as transparencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
@@ -118,14 +124,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">filmstrip</skos:prefLabel>
     <skos:definition xml:lang="en">Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.</skos:definition>
-    <skos:notation>f</skos:notation>
+    <skos:notation xml:lang="en">f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">flash card</skos:prefLabel>
     <skos:definition xml:lang="en">Card or other opaque material printed with words, numerals, or pictures and designed for rapid display.</skos:definition>
-    <skos:notation>o</skos:notation>
+    <skos:notation xml:lang="en">o</skos:notation>
     <skos:scopeNote xml:lang="en">Activity cards are included in this category.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
@@ -133,7 +139,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">realia</skos:prefLabel>
     <skos:definition xml:lang="en">Realia.</skos:definition>
-    <skos:notation>r</skos:notation>
+    <skos:notation xml:lang="en">r</skos:notation>
     <skos:scopeNote xml:lang="en">Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
@@ -141,40 +147,40 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.</skos:definition>
-    <skos:notation>c</skos:notation>
+    <skos:notation xml:lang="en">c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">electronic videorecording [obsolete]</skos:prefLabel>
-    <skos:notation>e</skos:notation>
+    <skos:notation xml:lang="en">e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">microscope slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.</skos:definition>
-    <skos:notation>p</skos:notation>
+    <skos:notation xml:lang="en">p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">toy</skos:prefLabel>
     <skos:definition xml:lang="en">Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.</skos:definition>
-    <skos:notation>w</skos:notation>
+    <skos:notation xml:lang="en">w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">videorecording</skos:prefLabel>
     <skos:definition xml:lang="en">Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.</skos:definition>
-    <skos:notation>v</skos:notation>
+    <skos:notation xml:lang="en">v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">model</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a real thing, either of the exact size of the original or to scale.</skos:definition>
-    <skos:notation>q</skos:notation>
+    <skos:notation xml:lang="en">q</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -33,7 +33,7 @@
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
-    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833"/>
+    <dct:provenance rdf:resource="https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues"/>
     <dct:creator rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:contributor rdf:resource="http://viaf.org/viaf/151962300"/>
     <dc:contributor xml:lang="en">Metadata Management Associates</dc:contributor>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -1,25 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rdf:RDF
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dct="http://purl.org/dc/terms/"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:schema="https://schema.org/"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
->
+<?xml version='1.0' encoding='UTF-8'?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:schema="https://schema.org/" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#k">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">graphic</skos:prefLabel>
     <skos:definition xml:lang="en">Graphic.</skos:definition>
     <skos:scopeNote xml:lang="en">Used for original or historical graphic material.</skos:scopeNote>
-    <skos:notation xml:lang="en">k</skos:notation>
+    <skos:notation>k</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#s">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer.</skos:definition>
-    <skos:notation xml:lang="en">s</skos:notation>
+    <skos:notation>s</skos:notation>
     <skos:scopeNote xml:lang="en">Modern stereographs, for example, Viewmaster reels, are included here.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#n">
@@ -27,7 +21,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">chart</skos:prefLabel>
     <skos:definition xml:lang="en">Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar).</skos:definition>
-    <skos:notation xml:lang="en">n</skos:notation>
+    <skos:notation>n</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
@@ -35,7 +29,7 @@
     <dct:title xml:lang="en">Visual: type of visual material</dct:title>
     <dct:alternative xml:lang="en">MARC21 008/33 values for visual materials expressed using RDF</dct:alternative>
     <dct:description xml:lang="en">Indicates the type of visual material being described.</dct:description>
-    <schema:disambiguatingDescription>SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
+    <schema:disambiguatingDescription xml:lang="en">SKOS Concept Scheme for MARC 00X Values</schema:disambiguatingDescription>
     <dct:publisher rdf:resource="http://viaf.org/viaf/139541794"/>
     <dct:source rdf:resource="https://www.loc.gov/marc/bibliographic/bd008.html"/>
     <dct:source rdf:resource="http://marc21rdf.info"/>
@@ -58,28 +52,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">motion picture</skos:prefLabel>
     <skos:definition xml:lang="en">Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion.</skos:definition>
-    <skos:notation xml:lang="en">m</skos:notation>
+    <skos:notation>m</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#d">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">diorama</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background.</skos:definition>
-    <skos:notation xml:lang="en">d</skos:notation>
+    <skos:notation>d</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#z">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">other</skos:prefLabel>
     <skos:definition xml:lang="en">Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy.</skos:definition>
-    <skos:notation xml:lang="en">z</skos:notation>
+    <skos:notation>z</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#g">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">game</skos:prefLabel>
     <skos:definition xml:lang="en">Item or set of items designed for play according to prescribed rules and intended for recreation or instruction.</skos:definition>
-    <skos:notation xml:lang="en">g</skos:notation>
+    <skos:notation>g</skos:notation>
     <skos:scopeNote xml:lang="en">includes puzzles and simulations.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#b">
@@ -87,7 +81,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">kit</skos:prefLabel>
     <skos:definition xml:lang="en">Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item.</skos:definition>
-    <skos:notation xml:lang="en">b</skos:notation>
+    <skos:notation>b</skos:notation>
     <skos:scopeNote xml:lang="en">Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.).</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#a">
@@ -95,28 +89,28 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art original</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it.</skos:definition>
-    <skos:notation xml:lang="en">a</skos:notation>
+    <skos:notation>a</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#l">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">technical drawing</skos:prefLabel>
     <skos:definition xml:lang="en">Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context.</skos:definition>
-    <skos:notation xml:lang="en">l</skos:notation>
+    <skos:notation>l</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#i">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">picture</skos:prefLabel>
     <skos:definition xml:lang="en">Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing.</skos:definition>
-    <skos:notation xml:lang="en">i</skos:notation>
+    <skos:notation>i</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#t">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">transparency</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box.</skos:definition>
-    <skos:notation xml:lang="en">t</skos:notation>
+    <skos:notation>t</skos:notation>
     <skos:scopeNote xml:lang="en">X-rays are coded as transparencies.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#f">
@@ -124,14 +118,14 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">filmstrip</skos:prefLabel>
     <skos:definition xml:lang="en">Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound.</skos:definition>
-    <skos:notation xml:lang="en">f</skos:notation>
+    <skos:notation>f</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#o">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">flash card</skos:prefLabel>
     <skos:definition xml:lang="en">Card or other opaque material printed with words, numerals, or pictures and designed for rapid display.</skos:definition>
-    <skos:notation xml:lang="en">o</skos:notation>
+    <skos:notation>o</skos:notation>
     <skos:scopeNote xml:lang="en">Activity cards are included in this category.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#r">
@@ -139,7 +133,7 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">realia</skos:prefLabel>
     <skos:definition xml:lang="en">Realia.</skos:definition>
-    <skos:notation xml:lang="en">r</skos:notation>
+    <skos:notation>r</skos:notation>
     <skos:scopeNote xml:lang="en">Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects.</skos:scopeNote>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#c">
@@ -147,40 +141,40 @@
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">art reproduction</skos:prefLabel>
     <skos:definition xml:lang="en">Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition.</skos:definition>
-    <skos:notation xml:lang="en">c</skos:notation>
+    <skos:notation>c</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#ex">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">electronic videorecording [obsolete]</skos:prefLabel>
-    <skos:notation xml:lang="en">e</skos:notation>
+    <skos:notation>e</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#p">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">microscope slide</skos:prefLabel>
     <skos:definition xml:lang="en">Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector.</skos:definition>
-    <skos:notation xml:lang="en">p</skos:notation>
+    <skos:notation>p</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#w">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">toy</skos:prefLabel>
     <skos:definition xml:lang="en">Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use.</skos:definition>
-    <skos:notation xml:lang="en">w</skos:notation>
+    <skos:notation>w</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#v">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">videorecording</skos:prefLabel>
     <skos:definition xml:lang="en">Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor.</skos:definition>
-    <skos:notation xml:lang="en">v</skos:notation>
+    <skos:notation>v</skos:notation>
   </rdf:Description>
   <rdf:Description rdf:about="https://doi.org/10.6069/uwlswd.qgc0-9r48#q">
     <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
     <skos:inScheme rdf:resource="https://doi.org/10.6069/uwlswd.qgc0-9r48"/>
     <skos:prefLabel xml:lang="en">model</skos:prefLabel>
     <skos:definition xml:lang="en">Three-dimensional representation of a real thing, either of the exact size of the original or to scale.</skos:definition>
-    <skos:notation xml:lang="en">q</skos:notation>
+    <skos:notation>q</skos:notation>
   </rdf:Description>
 </rdf:RDF>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf
@@ -40,7 +40,7 @@
     <dct:issued>2023</dct:issued>
     <dc:language>en</dc:language>
     <dct:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0"/>
-    <schema:version>1-0-1</schema:version>
+    <schema:version>1-1-0</schema:version>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.nt"/>
     <dct:hasFormat rdf:resource="https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.jsonld"/>

--- a/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl
+++ b/008/visual_type_of_visual_material/visual_type_of_visual_material.ttl
@@ -6,133 +6,133 @@
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#a> a skos:Concept ;
     skos:definition "Two or three-dimensional work of art created by an artist, for example, a sculpture, as contrasted with a reproduction of it."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "a"@en ;
+    skos:notation "a" ;
     skos:prefLabel "art original"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#b> a skos:Concept ;
     skos:definition "Mixture of components from two or more categories, that is, sound recording, maps, filmstrips, etc., no one of which is the predominant constituent of the item."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "b"@en ;
+    skos:notation "b" ;
     skos:prefLabel "kit"@en ;
     skos:scopeNote "Also includes the packages of material called laboratory kits, and packages of assorted materials, such as a set of K-12 social studies curriculum material (all books, workbooks, guides, activities, etc.) or packages of educational test materials (tests, answer sheets, scoring guides, score charts, interpretative manuals, etc.)."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#c> a skos:Concept ;
     skos:definition "Two or three-dimensional mechanically reproduced copy of a work of art, generally as one of a commercial edition."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "c"@en ;
+    skos:notation "c" ;
     skos:prefLabel "art reproduction"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#d> a skos:Concept ;
     skos:definition "Three-dimensional representation of a scene created by placing objects, figures, etc. in front of a two-dimensional background."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "d"@en ;
+    skos:notation "d" ;
     skos:prefLabel "diorama"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#ex> a skos:Concept ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "e"@en ;
+    skos:notation "e" ;
     skos:prefLabel "electronic videorecording [obsolete]"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#f> a skos:Concept ;
     skos:definition "Length of film containing a succession of images intended for projection one frame at a time with or without recorded sound."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "f"@en ;
+    skos:notation "f" ;
     skos:prefLabel "filmstrip"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#g> a skos:Concept ;
     skos:definition "Item or set of items designed for play according to prescribed rules and intended for recreation or instruction."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "g"@en ;
+    skos:notation "g" ;
     skos:prefLabel "game"@en ;
     skos:scopeNote "includes puzzles and simulations."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#i> a skos:Concept ;
     skos:definition "Two-dimensional visual representation accessible to the naked eye and generally on an opaque backing."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "i"@en ;
+    skos:notation "i" ;
     skos:prefLabel "picture"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#k> a skos:Concept ;
     skos:definition "Graphic."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "k"@en ;
+    skos:notation "k" ;
     skos:prefLabel "graphic"@en ;
     skos:scopeNote "Used for original or historical graphic material."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#l> a skos:Concept ;
     skos:definition "Cross section, detail, diagram, elevation, perspective, plan, working plan, etc., made for use in an architectural engineering or other technical context."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "l"@en ;
+    skos:notation "l" ;
     skos:prefLabel "technical drawing"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#m> a skos:Concept ;
     skos:definition "Series of still pictures on film with or without sound, designed to be projected in rapid succession to produce the optical effect of motion."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "m"@en ;
+    skos:notation "m" ;
     skos:prefLabel "motion picture"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#n> a skos:Concept ;
     skos:definition "Opaque sheet that exhibits data in graphic or tabular form (e.g., a calendar)."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "n"@en ;
+    skos:notation "n" ;
     skos:prefLabel "chart"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#o> a skos:Concept ;
     skos:definition "Card or other opaque material printed with words, numerals, or pictures and designed for rapid display."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "o"@en ;
+    skos:notation "o" ;
     skos:prefLabel "flash card"@en ;
     skos:scopeNote "Activity cards are included in this category."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#p> a skos:Concept ;
     skos:definition "Transparent mount, usually glass, containing a minute object to be viewed through a microscope or microprojector."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "p"@en ;
+    skos:notation "p" ;
     skos:prefLabel "microscope slide"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#q> a skos:Concept ;
     skos:definition "Three-dimensional representation of a real thing, either of the exact size of the original or to scale."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "q"@en ;
+    skos:notation "q" ;
     skos:prefLabel "model"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#r> a skos:Concept ;
     skos:definition "Realia."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "r"@en ;
+    skos:notation "r" ;
     skos:prefLabel "realia"@en ;
     skos:scopeNote "Includes 1) all three-dimensional items such as clothing, stitchery, fabrics, tools, and utensils; and 2) naturally occurring objects."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#s> a skos:Concept ;
     skos:definition "Transparent material on which there is a two-dimensional image, usually held in a mount, and designed for use in a projector or viewer."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "s"@en ;
+    skos:notation "s" ;
     skos:prefLabel "slide"@en ;
     skos:scopeNote "Modern stereographs, for example, Viewmaster reels, are included here."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#t> a skos:Concept ;
     skos:definition "Transparent material on which a basically still image is recorded. Transparencies are designed for use with an overhead projector or a light box."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "t"@en ;
+    skos:notation "t" ;
     skos:prefLabel "transparency"@en ;
     skos:scopeNote "X-rays are coded as transparencies."@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#v> a skos:Concept ;
     skos:definition "Recording on which visual images, usually in motion and accompanied by sound, have been registered. Videorecordings are designed for playback by means of a television receiver or monitor."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "v"@en ;
+    skos:notation "v" ;
     skos:prefLabel "videorecording"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#w> a skos:Concept ;
     skos:definition "Material object for children or others to play with (often an imitation of some familiar object); a plaything; also, something contrived for amusement rather than for practical use."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "w"@en ;
+    skos:notation "w" ;
     skos:prefLabel "toy"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48#z> a skos:Concept ;
     skos:definition "Type of visual material other than art original, kit, art reproduction, diorama, filmstrip, game, picture, graphic, technical drawing, motion picture, chart, flash card, microscope slide, model, realia, slide, transparency, videorecording, or toy."@en ;
     skos:inScheme <https://doi.org/10.6069/uwlswd.qgc0-9r48> ;
-    skos:notation "z"@en ;
+    skos:notation "z" ;
     skos:prefLabel "other"@en .
 
 <https://doi.org/10.6069/uwlswd.qgc0-9r48> a skos:ConceptScheme ;
@@ -149,12 +149,12 @@
         <https://uwlib-cams.github.io/uwlswd_vocabs_marc_006_008/008/visual_type_of_visual_material/visual_type_of_visual_material.rdf> ;
     dct:issued "2023" ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0> ;
-    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833> ;
+    dct:provenance <https://doi.org/10.6069/uwlswd.2e2b-y833#marc00Xvalues> ;
     dct:publisher <http://viaf.org/viaf/139541794> ;
     dct:source <http://marc21rdf.info>,
         <https://www.loc.gov/marc/bibliographic/bd008.html> ;
     dct:title "Visual: type of visual material"@en ;
     dct:type <http://purl.org/dc/dcmitype/Dataset> ;
-    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values" ;
-    schema:version "1-0-1" .
+    schema:disambiguatingDescription "SKOS Concept Scheme for MARC 00X Values"@en ;
+    schema:version "1-1-0" .
 


### PR DESCRIPTION
- added lang tags to all schema:disambiguatingDescription #22 
- removed lang tags from skos:notation #18 
- correced IRIs for provenance triples #11 